### PR TITLE
enh: support `--install-system-deps` flag in `uvr add`

### DIFF
--- a/crates/uvr/src/cli.rs
+++ b/crates/uvr/src/cli.rs
@@ -156,6 +156,15 @@ pub struct AddArgs {
     /// there's no fresh lockfile to install from.) (#76)
     #[arg(long)]
     pub no_install: bool,
+
+    /// When missing system libraries are detected, run the platform's
+    /// package manager (`apk add` / `apt-get install` / `dnf install`)
+    /// to install them automatically (#30). Also enabled by setting
+    /// `UVR_INSTALL_SYSREQS=1`. Without this flag, uvr only prints a
+    /// hint with the install command. Interactive sessions are
+    /// prompted for confirmation; non-TTY runs (CI) proceed without.
+    #[arg(long)]
+    pub install_system_deps: bool,
 }
 
 // ────────────────────────────────────────────────────────────

--- a/crates/uvr/src/main.rs
+++ b/crates/uvr/src/main.rs
@@ -85,6 +85,13 @@ async fn run() -> Result<()> {
         }
         Commands::Add(args) => {
             let timeout = parse_cli_timeout(args.timeout.as_deref())?;
+            // #30: mirror the Sync handler — --install-system-deps and
+            // UVR_INSTALL_SYSREQS=1 are equivalent. add::run installs via
+            // install_from_lockfile, which reads the env var to decide
+            // whether to auto-run the system package manager.
+            if args.install_system_deps {
+                std::env::set_var("UVR_INSTALL_SYSREQS", "1");
+            }
             commands::add::run(
                 args.packages,
                 args.dev,


### PR DESCRIPTION
## Summary
- Add `--install-system-deps` to `uvr add`, mirroring the existing flag on `uvr sync`.
- Syslib (sysreqs) detection already runs during `uvr add` since it installs via `sync::install_from_lockfile`, but the opt-in to auto-install detected system libraries through the platform package manager (`apk add` / `apt-get install` / `dnf install`) was only exposed on `sync`.
- The `Add` handler now sets `UVR_INSTALL_SYSREQS=1` when the flag is passed, the same mechanism the `Sync` handler uses, so no bool threading through the shared install path.