### PR TITLE
fix: correct R 4.5 → Bioconductor version mapping (3.21 → 3.22)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ release page on GitHub. Issue numbers reference https://github.com/nbafrank/uvr/
 
 Pure tracking section — fixes and small features land here between tags.
 
+- Fix: `bioc_release_for_r(4, 5)` now returns `"3.22"` instead of `"3.21"` — Bioc 3.21 was a devel release paired with R 4.5.0-devel and is no longer available on the CDN; Bioc 3.22 is the stable release for R 4.5.x. Previously all `--bioc` installs failed on R 4.5 with a 404 network error unless `bioc_version` was pinned manually in `uvr.toml`.
 - **GitLab-hosted package support** (#123, PR #174 by @pteridin): `uvr add gitlab::host/group/repo[@ref]` resolves via the GitLab API v4, mirroring the existing `forgejo::` support — self-hosted instances included, nested groups handled via URL-encoded project paths. Flows through lockfile, `uvr export`, and sync.
 - Cache filenames derived from download URLs strip query strings/fragments — GitLab archive URLs carry `?sha=...`, and `?` is an illegal filename character on Windows (os error 123). (PR #174)
 - `R CMD INSTALL` failure logs now combine stdout and stderr instead of picking one stream — R splits progress and the actual error across both inconsistently. (PR #174)

--- a/crates/uvr-core/src/registry/bioconductor.rs
+++ b/crates/uvr-core/src/registry/bioconductor.rs
@@ -22,7 +22,7 @@ use crate::resolver::PackageRegistry;
 fn bioc_release_for_r(r_major: u64, r_minor: u64) -> &'static str {
     match (r_major, r_minor) {
         (4, 6) => "3.23",
-        (4, 5) => "3.21",
+        (4, 5) => "3.22",
         (4, 4) => "3.20",
         (4, 3) => "3.18",
         (4, 2) => "3.16",
@@ -328,7 +328,7 @@ mod tests {
 
     #[test]
     fn bioc_release_mapping() {
-        assert_eq!(bioc_release_for_r(4, 5), "3.21");
+        assert_eq!(bioc_release_for_r(4, 5), "3.22");
         assert_eq!(bioc_release_for_r(4, 4), "3.20");
         assert_eq!(bioc_release_for_r(4, 3), "3.18");
         assert_eq!(bioc_release_for_r(4, 2), "3.16");
@@ -429,10 +429,10 @@ mod tests {
     #[test]
     fn default_release_maps_r_to_bioc() {
         // R 4.6 must map to its own Bioc release (3.23), not the 4.5 fallback —
-        // pulling 3.21 here ships R-4.5-API package sources that fail to compile
+        // pulling 3.22 here ships R-4.5-API package sources that fail to compile
         // against R 4.6 headers (the S4Vectors PRENV/Rf_findVar bug).
         assert_eq!(default_release_for_r("4.6.0"), "3.23");
-        assert_eq!(default_release_for_r("4.5.1"), "3.21");
+        assert_eq!(default_release_for_r("4.5.1"), "3.22");
         assert_eq!(default_release_for_r("4.4.0"), "3.20");
         assert_eq!(default_release_for_r("4.3"), "3.18");
         // Unparseable / partial versions fall through to the newest known

--- a/repro/tls-repro.sh
+++ b/repro/tls-repro.sh
@@ -44,10 +44,14 @@ echo "Server cert signed by custom CA (NOT trusted by webpki-roots)"
 
 echo ""
 echo "=== Step 3: Start local HTTPS server (no sudo needed) ==="
-python3 - "$WORK" << 'PYEOF' &
+# Use a random available port to avoid conflicts
+PORT=$(python3 -c "import socket; s=socket.socket(); s.bind(('',0)); print(s.getsockname()[1]); s.close()")
+echo "Using port: $PORT"
+
+python3 - "$WORK" "$PORT" << 'PYEOF' &
 import http.server, ssl, sys
 
-work = sys.argv[1]
+work, port = sys.argv[1], int(sys.argv[2])
 
 class Handler(http.server.BaseHTTPRequestHandler):
     def do_GET(self):
@@ -56,7 +60,7 @@ class Handler(http.server.BaseHTTPRequestHandler):
         self.wfile.write(b'Package: BiocStyle\nVersion: 2.38.0\n')
     def log_message(self, *a): pass
 
-server = http.server.HTTPServer(('127.0.0.1', 14443), Handler)
+server = http.server.HTTPServer(('127.0.0.1', port), Handler)
 ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
 ctx.load_cert_chain(f'{work}/server.crt', f'{work}/server.key')
 server.socket = ctx.wrap_socket(server.socket, server_side=True)
@@ -67,7 +71,7 @@ sleep 1
 
 echo ""
 echo "=== Step 4: curl with --cacert (simulates system cert store trusting our CA) ==="
-curl -s --cacert $WORK/ca.crt https://localhost:14443/ \
+curl -s --cacert $WORK/ca.crt https://localhost:$PORT/ \
   && echo "curl --cacert: ✅ SUCCESS" \
   || echo "curl --cacert: ❌ FAIL"
 
@@ -89,6 +93,8 @@ cat > $WORK/rust-test/src/main.rs << 'RUST'
 fn main() {
     // rustls-tls: uses webpki-roots only — does NOT trust system/custom CAs
     let result = reqwest::blocking::get("https://localhost:14443/");
+    let url = format!("https://localhost:{}/", std::env::var("TEST_PORT").unwrap_or("14443".into()));
+    let result = reqwest::blocking::get(&url);
     match result {
         Ok(r)  => println!("reqwest rustls-tls: ✅ OK ({})", r.status()),
         Err(e) => println!("reqwest rustls-tls: ❌ FAIL\n  Error: {e}"),
@@ -97,7 +103,7 @@ fn main() {
 RUST
 
 echo "Building reqwest rustls-tls test (first build ~30s, subsequent instant)..."
-cd $WORK/rust-test && cargo run 2>&1
+TEST_PORT=$PORT cd $WORK/rust-test && TEST_PORT=$PORT cargo run 2>&1
 
 echo ""
 echo "=== Step 6: Same test with native-tls (uses system cert store) ==="
@@ -105,7 +111,7 @@ sed -i '' 's/rustls-tls/native-tls/' $WORK/rust-test/Cargo.toml 2>/dev/null || \
   sed -i 's/rustls-tls/native-tls/' $WORK/rust-test/Cargo.toml
 # native-tls needs to trust our CA — pass it via SSL_CERT_FILE (macOS/Linux)
 export SSL_CERT_FILE=$WORK/ca.crt
-cd $WORK/rust-test && cargo run 2>&1
+cd $WORK/rust-test && TEST_PORT=$PORT cargo run 2>&1
 
 kill $SERVER_PID 2>/dev/null || true
 

--- a/repro/tls-repro.sh
+++ b/repro/tls-repro.sh
@@ -11,6 +11,20 @@
 
 set -e
 WORK=$(mktemp -d)
+
+# Check requirements
+if ! command -v cargo &>/dev/null; then
+  echo "❌ cargo not found. Install Rust: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh"
+  exit 1
+fi
+if ! command -v openssl &>/dev/null; then
+  echo "❌ openssl not found"
+  exit 1
+fi
+if ! command -v python3 &>/dev/null; then
+  echo "❌ python3 not found"
+  exit 1
+fi
 trap "rm -rf $WORK" EXIT
 
 echo "=== Step 1: Generate a self-signed CA (not in webpki-roots) ==="
@@ -83,7 +97,7 @@ fn main() {
 RUST
 
 echo "Building reqwest rustls-tls test (first build ~30s, subsequent instant)..."
-cd $WORK/rust-test && cargo run -q 2>/dev/null
+cd $WORK/rust-test && cargo run 2>&1
 
 echo ""
 echo "=== Step 6: Same test with native-tls (uses system cert store) ==="
@@ -91,7 +105,7 @@ sed -i '' 's/rustls-tls/native-tls/' $WORK/rust-test/Cargo.toml 2>/dev/null || \
   sed -i 's/rustls-tls/native-tls/' $WORK/rust-test/Cargo.toml
 # native-tls needs to trust our CA — pass it via SSL_CERT_FILE (macOS/Linux)
 export SSL_CERT_FILE=$WORK/ca.crt
-cd $WORK/rust-test && cargo run -q 2>/dev/null
+cd $WORK/rust-test && cargo run 2>&1
 
 kill $SERVER_PID 2>/dev/null || true
 

--- a/repro/tls-repro.sh
+++ b/repro/tls-repro.sh
@@ -1,128 +1,98 @@
 #!/bin/bash
-# Reproduction script for uvr rustls TLS issue
-# NO sudo required — uses a temporary user-level cert store
+# Reproduce uvr TLS issue: custom CA trusted by system but not by rustls webpki-roots
+# NO sudo, NO cargo/Rust required — uses openssl + curl only
 #
-# Demonstrates that reqwest with rustls-tls does NOT use the system cert store,
-# while reqwest with native-tls does. This explains why corporate VPN/TLS-inspection
-# causes UnknownIssuer in uvr but not in curl/Python/R.
+# Demonstrates the core problem:
+#   curl with explicit --cacert: trusts custom CA → works
+#   openssl with system store:   trusts custom CA → works (like native-tls)
+#   openssl without custom CA:   rejects cert → fails (like rustls webpki-roots)
 #
-# Requirements: cargo (rustup), openssl, python3
-# Usage: bash repro-noroot.sh
+# This is exactly what happens in corporate environments with TLS inspection:
+#   System cert store has corporate CA → curl/R/Python work
+#   rustls webpki-roots missing corporate CA → uvr fails
+#
+# Requirements: openssl, curl, python3
+# Usage: bash repro-norust.sh
 
 set -e
 WORK=$(mktemp -d)
+trap "rm -rf $WORK; kill $SERVER_PID 2>/dev/null || true" EXIT
 
-# Check requirements
-if ! command -v cargo &>/dev/null; then
-  echo "❌ cargo not found. Install Rust: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh"
-  exit 1
-fi
-if ! command -v openssl &>/dev/null; then
-  echo "❌ openssl not found"
-  exit 1
-fi
-if ! command -v python3 &>/dev/null; then
-  echo "❌ python3 not found"
-  exit 1
-fi
-trap "rm -rf $WORK" EXIT
+echo "=== Requirements check ==="
+for cmd in openssl curl python3; do
+  command -v $cmd &>/dev/null && echo "  ✅ $cmd" || { echo "  ❌ $cmd not found"; exit 1; }
+done
+echo ""
 
-echo "=== Step 1: Generate a self-signed CA (not in webpki-roots) ==="
+echo "=== Step 1: Generate self-signed CA (not in webpki-roots/system store) ==="
 openssl genrsa -out $WORK/ca.key 2048 2>/dev/null
 openssl req -x509 -new -key $WORK/ca.key -out $WORK/ca.crt \
   -days 1 -nodes -subj "/CN=test-corporate-CA" 2>/dev/null
-echo "Custom CA: $WORK/ca.crt"
-
+echo "Custom CA: $WORK/ca.crt  (CN=test-corporate-CA)"
 echo ""
-echo "=== Step 2: Generate server cert signed by our CA ==="
+
+echo "=== Step 2: Generate server cert signed by custom CA ==="
 openssl genrsa -out $WORK/server.key 2048 2>/dev/null
 openssl req -new -key $WORK/server.key -out $WORK/server.csr \
-  -subj "/CN=localhost" 2>/dev/null
+  -subj "/CN=127.0.0.1" 2>/dev/null
 openssl x509 -req -in $WORK/server.csr -CA $WORK/ca.crt -CAkey $WORK/ca.key \
-  -CAcreateserial -out $WORK/server.crt -days 1 2>/dev/null
-echo "Server cert signed by custom CA (NOT trusted by webpki-roots)"
-
+  -CAcreateserial -out $WORK/server.crt -days 1 \
+  -extfile <(echo "subjectAltName=IP:127.0.0.1") 2>/dev/null
+echo "Server cert: signed by test-corporate-CA"
 echo ""
-echo "=== Step 3: Start local HTTPS server (no sudo needed) ==="
-# Use a random available port to avoid conflicts
-PORT=$(python3 -c "import socket; s=socket.socket(); s.bind(('',0)); print(s.getsockname()[1]); s.close()")
-echo "Using port: $PORT"
 
-python3 - "$WORK" "$PORT" << 'PYEOF' &
-import http.server, ssl, sys
+echo "=== Step 3: Start local HTTPS server (no sudo) ==="
+PORT=$(python3 -c "import socket; s=socket.socket(); s.bind(('',0)); p=s.getsockname()[1]; s.close(); print(p)")
 
-work, port = sys.argv[1], int(sys.argv[2])
-
-class Handler(http.server.BaseHTTPRequestHandler):
-    def do_GET(self):
-        self.send_response(200)
-        self.end_headers()
-        self.wfile.write(b'Package: BiocStyle\nVersion: 2.38.0\n')
-    def log_message(self, *a): pass
-
-server = http.server.HTTPServer(('127.0.0.1', port), Handler)
-ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
-ctx.load_cert_chain(f'{work}/server.crt', f'{work}/server.key')
-server.socket = ctx.wrap_socket(server.socket, server_side=True)
-server.serve_forever()
-PYEOF
+python3 - "$WORK" "$PORT" &
 SERVER_PID=$!
 sleep 1
 
+cat << PYEOF | python3 - "$WORK" "$PORT" &
+import http.server, ssl, sys, threading
+
+work, port = sys.argv[1], int(sys.argv[2])
+
+class H(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(200)
+        self.end_headers()
+        self.wfile.write(b"Package: BiocStyle\nVersion: 2.38.0\n")
+    def log_message(self, *a): pass
+
+server = http.server.HTTPServer(("127.0.0.1", port), H)
+ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+ctx.load_cert_chain(f"{work}/server.crt", f"{work}/server.key")
+server.socket = ctx.wrap_socket(server.socket, server_side=True)
+server.serve_forever()
+PYEOF
+
+SERVER_PID=$!
+sleep 1
+echo "HTTPS server on 127.0.0.1:$PORT  (cert signed by test-corporate-CA)"
 echo ""
-echo "=== Step 4: curl with --cacert (simulates system cert store trusting our CA) ==="
-curl -s --cacert $WORK/ca.crt https://localhost:$PORT/ \
-  && echo "curl --cacert: ✅ SUCCESS" \
-  || echo "curl --cacert: ❌ FAIL"
 
+echo "=== Test A: curl WITH --cacert (explicit trust — simulates system cert store) ==="
+curl -sf --cacert $WORK/ca.crt https://127.0.0.1:$PORT/ \
+  && echo "result: ✅ SUCCESS — curl trusts our custom CA" \
+  || echo "result: ❌ FAIL"
 echo ""
-echo "=== Step 5: Build and run reqwest test (no sudo, isolated cargo project) ==="
-mkdir -p $WORK/rust-test/src
 
-cat > $WORK/rust-test/Cargo.toml << 'TOML'
-[package]
-name = "tls-test"
-version = "0.1.0"
-edition = "2021"
-
-[dependencies]
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "blocking"] }
-TOML
-
-cat > $WORK/rust-test/src/main.rs << 'RUST'
-fn main() {
-    // rustls-tls: uses webpki-roots only — does NOT trust system/custom CAs
-    let result = reqwest::blocking::get("https://localhost:14443/");
-    let url = format!("https://localhost:{}/", std::env::var("TEST_PORT").unwrap_or("14443".into()));
-    let result = reqwest::blocking::get(&url);
-    match result {
-        Ok(r)  => println!("reqwest rustls-tls: ✅ OK ({})", r.status()),
-        Err(e) => println!("reqwest rustls-tls: ❌ FAIL\n  Error: {e}"),
-    }
-}
-RUST
-
-echo "Building reqwest rustls-tls test (first build ~30s, subsequent instant)..."
-TEST_PORT=$PORT cd $WORK/rust-test && TEST_PORT=$PORT cargo run 2>&1
-
+echo "=== Test B: curl WITHOUT --cacert (no custom CA trust — simulates rustls webpki-roots) ==="
+curl -sf https://127.0.0.1:$PORT/ \
+  && echo "result: ✅ SUCCESS" \
+  || echo "result: ❌ FAIL — curl rejects cert (CA not trusted)"
 echo ""
-echo "=== Step 6: Same test with native-tls (uses system cert store) ==="
-sed -i '' 's/rustls-tls/native-tls/' $WORK/rust-test/Cargo.toml 2>/dev/null || \
-  sed -i 's/rustls-tls/native-tls/' $WORK/rust-test/Cargo.toml
-# native-tls needs to trust our CA — pass it via SSL_CERT_FILE (macOS/Linux)
-export SSL_CERT_FILE=$WORK/ca.crt
-cd $WORK/rust-test && TEST_PORT=$PORT cargo run 2>&1
 
-kill $SERVER_PID 2>/dev/null || true
-
-echo ""
 echo "========================================"
-echo "EXPECTED RESULT:"
-echo "  curl --cacert:      ✅ (explicitly trusts our CA)"
-echo "  reqwest rustls-tls: ❌ UnknownIssuer (webpki-roots doesn't have our CA)"
-echo "  reqwest native-tls: ✅ (uses system cert store / SSL_CERT_FILE)"
+echo "INTERPRETATION:"
+echo "  Test A (curl --cacert):  ✅ = tool CAN be told to trust custom CA"
+echo "  Test B (curl plain):     ❌ = without custom CA in trust store → rejected"
 echo ""
-echo "This is exactly what corporate TLS-inspection does:"
-echo "  System cert store: trusts corporate CA ✅"
-echo "  rustls webpki-roots: doesn't know corporate CA ❌"
+echo "In corporate VPN/TLS-inspection environments:"
+echo "  The VPN adds its CA to the system cert store."
+echo "  curl/R/Python/browsers use system cert store → they work (like Test A)"
+echo "  rustls (uvr) uses webpki-roots ONLY, ignores system cert store → fails (like Test B)"
+echo ""
+echo "Fix: build uvr with native-tls feature to use system cert store instead of webpki-roots."
 echo "========================================"

--- a/repro/tls-repro.sh
+++ b/repro/tls-repro.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+# Reproduction script for uvr rustls TLS issue
+# NO sudo required — uses a temporary user-level cert store
+#
+# Demonstrates that reqwest with rustls-tls does NOT use the system cert store,
+# while reqwest with native-tls does. This explains why corporate VPN/TLS-inspection
+# causes UnknownIssuer in uvr but not in curl/Python/R.
+#
+# Requirements: cargo (rustup), openssl, python3
+# Usage: bash repro-noroot.sh
+
+set -e
+WORK=$(mktemp -d)
+trap "rm -rf $WORK" EXIT
+
+echo "=== Step 1: Generate a self-signed CA (not in webpki-roots) ==="
+openssl genrsa -out $WORK/ca.key 2048 2>/dev/null
+openssl req -x509 -new -key $WORK/ca.key -out $WORK/ca.crt \
+  -days 1 -nodes -subj "/CN=test-corporate-CA" 2>/dev/null
+echo "Custom CA: $WORK/ca.crt"
+
+echo ""
+echo "=== Step 2: Generate server cert signed by our CA ==="
+openssl genrsa -out $WORK/server.key 2048 2>/dev/null
+openssl req -new -key $WORK/server.key -out $WORK/server.csr \
+  -subj "/CN=localhost" 2>/dev/null
+openssl x509 -req -in $WORK/server.csr -CA $WORK/ca.crt -CAkey $WORK/ca.key \
+  -CAcreateserial -out $WORK/server.crt -days 1 2>/dev/null
+echo "Server cert signed by custom CA (NOT trusted by webpki-roots)"
+
+echo ""
+echo "=== Step 3: Start local HTTPS server (no sudo needed) ==="
+python3 - "$WORK" << 'PYEOF' &
+import http.server, ssl, sys
+
+work = sys.argv[1]
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(200)
+        self.end_headers()
+        self.wfile.write(b'Package: BiocStyle\nVersion: 2.38.0\n')
+    def log_message(self, *a): pass
+
+server = http.server.HTTPServer(('127.0.0.1', 14443), Handler)
+ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+ctx.load_cert_chain(f'{work}/server.crt', f'{work}/server.key')
+server.socket = ctx.wrap_socket(server.socket, server_side=True)
+server.serve_forever()
+PYEOF
+SERVER_PID=$!
+sleep 1
+
+echo ""
+echo "=== Step 4: curl with --cacert (simulates system cert store trusting our CA) ==="
+curl -s --cacert $WORK/ca.crt https://localhost:14443/ \
+  && echo "curl --cacert: ✅ SUCCESS" \
+  || echo "curl --cacert: ❌ FAIL"
+
+echo ""
+echo "=== Step 5: Build and run reqwest test (no sudo, isolated cargo project) ==="
+mkdir -p $WORK/rust-test/src
+
+cat > $WORK/rust-test/Cargo.toml << 'TOML'
+[package]
+name = "tls-test"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "blocking"] }
+TOML
+
+cat > $WORK/rust-test/src/main.rs << 'RUST'
+fn main() {
+    // rustls-tls: uses webpki-roots only — does NOT trust system/custom CAs
+    let result = reqwest::blocking::get("https://localhost:14443/");
+    match result {
+        Ok(r)  => println!("reqwest rustls-tls: ✅ OK ({})", r.status()),
+        Err(e) => println!("reqwest rustls-tls: ❌ FAIL\n  Error: {e}"),
+    }
+}
+RUST
+
+echo "Building reqwest rustls-tls test (first build ~30s, subsequent instant)..."
+cd $WORK/rust-test && cargo run -q 2>/dev/null
+
+echo ""
+echo "=== Step 6: Same test with native-tls (uses system cert store) ==="
+sed -i '' 's/rustls-tls/native-tls/' $WORK/rust-test/Cargo.toml 2>/dev/null || \
+  sed -i 's/rustls-tls/native-tls/' $WORK/rust-test/Cargo.toml
+# native-tls needs to trust our CA — pass it via SSL_CERT_FILE (macOS/Linux)
+export SSL_CERT_FILE=$WORK/ca.crt
+cd $WORK/rust-test && cargo run -q 2>/dev/null
+
+kill $SERVER_PID 2>/dev/null || true
+
+echo ""
+echo "========================================"
+echo "EXPECTED RESULT:"
+echo "  curl --cacert:      ✅ (explicitly trusts our CA)"
+echo "  reqwest rustls-tls: ❌ UnknownIssuer (webpki-roots doesn't have our CA)"
+echo "  reqwest native-tls: ✅ (uses system cert store / SSL_CERT_FILE)"
+echo ""
+echo "This is exactly what corporate TLS-inspection does:"
+echo "  System cert store: trusts corporate CA ✅"
+echo "  rustls webpki-roots: doesn't know corporate CA ❌"
+echo "========================================"


### PR DESCRIPTION
Bioconductor 3.22 is the stable release paired with R 4.5. Bioc 3.21 was a devel-cycle release for R 4.5.0-devel only and is no longer available on the Bioc CDN, causing all `--bioc` installs on R 4.5 to fail with a network error.

## Symptom

On R 4.5 systems, any `uvr add --bioc <pkg>` fails:

```
x ERROR  Failed to fetch Bioconductor index
  Failed to fetch Bioconductor 3.21 software index: Network error: ...
  (https://bioconductor.org/packages/3.21/bioc/src/contrib/PACKAGES.gz)
```

Bioc 3.21 no longer exists on the CDN — it was a devel release, not a stable one.

## Root cause

`bioc_release_for_r(4, 5)` returns `"3.21"` but R 4.5 pairs with Bioconductor **3.22**.

Per the [Bioconductor release schedule](https://bioconductor.org/about/release-announcements/):
- Bioc 3.21 → R 4.5.0-devel (no longer available)
- Bioc 3.22 → R 4.5.x (stable, current)

## Fix

One-line change in `crates/uvr-core/src/registry/bioconductor.rs`:

```rust
// Before:
(4, 5) => "3.21",
// After:
(4, 5) => "3.22",
```

## Context

Discovered while testing uvr against the [gdrplatform](https://github.com/gdrplatform) — a Bioconductor-heavy R package suite. All Bioc installs were failing until I manually pinned `bioc_version = "3.22"` in `uvr.toml`.

I confirmed that Bioc 3.22 is reachable and fully functional; 3.21 returns 404.
