### PR TITLE
fix(sysreqs): read SystemRequirements from the downloaded tarball

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ release page on GitHub. Issue numbers reference https://github.com/nbafrank/uvr/
 
 Pure tracking section — fixes and small features land here between tags.
 
+- System dependencies are resolved on distributions Posit's sysreqs API
+  doesn't cover (#207). `SystemRequirements` was only ever read from the
+  resolved repository's `PACKAGES` index, and CRAN's index doesn't publish
+  that field — so on Alpine every CRAN package reached the vendored local
+  rules with nothing to match, and `uvr sync --install-system-deps` went
+  straight into a source build that failed on the missing library (`terra`
+  → `gdal-config not found`, `units` → `libudunits2.so was not found`)
+  without printing a sysreqs warning either. The check now runs after the
+  tarballs are downloaded and reads `SystemRequirements` from each one's
+  DESCRIPTION, which is where the field is actually published.
 - System dependencies are resolved on RHEL and its rebuilds (#209). uvr asked
   both sysreqs catalogs under the raw `/etc/os-release` identity, which neither
   speaks: Posit's API answers `Unsupported system` for `rhel`/`8.10` but

--- a/crates/uvr-core/src/installer/binary_install.rs
+++ b/crates/uvr-core/src/installer/binary_install.rs
@@ -664,6 +664,12 @@ pub struct TarballMeta {
     /// True iff DESCRIPTION explicitly states `NeedsCompilation: no`.
     /// Absent means uvr can't prove the package is pure-R — treat conservatively as source.
     pub pure_r: bool,
+    /// Raw `SystemRequirements:` field, continuation lines joined.
+    ///
+    /// The tarball is the only place this is reliably published: CRAN's
+    /// `PACKAGES` index omits the field, so it never reaches the lockfile
+    /// and the sysreqs fallback has nothing to match (#207).
+    pub system_requirements: Option<String>,
 }
 
 /// Inspect a downloaded `.tar.gz` for both `Built:` and `NeedsCompilation` in
@@ -710,6 +716,12 @@ pub fn inspect_tarball(tarball_path: &Path, package_name: &str) -> Option<Tarbal
                 }
             }
         }
+        // `SystemRequirements` routinely wraps across lines (terra's spans
+        // two), so it needs the real DCF parser rather than the line-prefix
+        // scan above — a truncated value would silently lose rule matches.
+        meta.system_requirements = crate::dcf::parse_dcf_fields(&buf)
+            .remove("SystemRequirements")
+            .filter(|s| !s.trim().is_empty());
         return Some(meta);
     }
     None
@@ -727,6 +739,19 @@ pub fn detect_built_from_tarball(
     package_name: &str,
 ) -> Option<crate::registry::cran::BuiltInfo> {
     inspect_tarball(tarball_path, package_name).and_then(|m| m.built)
+}
+
+/// Read the `SystemRequirements:` field out of a downloaded tarball's
+/// DESCRIPTION.
+///
+/// The field never survives the trip through a `PACKAGES` index — CRAN's
+/// doesn't publish it — so the tarball uvr has just downloaded is the only
+/// authoritative source for the exact version being installed (#207).
+///
+/// Thin convenience wrapper around `inspect_tarball` for callers that only
+/// care about `SystemRequirements`.
+pub fn detect_sysreqs_from_tarball(tarball_path: &Path, package_name: &str) -> Option<String> {
+    inspect_tarball(tarball_path, package_name).and_then(|m| m.system_requirements)
 }
 
 /// Public entry-point for retroactively patching already-installed packages.
@@ -1037,6 +1062,59 @@ mod tests {
         let m = inspect_tarball(tarball.path(), "bin").unwrap();
         assert!(!m.pure_r);
         assert!(m.built.is_some());
+    }
+
+    #[test]
+    fn inspect_tarball_extracts_wrapped_system_requirements() {
+        // #207: terra's SystemRequirements wraps onto a second line, so the
+        // value has to come from the DCF parser — a line-prefix scan would
+        // truncate it at "PROJ (>=" and lose the proj/sqlite rule matches.
+        let tarball = write_tarball_with_description_for(
+            "terra",
+            "Package: terra\nVersion: 1.9-34\nNeedsCompilation: yes\n\
+             SystemRequirements: C++17, GDAL (>= 2.2.3), GEOS (>= 3.4.0), PROJ (>=\n\
+             \x204.9.3), TBB, sqlite3\n",
+        );
+        let m = inspect_tarball(tarball.path(), "terra").unwrap();
+        assert_eq!(
+            m.system_requirements.as_deref(),
+            Some("C++17, GDAL (>= 2.2.3), GEOS (>= 3.4.0), PROJ (>= 4.9.3), TBB, sqlite3")
+        );
+    }
+
+    #[test]
+    fn detect_sysreqs_from_tarball_reads_the_field() {
+        let tarball = write_tarball_with_description_for(
+            "units",
+            "Package: units\nVersion: 1.0-1\nSystemRequirements: udunits-2\n",
+        );
+        assert_eq!(
+            detect_sysreqs_from_tarball(tarball.path(), "units").as_deref(),
+            Some("udunits-2")
+        );
+        // A package declaring none stays None rather than Some("").
+        let plain = write_tarball_with_description_for("cli", "Package: cli\nVersion: 3.6.3\n");
+        assert!(detect_sysreqs_from_tarball(plain.path(), "cli").is_none());
+    }
+
+    #[test]
+    fn backfilled_sysreqs_resolve_to_alpine_packages() {
+        // The end of the #207 chain: the string read off the tarball is what
+        // the vendored rules turn into the apk names that were previously
+        // never installed.
+        let tarball = write_tarball_with_description_for(
+            "terra",
+            "Package: terra\nVersion: 1.9-34\n\
+             SystemRequirements: C++17, GDAL (>= 2.2.3), GEOS (>= 3.4.0), PROJ (>= 4.9.3), TBB, sqlite3\n",
+        );
+        let sys_reqs = detect_sysreqs_from_tarball(tarball.path(), "terra").unwrap();
+        let pkgs = crate::sysreqs_rules::resolve_local(&sys_reqs, "alpine", "3.24.1");
+        for expected in ["gdal-dev", "geos-dev", "proj-dev", "sqlite-dev"] {
+            assert!(
+                pkgs.iter().any(|p| p == expected),
+                "expected {expected}, got {pkgs:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/uvr/src/commands/sync.rs
+++ b/crates/uvr/src/commands/sync.rs
@@ -32,6 +32,23 @@ struct PkgPlan<'a> {
     is_binary: bool,
 }
 
+/// Read `SystemRequirements` out of the tarball just downloaded for `name`,
+/// if one was downloaded at all.
+///
+/// Packages served from the package cache have no tarball in this run and
+/// yield `None` — they are installed without compiling, so a build-time
+/// system library can't be what's missing for them.
+#[cfg(target_os = "linux")]
+fn tarball_sysreqs(
+    name: &str,
+    plans: &[PkgPlan<'_>],
+    results: &[uvr_core::installer::download::DownloadResult],
+) -> Option<String> {
+    let idx = plans.iter().position(|p| p.pkg.name == name)?;
+    let path = &results.get(idx)?.path;
+    uvr_core::installer::binary_install::detect_sysreqs_from_tarball(path, name)
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum InstallKind {
     /// Pre-built binary tarball with host-matching `Built:`. Fast-path extract.
@@ -512,167 +529,6 @@ async fn install_from_lockfile_with_r(
 
     let client = crate::commands::util::build_client()?;
 
-    // On Linux, check for missing system dependencies before installing.
-    #[cfg(target_os = "linux")]
-    {
-        use uvr_core::sysreqs;
-
-        if let Some(distro) = sysreqs::detect_linux_distro() {
-            let queries: Vec<sysreqs::PackageSysReqQuery> = to_install
-                .iter()
-                .map(|p| sysreqs::PackageSysReqQuery {
-                    name: p.name.clone(),
-                    system_requirements: p.system_requirements.clone(),
-                    bioc: matches!(p.source, uvr_core::lockfile::PackageSource::Bioconductor),
-                })
-                .collect();
-
-            if !queries.is_empty() {
-                let check = sysreqs::check_system_deps(&client, &queries, &distro).await;
-
-                // #30 follow-up: only fire the unsupported-distro warning
-                // when at least one package actually declares
-                // `SystemRequirements`. pat-s reported that on Alpine 3.23.x
-                // a binaries-only install of `cli/glue/rlang` (no sysreqs
-                // at all) still triggered the loud "System dependency check
-                // skipped" warning, which reads as a real problem when in
-                // fact nothing needed checking. Gate on the presence of
-                // sysreqs so the warning fires only when there's actually
-                // a check we couldn't perform.
-                let any_has_sysreqs = queries.iter().any(|q| {
-                    q.system_requirements
-                        .as_deref()
-                        .is_some_and(|s| !s.trim().is_empty())
-                });
-
-                if check.lookup_failed && check.missing.is_empty() && any_has_sysreqs {
-                    // The sysreqs API couldn't be reached/parsed for at least
-                    // one package and the local-rules fallback found nothing
-                    // missing (#148). Say the check was degraded rather than
-                    // silently implying it passed.
-                    eprintln!();
-                    ui::warn_block(
-                        "System dependency check degraded",
-                        vec![
-                            "The Posit sysreqs API could not be consulted (network or service issue); the vendored local rules were used instead.".to_string(),
-                            "Packages with system-library requirements may fail to compile from source if the local rules missed something.".to_string(),
-                        ],
-                    );
-                    eprintln!();
-                } else if check.unsupported_distro && check.missing.is_empty() && any_has_sysreqs {
-                    // PPM doesn't cover this distro AND the local fallback
-                    // found nothing (either no rule matched any of the
-                    // declared SystemRequirements, or the local rules are
-                    // out of date). Tell the user we skipped the check
-                    // rather than silently claiming everything is fine.
-                    eprintln!();
-                    ui::warn_block(
-                        &format!("System dependency check skipped on {distro}"),
-                        vec![
-                            "Posit's sysreqs catalog doesn't cover this distribution, and the local fallback had no applicable rules.".to_string(),
-                            "Packages with system-library requirements may fail to compile from source.".to_string(),
-                        ],
-                    );
-                    ui::hint(
-                        "Install build prerequisites manually (e.g. libxml2-dev, libcurl-dev, libssl-dev) if source builds fail.",
-                    );
-                    eprintln!();
-                } else if !check.missing.is_empty() {
-                    let missing = &check.missing;
-                    let all_pkgs: Vec<&str> = missing
-                        .values()
-                        .flat_map(|reqs| reqs.iter().map(|r| r.package.as_str()))
-                        .collect::<std::collections::BTreeSet<&str>>()
-                        .into_iter()
-                        .collect();
-
-                    eprintln!();
-                    // Structured warning with a loud `⚠ WARN` header and one
-                    // bullet per package → missing deps. The user's fix is
-                    // delivered as a proper hint below, not an extra warn line.
-                    let body: Vec<String> = missing
-                        .iter()
-                        .map(|(pkg_name, reqs)| {
-                            let names: Vec<&str> =
-                                reqs.iter().map(|r| r.package.as_str()).collect();
-                            format!("{pkg_name} needs: {}", names.join(", "))
-                        })
-                        .collect();
-                    ui::warn_block(
-                        &format!(
-                            "Missing system dependencies for {} package(s)",
-                            missing.len()
-                        ),
-                        body,
-                    );
-                    // Pick the platform's installer (returns None when sudo
-                    // is needed but missing — reviewer-flagged regression
-                    // in minimal containers). For the display hint, fall
-                    // back to a manual command shape so the user still has
-                    // an actionable line even when uvr can't run it.
-                    let installer = pick_sysreqs_installer(&all_pkgs);
-                    let install_cmd_display = match &installer {
-                        Some((prog, args)) => format!("{} {}", prog, args.join(" ")),
-                        None => {
-                            if which::which("apk").is_ok() {
-                                format!("apk add {}", all_pkgs.join(" "))
-                            } else if which::which("dnf").is_ok() {
-                                format!("dnf install -y {}", all_pkgs.join(" "))
-                            } else {
-                                format!("apt-get install -y {}", all_pkgs.join(" "))
-                            }
-                        }
-                    };
-
-                    let want_run = sysreqs_install_enabled();
-                    match (want_run, installer) {
-                        (true, None) => {
-                            ui::warn(
-                                "--install-system-deps requested, but `sudo` is not on PATH and uvr is not running as root.",
-                            );
-                            ui::hint(format!("Install manually: {install_cmd_display}"));
-                            ui::hint("Or run uvr as root in this container.");
-                        }
-                        (true, Some((install_program, install_args))) => {
-                            if confirm_sysreqs_install(&install_cmd_display)? {
-                                ui::info(format!("Running: {install_cmd_display}"));
-                                let status = std::process::Command::new(&install_program)
-                                    .args(&install_args)
-                                    .status()
-                                    .with_context(|| {
-                                        format!("Failed to spawn {install_program}")
-                                    })?;
-                                if !status.success() {
-                                    anyhow::bail!(
-                                        "System dependency install failed (exit {}). \
-                                         Re-run `{install_cmd_display}` manually or \
-                                         install the listed libraries before retrying `uvr sync`.",
-                                        status.code().unwrap_or(-1)
-                                    );
-                                }
-                                ui::success("System dependencies installed.");
-                            } else {
-                                ui::hint(format!("Install with: {install_cmd_display}"));
-                                ui::hint(
-                                    "Continuing — some packages may fail to compile without these.",
-                                );
-                            }
-                        }
-                        (false, _) => {
-                            ui::hint(format!("Install with: {install_cmd_display}"));
-                            ui::hint(
-                                "Or set --install-system-deps / UVR_INSTALL_SYSREQS=1 to let uvr run that for you.",
-                            );
-                            ui::hint(
-                                "Continuing — some packages may fail to compile without these.",
-                            );
-                        }
-                    }
-                    eprintln!();
-                }
-            }
-        }
-    }
     let cache_dir = uvr_core::env_vars::cache_dir_or_temp();
 
     // Use the R binary resolved at the top of install_from_lockfile.
@@ -957,7 +813,9 @@ async fn install_from_lockfile_with_r(
             })
             .collect();
 
-        let downloader = Downloader::new(client, cache_dir, jobs);
+        // Cloned rather than moved: the sysreqs check below still needs the
+        // client, and it now runs after the download phase (#207).
+        let downloader = Downloader::new(client.clone(), cache_dir, jobs);
         let results = downloader
             .download_all(&specs)
             .await
@@ -1037,6 +895,184 @@ async fn install_from_lockfile_with_r(
                 "  i  No binary repo for {} on R {}; compiling {} package(s) from source.",
                 host_info.distro_label, r_minor_str, runtime_source
             );
+        }
+
+        // Check for missing system dependencies: the tarballs are on disk
+        // now, and nothing has been compiled yet.
+        //
+        // Reading `SystemRequirements` from the downloaded tarball is what
+        // makes the check work at all on distributions Posit's sysreqs API
+        // doesn't cover (#207). The field never survives the trip through a
+        // `PACKAGES` index — CRAN's omits it — so `p.system_requirements`
+        // from the lockfile is `None` for every CRAN package, and the
+        // vendored local rules had nothing to match. The tarball is also
+        // authoritative for the exact version being installed, which an
+        // index-level lookup wouldn't be.
+        #[cfg(target_os = "linux")]
+        {
+            use uvr_core::sysreqs;
+
+            if let Some(distro) = sysreqs::detect_linux_distro() {
+                let queries: Vec<sysreqs::PackageSysReqQuery> = to_install
+                    .iter()
+                    .map(|p| sysreqs::PackageSysReqQuery {
+                        name: p.name.clone(),
+                        system_requirements: p
+                            .system_requirements
+                            .clone()
+                            .or_else(|| tarball_sysreqs(&p.name, &plans, &results)),
+                        bioc: matches!(p.source, uvr_core::lockfile::PackageSource::Bioconductor),
+                    })
+                    .collect();
+
+                if !queries.is_empty() {
+                    let check = sysreqs::check_system_deps(&client, &queries, &distro).await;
+
+                    // #30 follow-up: only fire the unsupported-distro warning
+                    // when at least one package actually declares
+                    // `SystemRequirements`. pat-s reported that on Alpine 3.23.x
+                    // a binaries-only install of `cli/glue/rlang` (no sysreqs
+                    // at all) still triggered the loud "System dependency check
+                    // skipped" warning, which reads as a real problem when in
+                    // fact nothing needed checking. Gate on the presence of
+                    // sysreqs so the warning fires only when there's actually
+                    // a check we couldn't perform.
+                    let any_has_sysreqs = queries.iter().any(|q| {
+                        q.system_requirements
+                            .as_deref()
+                            .is_some_and(|s| !s.trim().is_empty())
+                    });
+
+                    if check.lookup_failed && check.missing.is_empty() && any_has_sysreqs {
+                        // The sysreqs API couldn't be reached/parsed for at least
+                        // one package and the local-rules fallback found nothing
+                        // missing (#148). Say the check was degraded rather than
+                        // silently implying it passed.
+                        eprintln!();
+                        ui::warn_block(
+                            "System dependency check degraded",
+                            vec![
+                                "The Posit sysreqs API could not be consulted (network or service issue); the vendored local rules were used instead.".to_string(),
+                                "Packages with system-library requirements may fail to compile from source if the local rules missed something.".to_string(),
+                            ],
+                        );
+                        eprintln!();
+                    } else if check.unsupported_distro
+                        && check.missing.is_empty()
+                        && any_has_sysreqs
+                    {
+                        // PPM doesn't cover this distro AND the local fallback
+                        // found nothing (either no rule matched any of the
+                        // declared SystemRequirements, or the local rules are
+                        // out of date). Tell the user we skipped the check
+                        // rather than silently claiming everything is fine.
+                        eprintln!();
+                        ui::warn_block(
+                            &format!("System dependency check skipped on {distro}"),
+                            vec![
+                                "Posit's sysreqs catalog doesn't cover this distribution, and the local fallback had no applicable rules.".to_string(),
+                                "Packages with system-library requirements may fail to compile from source.".to_string(),
+                            ],
+                        );
+                        ui::hint(
+                            "Install build prerequisites manually (e.g. libxml2-dev, libcurl-dev, libssl-dev) if source builds fail.",
+                        );
+                        eprintln!();
+                    } else if !check.missing.is_empty() {
+                        let missing = &check.missing;
+                        let all_pkgs: Vec<&str> = missing
+                            .values()
+                            .flat_map(|reqs| reqs.iter().map(|r| r.package.as_str()))
+                            .collect::<std::collections::BTreeSet<&str>>()
+                            .into_iter()
+                            .collect();
+
+                        eprintln!();
+                        // Structured warning with a loud `⚠ WARN` header and one
+                        // bullet per package → missing deps. The user's fix is
+                        // delivered as a proper hint below, not an extra warn line.
+                        let body: Vec<String> = missing
+                            .iter()
+                            .map(|(pkg_name, reqs)| {
+                                let names: Vec<&str> =
+                                    reqs.iter().map(|r| r.package.as_str()).collect();
+                                format!("{pkg_name} needs: {}", names.join(", "))
+                            })
+                            .collect();
+                        ui::warn_block(
+                            &format!(
+                                "Missing system dependencies for {} package(s)",
+                                missing.len()
+                            ),
+                            body,
+                        );
+                        // Pick the platform's installer (returns None when sudo
+                        // is needed but missing — reviewer-flagged regression
+                        // in minimal containers). For the display hint, fall
+                        // back to a manual command shape so the user still has
+                        // an actionable line even when uvr can't run it.
+                        let installer = pick_sysreqs_installer(&all_pkgs);
+                        let install_cmd_display = match &installer {
+                            Some((prog, args)) => format!("{} {}", prog, args.join(" ")),
+                            None => {
+                                if which::which("apk").is_ok() {
+                                    format!("apk add {}", all_pkgs.join(" "))
+                                } else if which::which("dnf").is_ok() {
+                                    format!("dnf install -y {}", all_pkgs.join(" "))
+                                } else {
+                                    format!("apt-get install -y {}", all_pkgs.join(" "))
+                                }
+                            }
+                        };
+
+                        let want_run = sysreqs_install_enabled();
+                        match (want_run, installer) {
+                            (true, None) => {
+                                ui::warn(
+                                    "--install-system-deps requested, but `sudo` is not on PATH and uvr is not running as root.",
+                                );
+                                ui::hint(format!("Install manually: {install_cmd_display}"));
+                                ui::hint("Or run uvr as root in this container.");
+                            }
+                            (true, Some((install_program, install_args))) => {
+                                if confirm_sysreqs_install(&install_cmd_display)? {
+                                    ui::info(format!("Running: {install_cmd_display}"));
+                                    let status = std::process::Command::new(&install_program)
+                                        .args(&install_args)
+                                        .status()
+                                        .with_context(|| {
+                                            format!("Failed to spawn {install_program}")
+                                        })?;
+                                    if !status.success() {
+                                        anyhow::bail!(
+                                            "System dependency install failed (exit {}). \
+                                             Re-run `{install_cmd_display}` manually or \
+                                             install the listed libraries before retrying `uvr sync`.",
+                                            status.code().unwrap_or(-1)
+                                        );
+                                    }
+                                    ui::success("System dependencies installed.");
+                                } else {
+                                    ui::hint(format!("Install with: {install_cmd_display}"));
+                                    ui::hint(
+                                        "Continuing — some packages may fail to compile without these.",
+                                    );
+                                }
+                            }
+                            (false, _) => {
+                                ui::hint(format!("Install with: {install_cmd_display}"));
+                                ui::hint(
+                                    "Or set --install-system-deps / UVR_INSTALL_SYSREQS=1 to let uvr run that for you.",
+                                );
+                                ui::hint(
+                                    "Continuing — some packages may fail to compile without these.",
+                                );
+                            }
+                        }
+                        eprintln!();
+                    }
+                }
+            }
         }
 
         let installer = RCmdInstall::new(r_binary.to_string_lossy());


### PR DESCRIPTION
Fixes #207.

## Problem

`system_requirements` is only ever populated from the `PACKAGES` index of the repository a package resolved from (`registry/cran.rs:650`), and CRAN's `src/contrib/PACKAGES` carries no `SystemRequirements:` field.
Every CRAN-sourced package therefore reaches `check_pkg_local()` as `None`, where it early-returns before touching a single rule.

On a distribution Posit's sysreqs API doesn't cover this disables the whole #30 fallback: nothing is resolved, nothing is installed, and the "System dependency check skipped" warning stays silent too, because it is gated on some package declaring sysreqs (`sync.rs:542`) — which none do, for the same reason.
The visible result on Alpine is `uvr sync --install-system-deps` walking straight into a source build that dies on `gdal-config not found` / `libudunits2.so was not found`, with no sysreqs output at all.

## Fix

Read the field where it is actually published: the package's own DESCRIPTION, inside the tarball uvr has just downloaded.

- The sysreqs check moves from before the download phase to just after it, still before anything is compiled or extracted.
- `inspect_tarball` — which already reads `Built:` and `NeedsCompilation:` out of the downloaded tarball for install-time classification — now also returns `SystemRequirements`, via the DCF parser so wrapped values survive (terra's spans two lines; a line-prefix scan would truncate it at `PROJ (>=` and lose the proj/sqlite matches).
- The lockfile value still wins when a repository does publish the field; the tarball is consulted only as the fallback.

No extra network access and no second download: the tarballs are already on disk at that point, and reading a DESCRIPTION out of one is the same scan `inspect_tarball` was doing anyway.
Reading the tarball also makes the answer authoritative for the exact locked version, which an index- or API-level lookup by package name wouldn't be.

Two consequences of the move worth calling out explicitly:

- Packages served from the package cache have no tarball in this run, so they contribute no `SystemRequirements` beyond what the lockfile carries. They're installed without compiling, so a missing build-time header can't be what breaks them.
- If every package in a sync is a cache hit, `plans` is empty and the check doesn't run at all. Same reasoning: nothing is downloaded, nothing is built.

`Downloader::new` now takes a cloned client, since the check that follows still needs one.

## Verification

Alpine 3.24.1 / R 4.6, patched binary built for musl, project with `Imports: terra, units`:

```
> Installing 3 package(s): 3 from source
  i  No binary repo for Alpine Linux 3.24.1 on R 4.6; compiling 3 package(s) from source.

 ! WARN  Missing system dependencies for 2 package(s)
  units needs: udunits-dev
  terra needs: gdal-dev, gdal-tools, geos-dev, proj-dev, sqlite-dev
> Running: apk add gdal-dev gdal-tools geos-dev proj-dev sqlite-dev udunits-dev
v System dependencies installed.

v Installed 3 package(s) in 5m14s
```

`apk info -e` afterwards: `gdal-dev`, `geos-dev`, `proj-dev`, `sqlite-dev`, `udunits-dev` all present, and `terra`, `units`, `Rcpp` in the library.

Before the patch the same project printed no sysreqs line at all and stopped at `configure: error: gdal-config not found or not executable.`, with `gdal-dev` still absent afterwards.

`cargo test --workspace` green, `cargo clippy --workspace --all-targets` clean, `cargo fmt --check` clean.
Three tests added: the wrapped-value parse, the `detect_sysreqs_from_tarball` wrapper (including "declares none" staying `None` rather than `Some("")`), and one asserting the end of the chain — that the string read off a terra tarball resolves to `gdal-dev`/`geos-dev`/`proj-dev`/`sqlite-dev` on `alpine-3.24.1`.
