### PR TITLE
Fix #175: stop installing incompatible binaries on unrecognized distros; use portable manylinux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,6 +211,122 @@ jobs:
             "$bin" r list --all
           '
 
+  # Binary-repo selection across distros (#175).
+  #
+  # The `test` matrix above only runs on distros P3M publishes for, so it
+  # cannot catch uvr choosing a repo whose binaries don't load here. Nor can
+  # SMOKE_PKG: jsonlite links only libR and libc, so it loads no matter which
+  # distro's binary you install. #175 needed a package with an *external*
+  # system library — xml2 pulls libxml2, and that is exactly how it surfaced
+  # (jammy binaries want libxml2.so.2; Arch ships .so.16).
+  #
+  # One static binary is built and reused so each container only runs uvr.
+  build-static:
+    name: Build static uvr (distro matrix)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-unknown-linux-musl
+      - name: Install musl toolchain
+        run: sudo apt-get update && sudo apt-get install -y musl-tools
+      # Static: runs on any glibc distro regardless of its version. uvr's own
+      # libc/distro detection is all runtime (os-release, getconf), so a musl
+      # build still identifies the glibc host correctly.
+      - name: Build
+        run: cargo build --release --target x86_64-unknown-linux-musl --bin uvr
+      - uses: actions/upload-artifact@v4
+        with:
+          name: uvr-static
+          path: target/x86_64-unknown-linux-musl/release/uvr
+          retention-days: 1
+
+  test-distros:
+    name: Distro (${{ matrix.name }})
+    needs: build-static
+    runs-on: ubuntu-latest
+    container: ${{ matrix.image }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Not published by P3M — must degrade to the portable repo, NOT
+          # claim to be Ubuntu (#175) and not silently drop to source.
+          - name: arch (unmapped)
+            image: archlinux:latest
+            expect: manylinux_2_28
+            setup: pacman -Sy --noconfirm --needed gcc make which fontconfig ca-certificates libxml2
+          - name: fedora (unmapped)
+            image: fedora:42
+            expect: manylinux_2_28
+            setup: dnf -y install gcc make which fontconfig ca-certificates libxml2-devel
+          # Repos uvr previously did not map, so these users compiled everything.
+          - name: debian 13 (trixie)
+            image: debian:trixie
+            expect: trixie
+            setup: apt-get update && apt-get install -y --no-install-recommends gcc make ca-certificates fontconfig libxml2-dev
+          - name: rocky 10 (rhel10)
+            image: rockylinux/rockylinux:10
+            expect: rhel10
+            setup: dnf -y install gcc make which fontconfig ca-certificates libxml2-devel
+    steps:
+      - name: Install host prerequisites
+        run: ${{ matrix.setup }}
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: uvr-static
+
+      - name: Prepare uvr
+        run: |
+          set -eux
+          install -m 0755 uvr /usr/local/bin/uvr
+          uvr --version
+
+      # The assertion that would have caught #175: uvr must pick the repo this
+      # distro can actually run, not the one it guessed.
+      - name: Binary repo selection
+        run: |
+          set -eux
+          uvr doctor | tee doctor.txt
+          grep -q "${{ matrix.expect }}" doctor.txt
+
+      - name: Install R
+        run: uvr r install "${R_VERSIONS##* }"
+
+      # Install a package with an external system-library dependency and load
+      # it. A wrong-repo binary installs fine and only fails here.
+      - name: Install and load xml2
+        run: |
+          set -eux
+          mkdir -p /tmp/distro-smoke && cd /tmp/distro-smoke
+          uvr init --here distro-smoke --r-version "${R_VERSIONS##* }"
+          printf 'library(xml2); stopifnot(xml_text(xml_find_first(read_xml("<a><b>ok</b></a>"), "//b")) == "ok"); cat("distro-smoke-ok\\n")\n' > check.R
+          uvr add xml2
+          uvr run check.R
+
+      # The escape hatch must still produce a working package.
+      - name: Force source build
+        run: |
+          set -eux
+          mkdir -p /tmp/src-smoke && cd /tmp/src-smoke
+          uvr init --here src-smoke --r-version "${R_VERSIONS##* }"
+          printf 'library(xml2); cat("source-smoke-ok\\n")\n' > check.R
+          uvr add xml2 --no-binary
+          uvr run check.R
+
+  # Guards the slug -> P3M repo table against drift: Posit adds repos as
+  # distros ship and retires them at EOL, and both directions fail silently.
+  test-p3m-repos:
+    name: P3M repo coverage (live)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Check every mapped repo still serves
+        run: cargo test -p uvr-core --test p3m_repos_live -- --ignored --nocapture
+
   audit:
     name: Security audit
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,21 +256,23 @@ jobs:
           - name: arch (unmapped)
             image: archlinux:latest
             expect: manylinux_2_28
-            setup: pacman -Sy --noconfirm --needed gcc make which fontconfig ca-certificates libxml2
+            setup: pacman -Sy --noconfirm --needed gcc make pkgconf which fontconfig ca-certificates libxml2
           - name: fedora (unmapped)
             image: fedora:42
             expect: manylinux_2_28
-            setup: dnf -y install gcc make which fontconfig ca-certificates libxml2-devel
+            setup: dnf -y install gcc gcc-c++ make pkgconf-pkg-config which fontconfig ca-certificates libxml2-devel
           # Repos uvr previously did not map, so these users compiled everything.
           - name: debian 13 (trixie)
             image: debian:trixie
             expect: trixie
-            setup: apt-get update && apt-get install -y --no-install-recommends gcc make ca-certificates fontconfig libxml2-dev
+            setup: apt-get update && apt-get install -y --no-install-recommends build-essential pkg-config ca-certificates fontconfig libxml2-dev
           - name: rocky 10 (rhel10)
             image: rockylinux/rockylinux:10
             expect: rhel10
-            setup: dnf -y install gcc make which fontconfig ca-certificates libxml2-devel
+            setup: dnf -y install gcc gcc-c++ make pkgconf-pkg-config which fontconfig ca-certificates libxml2-devel
     steps:
+      # The C/C++ toolchain, pkg-config and libxml2 headers are needed only by
+      # the `--no-binary` step; the binary path below needs none of them.
       - name: Install host prerequisites
         run: ${{ matrix.setup }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ release page on GitHub. Issue numbers reference https://github.com/nbafrank/uvr/
 
 Pure tracking section — fixes and small features land here between tags.
 
+- **Unknown Linux distros no longer install incompatible binaries** (#175):
+  uvr treated any unrecognized distro as Ubuntu 22.04 and installed P3M's
+  jammy binaries. On Arch those link `libxml2.so.2` against a system shipping
+  `libxml2.so.16` — the install "succeeded" in seconds and every affected
+  package failed at `library()`. An unrecognized distro now reports itself and
+  no per-distro repo matches.
+- **Portable `manylinux_2_28` binaries on distros Posit doesn't publish for**
+  (#175): rather than falling back to source, uvr now uses P3M's portable
+  manylinux repo, whose binaries vendor their own shared libraries. Arch,
+  Fedora, NixOS and Gentoo get binary installs (~5s) instead of source builds
+  (~45s). Requires glibc >= 2.28; musl and older glibc still build from source.
+- **New P3M repos**: Ubuntu 26.04 (`resolute`), Debian 13 (`trixie`),
+  RHEL/Rocky 10 (`rhel10`), openSUSE 15.6 (`opensuse156`). Users on those
+  distros were silently compiling everything from source.
+- **`uvr add --no-binary` / `uvr sync --no-binary`** (also `UVR_NO_BINARY=1`):
+  build everything from source, ignoring pre-built binaries — an escape hatch
+  for a binary that doesn't suit the host, including opting out of the preview
+  manylinux repo.
+- Binary cache entries now record which repo they came from, so a jammy build
+  and a manylinux build of the same package can't collide. Without this, a
+  machine that already cached a wrong-distro binary would keep reusing it.
+- The system-dependency check and P3M distro detection now share one parse of
+  `/etc/os-release`; they previously disagreed on whether `VERSION_ID` was
+  required, and a test assumed every Linux has dpkg/rpm/apk (it fails on Arch).
 - **GitLab-hosted package support** (#123, PR #174 by @pteridin): `uvr add gitlab::host/group/repo[@ref]` resolves via the GitLab API v4, mirroring the existing `forgejo::` support — self-hosted instances included, nested groups handled via URL-encoded project paths. Flows through lockfile, `uvr export`, and sync.
 - Cache filenames derived from download URLs strip query strings/fragments — GitLab archive URLs carry `?sha=...`, and `?` is an illegal filename character on Windows (os error 123). (PR #174)
 - `R CMD INSTALL` failure logs now combine stdout and stderr instead of picking one stream — R splits progress and the actual error across both inconsistently. (PR #174)

--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ uvr tree
 | `uvr remove <pkg...>` | Remove packages from manifest and re-lock |
 | `uvr sync` | Install all packages from the lockfile |
 | `uvr sync --frozen` | Like `sync`, but fail if the lockfile is stale (CI mode) |
+| `uvr sync --no-binary` | Build everything from source, ignoring pre-built binaries |
 | `uvr update [pkg...]` | Upgrade packages to latest allowed versions |
 | `uvr update --dry-run` | Show what would change without installing |
 | `uvr lock` | Re-resolve all deps and update `uvr.lock` without installing |

--- a/crates/uvr-core/src/installer/package_cache.rs
+++ b/crates/uvr-core/src/installer/package_cache.rs
@@ -62,6 +62,7 @@ pub fn cache_key(
     r_minor: &str,
     is_binary: bool,
     libr_path: Option<&Path>,
+    binary_flavor: Option<&str>,
 ) -> String {
     let mut hasher = Sha256::new();
     hasher.update(checksum.unwrap_or("none").as_bytes());
@@ -77,6 +78,18 @@ pub fn cache_key(
     hasher.update(std::env::consts::ARCH.as_bytes());
     hasher.update(b"-");
     hasher.update(std::env::consts::OS.as_bytes());
+    // Which binary repo the artifact came from. A `jammy` build and a
+    // `manylinux_2_28` build of the same package+version are different
+    // artifacts linking different libraries, and only one of them loads on a
+    // given host (#175) — so they must not share a cache entry.
+    //
+    // Only hashed when present, which keeps macOS/Windows and source-built
+    // keys byte-identical to before; only Linux binary entries are
+    // re-keyed, and those are exactly the ones that were ambiguous.
+    if let Some(flavor) = binary_flavor {
+        hasher.update(b"|");
+        hasher.update(flavor.as_bytes());
+    }
     if let Some(p) = libr_path {
         hasher.update(b"|");
         hasher.update(p.to_string_lossy().as_bytes());
@@ -167,12 +180,31 @@ pub fn lookup_any(
     version: &str,
     checksum: Option<&str>,
     r_minor: &str,
-    is_binary_hint: bool,
+    binary_allowed: bool,
     libr_path: Option<&Path>,
+    binary_flavor: Option<&str>,
 ) -> Option<PathBuf> {
-    // Try the hinted variant first, then the opposite.
-    for &try_binary in &[is_binary_hint, !is_binary_hint] {
-        let key = cache_key(name, version, checksum, r_minor, try_binary, libr_path);
+    // Probe the binary variant first when this platform can use P3M binaries
+    // at all, then source.
+    //
+    // When it cannot, a cached *binary* entry must never be served. Those
+    // entries exist on such machines only as leftovers from a uvr that
+    // mis-identified the distro (#175) — they link shared libraries this
+    // system does not have and fail at `library()`. Without this gate the
+    // distro fix is inert for exactly the users who already hit the bug,
+    // because the broken artifact is still in `~/.uvr/packages/`.
+    let variants: &[bool] = if binary_allowed {
+        &[true, false]
+    } else {
+        &[false]
+    };
+    for &try_binary in variants {
+        // Flavour only identifies a *binary* artifact; a source build is
+        // compiled here and is not repo-specific.
+        let flavor = if try_binary { binary_flavor } else { None };
+        let key = cache_key(
+            name, version, checksum, r_minor, try_binary, libr_path, flavor,
+        );
         let pkg_dir = global_packages_dir().join(&key).join(name);
         if pkg_dir.join("DESCRIPTION").exists() {
             return Some(pkg_dir);
@@ -517,8 +549,8 @@ mod tests {
 
     #[test]
     fn cache_key_deterministic() {
-        let k1 = cache_key("ggplot2", "3.5.1", Some("abc123"), "4.4", true, None);
-        let k2 = cache_key("ggplot2", "3.5.1", Some("abc123"), "4.4", true, None);
+        let k1 = cache_key("ggplot2", "3.5.1", Some("abc123"), "4.4", true, None, None);
+        let k2 = cache_key("ggplot2", "3.5.1", Some("abc123"), "4.4", true, None, None);
         assert_eq!(k1, k2);
         assert!(k1.starts_with("ggplot2-3.5.1-"));
         assert_eq!(k1.len(), "ggplot2-3.5.1-".len() + 32);
@@ -526,33 +558,65 @@ mod tests {
 
     #[test]
     fn cache_key_differs_by_r_version() {
-        let k1 = cache_key("pkg", "1.0", Some("abc"), "4.4", true, None);
-        let k2 = cache_key("pkg", "1.0", Some("abc"), "4.5", true, None);
+        let k1 = cache_key("pkg", "1.0", Some("abc"), "4.4", true, None, None);
+        let k2 = cache_key("pkg", "1.0", Some("abc"), "4.5", true, None, None);
         assert_ne!(k1, k2);
     }
 
     #[test]
     fn cache_key_differs_by_method() {
-        let k1 = cache_key("pkg", "1.0", Some("abc"), "4.4", true, None);
-        let k2 = cache_key("pkg", "1.0", Some("abc"), "4.4", false, None);
+        let k1 = cache_key("pkg", "1.0", Some("abc"), "4.4", true, None, None);
+        let k2 = cache_key("pkg", "1.0", Some("abc"), "4.4", false, None, None);
         assert_ne!(k1, k2);
+    }
+
+    #[test]
+    fn cache_key_differs_by_binary_flavor() {
+        // A jammy build and a manylinux build of the same package+version
+        // link different libraries and only one loads on a given host
+        // (#175), so they must not collide in the cache.
+        let jammy = cache_key("pkg", "1.0", Some("abc"), "4.4", true, None, Some("jammy"));
+        let many = cache_key(
+            "pkg",
+            "1.0",
+            Some("abc"),
+            "4.4",
+            true,
+            None,
+            Some("manylinux_2_28"),
+        );
+        assert_ne!(jammy, many);
+
+        // Absent flavour must stay byte-identical to before this field
+        // existed, so macOS/Windows and source entries are not invalidated.
+        let unflavoured = cache_key("pkg", "1.0", Some("abc"), "4.4", true, None, None);
+        assert_ne!(unflavoured, jammy);
+        assert_ne!(unflavoured, many);
     }
 
     #[test]
     fn cache_key_differs_by_libr_path() {
         let p1 = PathBuf::from("/home/.uvr/r-versions/4.4.2/lib/libR.dylib");
         let p2 = PathBuf::from("/home/.uvr/r-versions/4.4.3/lib/libR.dylib");
-        let k1 = cache_key("pkg", "1.0", Some("abc"), "4.4", true, Some(&p1));
-        let k2 = cache_key("pkg", "1.0", Some("abc"), "4.4", true, Some(&p2));
+        let k1 = cache_key("pkg", "1.0", Some("abc"), "4.4", true, Some(&p1), None);
+        let k2 = cache_key("pkg", "1.0", Some("abc"), "4.4", true, Some(&p2), None);
         assert_ne!(k1, k2);
     }
 
     #[test]
     fn package_name_from_key_roundtrips_cache_key() {
-        let key = cache_key("ggplot2", "3.5.1", Some("abc123"), "4.4", true, None);
+        let key = cache_key("ggplot2", "3.5.1", Some("abc123"), "4.4", true, None, None);
         assert_eq!(package_name_from_key(&key), Some("ggplot2"));
         // Dots in names are fine (e.g. data.table).
-        let key = cache_key("data.table", "1.15.4", Some("abc"), "4.5", false, None);
+        let key = cache_key(
+            "data.table",
+            "1.15.4",
+            Some("abc"),
+            "4.5",
+            false,
+            None,
+            None,
+        );
         assert_eq!(package_name_from_key(&key), Some("data.table"));
     }
 
@@ -560,7 +624,7 @@ mod tests {
     fn package_name_from_key_handles_hyphenated_versions() {
         // R package *versions* may contain hyphens (Matrix "1.6-5"); names
         // cannot, so the name is everything before the first hyphen.
-        let key = cache_key("Matrix", "1.6-5", Some("abc"), "4.4", true, None);
+        let key = cache_key("Matrix", "1.6-5", Some("abc"), "4.4", true, None, None);
         assert_eq!(package_name_from_key(&key), Some("Matrix"));
     }
 
@@ -699,15 +763,44 @@ mod tests {
         .unwrap();
 
         // Store under the source key (is_binary=false)
-        let source_key = cache_key("testpkg", "1.0", Some("cksum"), "4.5", false, None);
+        let source_key = cache_key("testpkg", "1.0", Some("cksum"), "4.5", false, None, None);
         store(&pkg_dir, &source_key, "testpkg", None).unwrap();
 
         // Lookup with binary hint (is_binary=true) — should still find the source entry
-        let found = lookup_any("testpkg", "1.0", Some("cksum"), "4.5", true, None);
+        let found = lookup_any("testpkg", "1.0", Some("cksum"), "4.5", true, None, None);
         assert!(found.is_some());
 
         // Cleanup
         let _ = std::fs::remove_dir_all(global_packages_dir().join(&source_key));
+    }
+
+    #[test]
+    fn lookup_any_refuses_a_binary_entry_when_binaries_are_unusable() {
+        // #175: on a distro P3M doesn't publish for, a cached binary is a
+        // leftover from a uvr that mis-identified the distro. Serving it
+        // reinstalls a package that cannot load, and would make the distro
+        // fix inert for exactly the people who already hit the bug.
+        let tmp = TempDir::new().unwrap();
+        let pkg_dir = tmp.path().join("binpkg");
+        std::fs::create_dir_all(&pkg_dir).unwrap();
+        std::fs::write(
+            pkg_dir.join("DESCRIPTION"),
+            "Package: binpkg\nVersion: 1.0\n",
+        )
+        .unwrap();
+
+        let binary_key = cache_key("binpkg", "1.0", Some("cksum"), "4.5", true, None, None);
+        store(&pkg_dir, &binary_key, "binpkg", None).unwrap();
+
+        // Binaries usable here → the entry is served.
+        assert!(lookup_any("binpkg", "1.0", Some("cksum"), "4.5", true, None, None).is_some());
+        // Binaries NOT usable here → it must be ignored, forcing a source build.
+        assert!(
+            lookup_any("binpkg", "1.0", Some("cksum"), "4.5", false, None, None).is_none(),
+            "a binary cache entry was served on a platform that cannot use binaries"
+        );
+
+        let _ = std::fs::remove_dir_all(global_packages_dir().join(&binary_key));
     }
 
     #[test]

--- a/crates/uvr-core/src/lib.rs
+++ b/crates/uvr-core/src/lib.rs
@@ -5,6 +5,7 @@ pub mod error;
 pub mod installer;
 pub mod lockfile;
 pub mod manifest;
+pub mod os_release;
 pub mod project;
 pub mod r_version;
 pub mod registry;

--- a/crates/uvr-core/src/os_release.rs
+++ b/crates/uvr-core/src/os_release.rs
@@ -1,0 +1,97 @@
+//! One parse of `/etc/os-release`, shared by everything that needs to know
+//! which Linux this is.
+//!
+//! uvr asks that question for two unrelated reasons:
+//!
+//! - **Which P3M binaries to install** — a wrong answer installs packages
+//!   linked against shared libraries that do not exist here, which fails at
+//!   `library()` rather than at install time (#175).
+//! - **Which system packages to check for** — a wrong answer produces a
+//!   misleading hint, but nothing breaks.
+//!
+//! Those were answered by two separate parsers that disagreed: one required
+//! `VERSION_ID` and returned `Option`, the other did not and fell back to a
+//! hardcoded distro. Parsing lives here now so the *identity* is decided once
+//! and each consumer only decides what to do about it.
+
+/// The fields of `/etc/os-release` uvr cares about, unquoted.
+///
+/// Either field may be empty. Rolling releases ship no `VERSION_ID` at all —
+/// Arch and CachyOS are the cases that matter here — so callers that need a
+/// version must handle its absence rather than assume a default.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct OsRelease {
+    /// `ID`, lowercased (e.g. `ubuntu`, `debian`, `arch`).
+    pub id: String,
+    /// `VERSION_ID` verbatim (e.g. `22.04`, `12`, `3.21`). Empty on rolling
+    /// releases.
+    pub version_id: String,
+}
+
+impl OsRelease {
+    /// Parse os-release content. Unknown/missing keys yield empty strings.
+    pub fn parse(content: &str) -> Self {
+        let mut out = OsRelease::default();
+        for line in content.lines() {
+            if let Some(val) = line.strip_prefix("ID=") {
+                out.id = val.trim_matches('"').to_lowercase();
+            } else if let Some(val) = line.strip_prefix("VERSION_ID=") {
+                out.version_id = val.trim_matches('"').to_string();
+            }
+        }
+        out
+    }
+
+    /// `true` when the file gave us nothing usable to identify the system.
+    pub fn is_empty(&self) -> bool {
+        self.id.is_empty()
+    }
+}
+
+/// Read and parse `/etc/os-release`. `None` when it is absent or unreadable
+/// (a scratch container, a non-Linux host).
+pub fn detect() -> Option<OsRelease> {
+    let content = std::fs::read_to_string("/etc/os-release").ok()?;
+    Some(OsRelease::parse(&content))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_id_and_version() {
+        let os = OsRelease::parse("NAME=\"Ubuntu\"\nID=ubuntu\nVERSION_ID=\"22.04\"\n");
+        assert_eq!(os.id, "ubuntu");
+        assert_eq!(os.version_id, "22.04");
+    }
+
+    #[test]
+    fn lowercases_the_id() {
+        // os-release says IDs are lowercase, but not every distro complies;
+        // both consumers used to normalize differently.
+        assert_eq!(OsRelease::parse("ID=Debian\n").id, "debian");
+    }
+
+    #[test]
+    fn rolling_release_has_no_version() {
+        // Arch / CachyOS: the case that broke both consumers, differently.
+        let os = OsRelease::parse("NAME=\"Arch Linux\"\nID=arch\n");
+        assert_eq!(os.id, "arch");
+        assert_eq!(os.version_id, "");
+        assert!(!os.is_empty(), "an id with no version still identifies it");
+    }
+
+    #[test]
+    fn id_like_is_not_mistaken_for_id() {
+        // `ID_LIKE=arch` must not be read as `ID`, or a derivative would be
+        // matched against rules meant for its parent.
+        let os = OsRelease::parse("ID=cachyos\nID_LIKE=arch\n");
+        assert_eq!(os.id, "cachyos");
+    }
+
+    #[test]
+    fn empty_content_identifies_nothing() {
+        assert!(OsRelease::parse("").is_empty());
+    }
+}

--- a/crates/uvr-core/src/r_version/downloader.rs
+++ b/crates/uvr-core/src/r_version/downloader.rs
@@ -174,6 +174,33 @@ fn ensure_linux_libc_supported() -> Result<()> {
     Ok(())
 }
 
+/// Lowest glibc the P3M `manylinux_2_28` package repo supports.
+const PPM_MANYLINUX_GLIBC_MIN: (u32, u32) = (2, 28);
+
+/// The portable P3M package repo usable on this host, if any.
+///
+/// Posit publishes a `manylinux_2_28` CRAN repo (preview) whose binaries
+/// vendor their own shared libraries — `libxml2-35ea8990.so.2.9.7` and the
+/// like, the same trick Python wheels use. Unlike the per-distro repos, they
+/// carry no dependency on the host's library versions, so they work on
+/// distros Posit doesn't publish for: Arch, Fedora, NixOS, Gentoo.
+///
+/// That makes this the right fallback for an unrecognized distro — better
+/// than compiling from source, and correct where a per-distro binary is not
+/// (#175). Verified on Arch: the manylinux `xml2` loads and parses, while the
+/// jammy build fails on a missing `libxml2.so.2`.
+///
+/// `None` on musl, on glibc older than 2.28, and on non-Linux hosts (where
+/// the per-platform repos already apply).
+pub fn ppm_manylinux_repo() -> Option<&'static str> {
+    if !cfg!(target_os = "linux") || linux_is_musl() {
+        return None;
+    }
+    // An unreadable glibc version is not evidence of a new enough one.
+    let (maj, min) = detect_glibc_version()?;
+    ((maj, min) >= PPM_MANYLINUX_GLIBC_MIN).then_some("manylinux_2_28")
+}
+
 /// Parse an `X.Y.Z` R version into a comparable tuple. Extra components and
 /// non-numeric tails are ignored. Returns `None` if the first component isn't numeric.
 fn parse_r_version(version: &str) -> Option<(u32, u32, u32)> {
@@ -205,7 +232,12 @@ pub fn set_posit_distro_override(slug: String) {
 /// override set by [`set_posit_distro_override`] if any.
 ///
 /// Returns strings like `"ubuntu-2204"`, `"ubuntu-2404"`, `"debian-12"`,
-/// `"centos-7"`, `"rhel-9"`, `"opensuse-154"`. Falls back to `"ubuntu-2204"`.
+/// `"centos-7"`, `"rhel-9"`, `"opensuse-154"`.
+///
+/// A distro Posit doesn't publish for returns its own identity (`"arch"`,
+/// `"cachyos"`, `"nixos-25.05"`), which no PPM codename maps to — so P3M is
+/// skipped and sync compiles from source. See
+/// [`detect_posit_distro_slug_from_os_release`] for why that matters.
 pub fn detect_posit_distro_slug() -> String {
     if let Some(override_slug) = DISTRO_OVERRIDE.get() {
         return override_slug.clone();
@@ -217,21 +249,39 @@ pub fn detect_posit_distro_slug() -> String {
 /// Testable helper: parse os-release content (or fall back) into a Posit
 /// CDN distro slug. Module-private; the inline test module calls it
 /// directly. Production callers go through [`detect_posit_distro_slug`].
+/// # Why an unknown distro must not guess
+///
+/// This slug's only remaining production consumer is P3M **binary package**
+/// selection (`sync`) and the `doctor` display; R itself is installed from
+/// portable manylinux/musllinux builds chosen by libc and architecture, so
+/// `--distribution` is deprecated and ignored.
+///
+/// That changed what a wrong guess costs. It used to pick an R tarball, where
+/// being approximately right still gave you a working R. Now it picks package
+/// binaries that link the *host distro's* shared libraries by SONAME. Claiming
+/// `ubuntu-2204` on Arch installed jammy binaries wanting `libxml2.so.2`
+/// against a system that ships `libxml2.so.16` — the install "succeeded" in
+/// seconds and every affected package failed at `library()` (#175).
+///
+/// There is no distro-neutral binary to fall back to either: every P3M flavour
+/// that serves a binary (jammy, noble, rhel9) links `libxml2.so.2`. rstudio's
+/// portable-R docs say the same thing — those builds cover the interpreter,
+/// and "users can compile R packages from source on target systems".
+///
+/// So an unrecognized distro returns its own identity, which
+/// [`crate::registry::p3m::ppm_linux_codename`] maps to `None`, P3M is skipped
+/// and sync compiles from source against the libraries actually installed.
+/// Slower, and correct. This mirrors what the `alpine` arm already does
+/// deliberately.
 pub(crate) fn detect_posit_distro_slug_from_os_release(content: Option<&str>) -> String {
-    let content = match content {
-        Some(c) => c,
-        None => return "ubuntu-2204".to_string(),
+    // No os-release at all: a scratch container, or not Linux. Nothing to
+    // identify, so claim nothing rather than a distro we merely hope for.
+    let Some(content) = content else {
+        return "unknown".to_string();
     };
 
-    let mut id = String::new();
-    let mut version_id = String::new();
-    for line in content.lines() {
-        if let Some(val) = line.strip_prefix("ID=") {
-            id = val.trim_matches('"').to_lowercase();
-        } else if let Some(val) = line.strip_prefix("VERSION_ID=") {
-            version_id = val.trim_matches('"').to_string();
-        }
-    }
+    let crate::os_release::OsRelease { id, version_id } =
+        crate::os_release::OsRelease::parse(content);
 
     // Posit CDN uses no dots in version for Ubuntu/openSUSE, but keeps them for others
     match id.as_str() {
@@ -256,7 +306,12 @@ pub(crate) fn detect_posit_distro_slug_from_os_release(content: Option<&str>) ->
             let minor = version_id.split('.').take(2).collect::<Vec<_>>().join(".");
             format!("alpine-{minor}")
         }
-        _ => "ubuntu-2204".to_string(),
+        // Anything Posit doesn't publish for — Arch, CachyOS, NixOS, Gentoo,
+        // Fedora, Void — reports itself. No PPM codename matches, so the
+        // caller falls through to a source build.
+        _ if id.is_empty() => "unknown".to_string(),
+        _ if version_id.is_empty() => id,
+        _ => format!("{id}-{version_id}"),
     }
 }
 
@@ -1187,11 +1242,52 @@ VERSION_ID=3.23.4
     }
 
     #[test]
-    fn detect_posit_distro_slug_unknown_distro_still_falls_back() {
-        // Regression: Arch / NixOS / Gentoo / etc. keep the ubuntu-2204
-        // fallback (out of scope for this PR).
-        let slug = detect_posit_distro_slug_from_os_release(Some("ID=arch\n"));
-        assert_eq!(slug, "ubuntu-2204");
+    fn detect_posit_distro_slug_unknown_distro_reports_itself() {
+        // #175: claiming ubuntu-2204 here installed jammy binaries on Arch
+        // that could not load. An unknown distro now identifies itself, and
+        // no PPM codename matches it, so sync compiles from source.
+        for (os_release, expected) in [
+            ("ID=arch\n", "arch"),
+            ("ID=cachyos\nID_LIKE=arch\n", "cachyos"),
+            ("ID=gentoo\n", "gentoo"),
+            ("ID=nixos\nVERSION_ID=\"25.05\"\n", "nixos-25.05"),
+            ("ID=fedora\nVERSION_ID=42\n", "fedora-42"),
+        ] {
+            let slug = detect_posit_distro_slug_from_os_release(Some(os_release));
+            assert_eq!(slug, expected, "slug for {os_release:?}");
+            assert_eq!(
+                crate::registry::p3m::ppm_linux_codename(&slug),
+                None,
+                "{slug} must not resolve to a PPM codename, or binaries get installed"
+            );
+        }
+    }
+
+    #[test]
+    fn detect_posit_distro_slug_without_os_release_claims_nothing() {
+        let slug = detect_posit_distro_slug_from_os_release(None);
+        assert_eq!(slug, "unknown");
+        assert_eq!(crate::registry::p3m::ppm_linux_codename(&slug), None);
+    }
+
+    #[test]
+    fn detect_posit_distro_slug_still_recognizes_supported_distros() {
+        // Regression: the distros Posit *does* publish for must keep
+        // resolving to a codename, or this fix would disable binaries for
+        // everyone.
+        for (os_release, slug, codename) in [
+            ("ID=ubuntu\nVERSION_ID=\"22.04\"\n", "ubuntu-2204", "jammy"),
+            ("ID=ubuntu\nVERSION_ID=\"24.04\"\n", "ubuntu-2404", "noble"),
+            ("ID=debian\nVERSION_ID=\"12\"\n", "debian-12", "bookworm"),
+            ("ID=rocky\nVERSION_ID=\"9.3\"\n", "rhel-9", "rhel9"),
+        ] {
+            let got = detect_posit_distro_slug_from_os_release(Some(os_release));
+            assert_eq!(got, slug);
+            assert_eq!(
+                crate::registry::p3m::ppm_linux_codename(&got),
+                Some(codename)
+            );
+        }
     }
 
     #[test]

--- a/crates/uvr-core/src/registry/p3m.rs
+++ b/crates/uvr-core/src/registry/p3m.rs
@@ -343,7 +343,7 @@ fn platform_info(
             // own server, which doesn't serve Linux binaries today; Bioc on
             // Linux falls back to source as before.
             let slug = posit_distro_slug?;
-            let codename = ppm_linux_codename(slug)?;
+            let codename = ppm_linux_repo(slug)?;
             let arch = if matches!(platform, Platform::LinuxX86_64) {
                 "x86_64"
             } else {
@@ -393,15 +393,35 @@ pub fn ppm_linux_codename(posit_slug: &str) -> Option<&'static str> {
         "ubuntu-2004" => Some("focal"),
         "ubuntu-2204" => Some("jammy"),
         "ubuntu-2404" => Some("noble"),
+        "ubuntu-2604" => Some("resolute"),
         "debian-11" => Some("bullseye"),
         "debian-12" => Some("bookworm"),
+        "debian-13" => Some("trixie"),
         "rhel-7" | "centos-7" => Some("centos7"),
         "rhel-8" | "centos-8" => Some("centos8"),
         "rhel-9" | "centos-9" => Some("rhel9"),
+        "rhel-10" | "centos-10" => Some("rhel10"),
         "opensuse-154" => Some("opensuse154"),
         "opensuse-155" => Some("opensuse155"),
+        "opensuse-156" => Some("opensuse156"),
         _ => None,
     }
+}
+
+/// The P3M Linux repo to install binaries from on this host.
+///
+/// Prefers the distro's own repo — those binaries link the system libraries
+/// and are what Posit builds for. Falls back to the portable
+/// `manylinux_2_28` repo, whose binaries vendor their dependencies and so
+/// work on distros Posit doesn't publish for (Arch, Fedora, NixOS, Gentoo).
+///
+/// `None` means no binaries are usable here at all — musl, glibc older than
+/// 2.28 — and the caller compiles from source.
+///
+/// Unlike [`ppm_linux_codename`] this inspects the host, so it is not a pure
+/// function of the slug; that mapping stays pure for tests.
+pub fn ppm_linux_repo(posit_slug: &str) -> Option<&'static str> {
+    ppm_linux_codename(posit_slug).or_else(crate::r_version::downloader::ppm_manylinux_repo)
 }
 
 fn cache_path(r_minor: &str, key: &str) -> PathBuf {
@@ -566,12 +586,68 @@ Version: 1.1.4
     }
 
     #[test]
-    fn platform_info_linux_unknown_distro_none() {
-        // Slackware isn't on PPM — falls back to None (source-only).
-        assert!(platform_info(Platform::LinuxX86_64, Some("slackware-15"), "4.5").is_none());
-        assert!(platform_info(Platform::LinuxArm64, Some("nixos-2411"), "4.5").is_none());
-        // Without a slug, we can't translate.
+    fn platform_info_linux_unknown_distro_uses_manylinux_or_source() {
+        // A distro PPM doesn't publish for no longer resolves to its own
+        // repo. What happens next depends on the host: on glibc >= 2.28 the
+        // portable manylinux repo applies, otherwise there are no usable
+        // binaries and the caller compiles from source. Assert the property
+        // rather than one host's answer, so this passes on every runner.
+        for slug in ["slackware-15", "nixos-2411"] {
+            let info = platform_info(Platform::LinuxX86_64, Some(slug), "4.5");
+            match crate::r_version::downloader::ppm_manylinux_repo() {
+                Some(repo) => {
+                    let info = info.expect("manylinux host should still get a repo");
+                    assert_eq!(info.linux_codename.as_deref(), Some(repo));
+                }
+                None => assert!(info.is_none(), "no binaries usable, expected source-only"),
+            }
+        }
+        // Without a slug there is nothing to translate, on any host.
         assert!(platform_info(Platform::LinuxX86_64, None, "4.5").is_none());
+    }
+
+    #[test]
+    fn ppm_linux_codename_stays_pure() {
+        // The slug→codename mapping must not consult the host; only
+        // `ppm_linux_repo` does. Guards the split that keeps this testable.
+        assert_eq!(ppm_linux_codename("slackware-15"), None);
+        assert_eq!(ppm_linux_codename("arch"), None);
+        assert_eq!(ppm_linux_codename("unknown"), None);
+    }
+
+    #[test]
+    fn ppm_linux_codename_covers_every_repo_posit_publishes() {
+        // Every Linux repo currently offered by the distro dropdown on
+        // https://packagemanager.posit.co/client/#/repos/cran/setup. A
+        // missing entry silently downgrades that distro's users to source
+        // builds, which is easy to ship and hard to notice.
+        for (slug, codename) in [
+            ("ubuntu-2204", "jammy"),
+            ("ubuntu-2404", "noble"),
+            ("ubuntu-2604", "resolute"),
+            ("debian-12", "bookworm"),
+            ("debian-13", "trixie"),
+            ("rhel-7", "centos7"),
+            ("rhel-8", "centos8"),
+            ("rhel-9", "rhel9"),
+            ("rhel-10", "rhel10"),
+            ("opensuse-156", "opensuse156"),
+        ] {
+            assert_eq!(ppm_linux_codename(slug), Some(codename), "slug {slug}");
+        }
+        // manylinux_2_28 is not keyed by slug — it is the host-dependent
+        // fallback in `ppm_linux_repo`.
+
+        // Retired from the dropdown but still served, so users on EOL
+        // systems keep their binaries rather than silently losing them.
+        for (slug, codename) in [
+            ("ubuntu-2004", "focal"),
+            ("debian-11", "bullseye"),
+            ("opensuse-154", "opensuse154"),
+            ("opensuse-155", "opensuse155"),
+        ] {
+            assert_eq!(ppm_linux_codename(slug), Some(codename), "legacy {slug}");
+        }
     }
 
     #[test]

--- a/crates/uvr-core/src/sysreqs.rs
+++ b/crates/uvr-core/src/sysreqs.rs
@@ -16,21 +16,16 @@ pub struct SysReq {
 /// Detect the Linux distribution from `/etc/os-release`.
 /// Returns `(id, version_id)` like `("ubuntu", "22.04")`.
 pub fn detect_linux_distro() -> Option<String> {
-    let content = std::fs::read_to_string("/etc/os-release").ok()?;
-    let mut id = None;
-    let mut version_id = None;
-
-    for line in content.lines() {
-        if let Some(val) = line.strip_prefix("ID=") {
-            id = Some(val.trim_matches('"').to_string());
-        } else if let Some(val) = line.strip_prefix("VERSION_ID=") {
-            version_id = Some(val.trim_matches('"').to_string());
-        }
+    let os = crate::os_release::detect()?;
+    // Both halves are required here, unlike P3M slug detection: the sysreqs
+    // API and the vendored rules are keyed by `id-version`, and there is no
+    // sensible query for a rolling release that publishes no version. Arch
+    // and CachyOS land here and the caller skips the check — the safe
+    // direction to fail, since a wrong answer only produces a wrong hint.
+    if os.id.is_empty() || os.version_id.is_empty() {
+        return None;
     }
-
-    let id = id?;
-    let version_id = version_id?;
-    Some(format!("{id}-{version_id}"))
+    Some(format!("{}-{}", os.id, os.version_id))
 }
 
 /// Response from the Posit Package Manager sysreqs API.
@@ -312,13 +307,44 @@ mod tests {
 
     #[test]
     fn filter_missing_with_nonexistent_package() {
-        if cfg!(target_os = "linux") {
-            let reqs = vec![SysReq {
-                package: "uvr-nonexistent-pkg-12345".to_string(),
-            }];
-            let missing = filter_missing(&reqs);
-            assert_eq!(missing.len(), 1);
+        if !cfg!(target_os = "linux") {
+            return;
         }
+        // `filter_missing` documents itself as a no-op without dpkg/rpm/apk,
+        // so asserting it reports something requires one of them to exist.
+        // The test used to assume every Linux has one and failed on Arch,
+        // NixOS, Gentoo and friends — a false alarm for anyone developing
+        // uvr there.
+        if which::which("dpkg").is_err()
+            && which::which("rpm").is_err()
+            && which::which("apk").is_err()
+        {
+            eprintln!("skipping: no dpkg/rpm/apk on this system");
+            return;
+        }
+        let reqs = vec![SysReq {
+            package: "uvr-nonexistent-pkg-12345".to_string(),
+        }];
+        let missing = filter_missing(&reqs);
+        assert_eq!(missing.len(), 1);
+    }
+
+    #[test]
+    fn filter_missing_is_a_no_op_without_a_package_manager() {
+        // The other half of the contract: with no supported package manager
+        // we report nothing missing rather than guessing. Callers must treat
+        // that as "unverified", not "verified clean" — see `check_system_deps`.
+        if which::which("dpkg").is_ok()
+            || which::which("rpm").is_ok()
+            || which::which("apk").is_ok()
+        {
+            eprintln!("skipping: a supported package manager is present");
+            return;
+        }
+        let reqs = vec![SysReq {
+            package: "uvr-nonexistent-pkg-12345".to_string(),
+        }];
+        assert!(filter_missing(&reqs).is_empty());
     }
 
     #[test]

--- a/crates/uvr-core/tests/p3m_repos_live.rs
+++ b/crates/uvr-core/tests/p3m_repos_live.rs
@@ -1,0 +1,108 @@
+//! Network-gated: every P3M Linux repo uvr maps must still exist.
+//!
+//! The distro list drifts — Posit adds repos as distros ship (Debian 13,
+//! Ubuntu 26.04, RHEL 10) and retires them at EOL. Both directions hurt
+//! silently: an unmapped repo downgrades those users to source builds, and a
+//! mapped-but-gone repo makes every install 404 into the source fallback.
+//!
+//! Skipped by default so CI stays offline-stable. Run with:
+//!     cargo test -p uvr-core --test p3m_repos_live -- --ignored
+
+use uvr_core::registry::p3m::{ppm_linux_codename, ppm_linux_repo};
+
+/// Every slug uvr maps, and the repo it must resolve to. Cross-checked against
+/// the distro dropdown at
+/// <https://packagemanager.posit.co/client/#/repos/cran/setup>.
+const MAPPED: &[(&str, &str)] = &[
+    // Currently offered in the dropdown.
+    ("ubuntu-2204", "jammy"),
+    ("ubuntu-2404", "noble"),
+    ("ubuntu-2604", "resolute"),
+    ("debian-12", "bookworm"),
+    ("debian-13", "trixie"),
+    ("rhel-7", "centos7"),
+    ("rhel-8", "centos8"),
+    ("rhel-9", "rhel9"),
+    ("rhel-10", "rhel10"),
+    ("opensuse-156", "opensuse156"),
+    // Retired from the dropdown but still served — kept so users on EOL
+    // systems don't silently lose their binaries.
+    ("ubuntu-2004", "focal"),
+    ("debian-11", "bullseye"),
+    ("opensuse-154", "opensuse154"),
+    ("opensuse-155", "opensuse155"),
+];
+
+fn index_url(codename: &str) -> String {
+    format!("https://packagemanager.posit.co/cran/__linux__/{codename}/latest/src/contrib/PACKAGES")
+}
+
+async fn serves(client: &reqwest::Client, codename: &str) -> bool {
+    match client.get(index_url(codename)).send().await {
+        Ok(resp) => resp.status().is_success(),
+        Err(e) => {
+            eprintln!("{codename}: {e}");
+            false
+        }
+    }
+}
+
+#[tokio::test]
+#[ignore = "requires network access to packagemanager.posit.co"]
+async fn every_mapped_repo_still_serves() {
+    let client = reqwest::Client::builder()
+        .user_agent("uvr-test")
+        .build()
+        .unwrap();
+    let mut gone = Vec::new();
+    for (slug, codename) in MAPPED {
+        assert_eq!(
+            ppm_linux_codename(slug),
+            Some(*codename),
+            "mapping for {slug} changed"
+        );
+        if !serves(&client, codename).await {
+            gone.push(*codename);
+        }
+    }
+    assert!(
+        gone.is_empty(),
+        "P3M no longer serves these repos uvr maps: {gone:?} — installs there \
+         silently fall back to source. Drop the mapping or point it elsewhere."
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires network access to packagemanager.posit.co"]
+async fn the_portable_manylinux_repo_still_serves() {
+    // The fallback for every distro Posit doesn't publish for (#175). If this
+    // preview repo goes away, those users drop to source builds and should
+    // find out from CI rather than from a 45-second install.
+    let client = reqwest::Client::builder()
+        .user_agent("uvr-test")
+        .build()
+        .unwrap();
+    assert!(
+        serves(&client, "manylinux_2_28").await,
+        "the manylinux_2_28 repo is gone; unknown distros now build from source"
+    );
+}
+
+#[test]
+#[ignore = "requires network access to packagemanager.posit.co"]
+fn an_unmapped_distro_degrades_to_manylinux() {
+    // Host-dependent by design: on glibc >= 2.28 an unrecognized distro must
+    // reach the portable repo rather than giving up on binaries.
+    let resolved = ppm_linux_repo("arch");
+    match uvr_core::r_version::downloader::ppm_manylinux_repo() {
+        Some(repo) => assert_eq!(
+            resolved,
+            Some(repo),
+            "unmapped distro did not degrade to the portable repo"
+        ),
+        None => assert_eq!(
+            resolved, None,
+            "no portable repo is usable here, so binaries must be skipped"
+        ),
+    }
+}

--- a/crates/uvr/src/cli.rs
+++ b/crates/uvr/src/cli.rs
@@ -165,6 +165,11 @@ pub struct AddArgs {
     /// prompted for confirmation; non-TTY runs (CI) proceed without.
     #[arg(long)]
     pub install_system_deps: bool,
+
+    /// Build every package from source, ignoring pre-built binaries.
+    /// Also enabled by `UVR_NO_BINARY=1`.
+    #[arg(long)]
+    pub no_binary: bool,
 }
 
 // ────────────────────────────────────────────────────────────
@@ -224,6 +229,13 @@ pub struct SyncArgs {
     /// syncs benefit again.
     #[arg(long)]
     pub ignore_cache: bool,
+
+    /// Build every package from source, ignoring pre-built binaries.
+    /// Also enabled by `UVR_NO_BINARY=1`. Useful when a binary repo serves
+    /// a build that doesn't suit the host, or to opt out of the preview
+    /// portable `manylinux` repo.
+    #[arg(long)]
+    pub no_binary: bool,
 }
 
 // ────────────────────────────────────────────────────────────

--- a/crates/uvr/src/commands/doctor.rs
+++ b/crates/uvr/src/commands/doctor.rs
@@ -65,7 +65,7 @@ fn check_platform() {
                 ui::check(true, label, palette::success("available"), LABEL_W);
             } else {
                 let slug = uvr_core::r_version::downloader::detect_posit_distro_slug();
-                if let Some(codename) = uvr_core::registry::p3m::ppm_linux_codename(&slug) {
+                if let Some(codename) = uvr_core::registry::p3m::ppm_linux_repo(&slug) {
                     ui::check(
                         true,
                         label,

--- a/crates/uvr/src/commands/sync.rs
+++ b/crates/uvr/src/commands/sync.rs
@@ -735,6 +735,7 @@ async fn install_from_lockfile_with_r(
     let bioc_release = lockfile.r.bioc_version.as_deref();
 
     // ── Phase 1: check global package cache ──────────────────────────────
+    // (see `binary_packages_usable` below for the binary-entry gate)
     // Packages found in the cache are cloned into the library instantly
     // (CoW on APFS, recursive copy elsewhere) — no download or extraction.
     // This runs BEFORE the P3M index fetch so a fully-cached sync skips
@@ -749,6 +750,21 @@ async fn install_from_lockfile_with_r(
     let mut cache_misses: Vec<&LockedPackage> = Vec::new();
     let mut cache_hit_count = 0usize;
     let ignore_cache = cache_lookup_disabled();
+    // Whether a cached *binary* entry is usable here at all — see
+    // `package_cache::lookup_any`.
+    let force_source = source_installs_forced();
+    if force_source {
+        ui::bullet_dim("Building from source (--no-binary / UVR_NO_BINARY).");
+    }
+    let binary_flavor: Option<String> = if force_source {
+        None
+    } else {
+        binary_repo_flavor()
+    };
+    // A cached *binary* is not eligible when the user asked for source
+    // builds — serving one would silently defeat the flag.
+    let binary_cache_allowed =
+        !force_source && (binary_flavor.is_some() || !cfg!(target_os = "linux"));
     if ignore_cache {
         ui::bullet_dim("Ignoring package cache (--ignore-cache / UVR_IGNORE_CACHE).");
     }
@@ -763,8 +779,9 @@ async fn install_from_lockfile_with_r(
             &pkg.version,
             pkg.checksum.as_deref(),
             &r_minor_str,
-            true, // probe binary key first
+            binary_cache_allowed,
             libr_path.as_deref(),
+            binary_flavor.as_deref(),
         ) {
             match package_cache::clone_to_library(&cached_dir, &library, &pkg.name) {
                 Ok(()) => {
@@ -833,7 +850,10 @@ async fn install_from_lockfile_with_r(
 
         // (C) decision: any binary-capable custom source fully replaces P3M
         // for this sync. P3M is not consulted at all.
-        let p3m = if custom_binary.is_empty() {
+        let p3m = if force_source {
+            // Nothing to consult: every package takes the source path below.
+            None
+        } else if custom_binary.is_empty() {
             match detected_platform {
                 Ok(platform) => {
                     let slug = if matches!(platform, Platform::LinuxX86_64 | Platform::LinuxArm64) {
@@ -1088,6 +1108,7 @@ async fn install_from_lockfile_with_r(
                 &r_minor_str,
                 cache_key_binary,
                 libr_path.as_deref(),
+                binary_flavor.as_deref(),
             );
             let pkg_dir = library.join(&plan.pkg.name);
             // Recorded inside the entry so `uvr cache clean --r-version` can
@@ -1436,6 +1457,42 @@ fn r_minor(version: &str) -> String {
     } else {
         version.to_string()
     }
+}
+
+/// Whether pre-built binary packages are usable on this machine at all.
+///
+/// macOS and Windows binaries are not distro-specific, so they always are.
+/// On Linux it depends on whether Posit publishes for this distro: when no
+/// PPM codename matches, any binary sitting in the package cache is a
+/// leftover from a uvr that mis-identified the distro (#175). It links
+/// shared libraries this system does not have and fails at `library()`, so
+/// only source-built entries may be reused.
+///
+/// Cheap — reads `/etc/os-release`, no network.
+fn binary_repo_flavor() -> Option<String> {
+    match Platform::detect() {
+        Ok(Platform::LinuxX86_64) | Ok(Platform::LinuxArm64) => {
+            let slug = uvr_core::r_version::downloader::detect_posit_distro_slug();
+            uvr_core::registry::p3m::ppm_linux_repo(&slug).map(str::to_string)
+        }
+        // macOS/Windows binaries are not repo-specific, so they need no
+        // flavour in the cache key — and keeping it `None` there leaves those
+        // keys byte-identical to before this change.
+        _ => None,
+    }
+}
+
+/// `--no-binary` flag or `UVR_NO_BINARY=1` env var: build everything from
+/// source, ignoring pre-built binaries.
+///
+/// The escape hatch for a binary that doesn't suit the host — including
+/// opting out of the preview portable `manylinux` repo — without having to
+/// pin a different distro.
+fn source_installs_forced() -> bool {
+    matches!(
+        std::env::var("UVR_NO_BINARY").ok().as_deref(),
+        Some("1") | Some("true") | Some("yes") | Some("TRUE") | Some("YES")
+    )
 }
 
 /// `--ignore-cache` flag or `UVR_IGNORE_CACHE=1` env var (#93).

--- a/crates/uvr/src/main.rs
+++ b/crates/uvr/src/main.rs
@@ -92,6 +92,9 @@ async fn run() -> Result<()> {
             if args.install_system_deps {
                 std::env::set_var("UVR_INSTALL_SYSREQS", "1");
             }
+            if args.no_binary {
+                std::env::set_var("UVR_NO_BINARY", "1");
+            }
             commands::add::run(
                 args.packages,
                 args.dev,
@@ -118,6 +121,9 @@ async fn run() -> Result<()> {
             }
             if args.ignore_cache {
                 std::env::set_var("UVR_IGNORE_CACHE", "1");
+            }
+            if args.no_binary {
+                std::env::set_var("UVR_NO_BINARY", "1");
             }
             commands::sync::run(args.frozen, args.no_dev, args.jobs, args.library, timeout).await?;
         }


### PR DESCRIPTION
Fixes #175.

On Arch, `uvr add xml2` installs in ~2.7s and then `library(xml2)` fails on a missing `libxml2.so.2`. Reproduced and fixed; verified end-to-end on a real Arch box and in a clean `archlinux` container.

## What was wrong

uvr treated every unrecognized Linux as `ubuntu-2204` and installed P3M's jammy binaries. Those link the host distro's libraries by SONAME:

```
jammy binary wants:  libxml2.so.2
Arch ships:          libxml2.so.16      (present on this system: 0)
```

Not a missing-package problem — libxml2 *is* installed. No system state makes a jammy binary load there, which is why the sysreqs machinery can't help.

The fallback made sense when this slug picked an **R tarball**: being roughly right still gave you a working R. R now comes from portable manylinux/musllinux builds selected by libc and arch (`--distribution` is deprecated and ignored), so the slug's only remaining job is picking **package binaries** — where a wrong guess installs successfully and fails later, at `library()`.

## What it does now

An unrecognized distro reports itself and matches no per-distro repo. Rather than dropping to source, it degrades to P3M's portable **`manylinux_2_28`** repo, whose binaries vendor their own libraries (`libxml2-35ea8990.so.2.9.7` — the same trick Python wheels use):

| | before | after |
|---|---|---|
| `uvr doctor` | `available (Linux jammy)` | `available (Linux manylinux_2_28)` |
| `uvr add xml2` | 2.7s → **fails at `library()`** | 5.4s → **loads and parses** |
| vs source fallback | — | 5.4s binary vs 45s source |

Requires glibc ≥ 2.28. musl and older glibc still build from source.

## Also in here

**Missing P3M repos.** Cross-checked against the [setup dropdown](https://packagemanager.posit.co/client/#/repos/cran/setup): `resolute` (Ubuntu 26.04), `trixie` (Debian 13), `rhel10`, `opensuse156`. Users on those distros were silently compiling everything from source. Kept `focal`/`bullseye`/`opensuse154`/`opensuse155` — retired from the dropdown but still served, so EOL users don't lose binaries. (`rhel7`/`rhel8`/`sles156` in the dropdown 404 — they're labels aliasing to `centos7`/`centos8`/`opensuse156`, which uvr already mapped correctly.)

**`--no-binary` / `UVR_NO_BINARY=1`** on `add` and `sync` — build everything from source. There was no way to opt out of binaries before, and `manylinux_2_28` is a preview repo, so an escape hatch seemed prudent.

**Two supporting fixes, both required for the above to actually reach users.** Fixing detection alone left Arch broken: the global package cache re-served the stale jammy binary. So binary cache entries now record which repo they came from, and lookup refuses binary entries on hosts where binaries aren't usable at all. Without these the fix is inert for exactly the people who already hit the bug.

**One `/etc/os-release` parse.** The sysreqs and P3M detectors each had their own, disagreeing on whether `VERSION_ID` was required — which is why the sysreqs check silently no-ops on rolling releases, and why `sysreqs::tests::filter_missing_with_nonexistent_package` fails on Arch (it assumed every Linux has dpkg/rpm/apk). Both fixed.

## Testing

Two new CI jobs, because the existing matrix couldn't catch this class of bug:

- **`test-distros`** — arch and fedora (unmapped → must degrade to manylinux), debian trixie and rocky 10 (newly mapped). Each asserts the repo uvr selects, installs `xml2`, loads it, then repeats with `--no-binary`.
- **`test-p3m-repos`** — live check that every mapped repo still serves. Posit adds repos as distros ship and retires them at EOL; both directions fail silently today.

Worth calling out: **`SMOKE_PKG` could not have caught #175.** `jsonlite` links only `libR` and `libc`, so it loads whichever distro's binary you install. The new job uses `xml2` because it pulls an external `libxml2` — the actual failure mode. I left the existing job on `jsonlite`; it's testing the libR-patch path, which is a different thing.

Pre-flighted in a real `archlinux` container: `doctor` reports `manylinux_2_28`, `uvr add xml2` installs 3 binaries in 843ms, `uvr run` prints `distro-smoke-ok`. The musl build step is the one piece I couldn't exercise locally (no `musl-tools` on my machine) — it follows the existing `test-musl-arm64` cross-compile precedent and gets its first real run in CI.

451 tests pass; `cargo fmt --check` and `clippy -D warnings` clean.

## Note on scope

Four related changes in one PR. They're separable on paper, but the first three don't deliver anything alone — detection without cache-flavouring leaves affected users broken, and the repo additions are the same table. Happy to split if you'd rather review them independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
