### PR TITLE
fix(sysreqs): ask the sysreqs catalogs under the names they use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,11 @@ Pure tracking section — fixes and small features land here between tags.
   API and nothing from the local fallback either. The `(ID, VERSION_ID)` pair
   is now mapped onto the catalogs' vocabulary — `rhel` → `redhat`,
   `rocky`/`almalinux` → `rockylinux`, `sles` → `sle`, openSUSE variants →
-  `opensuse` — with the RHEL family truncated to its major release.
+  `opensuse` — with the RHEL family truncated to its major release. Oracle
+  Linux (`ol`) joins them: it is a RHEL rebuild that neither catalog knew.
+  Coverage still varies behind the mapping — the API serves `rockylinux` 9/10
+  but not 8, and rejects `fedora` and `alpine` outright — so the local rules
+  remain the backstop for those.
 
 ## v0.4.4 (2026-07-31)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ release page on GitHub. Issue numbers reference https://github.com/nbafrank/uvr/
 
 Pure tracking section — fixes and small features land here between tags.
 
+- System dependencies are resolved on RHEL and its rebuilds (#209). uvr asked
+  both sysreqs catalogs under the raw `/etc/os-release` identity, which neither
+  speaks: Posit's API answers `Unsupported system` for `rhel`/`8.10` but
+  answers normally for `redhat`/`8`, and every vendored rule is written as
+  `redhat` with `versions: ["8"]`. RHEL hosts therefore got nothing from the
+  API and nothing from the local fallback either. The `(ID, VERSION_ID)` pair
+  is now mapped onto the catalogs' vocabulary — `rhel` → `redhat`,
+  `rocky`/`almalinux` → `rockylinux`, `sles` → `sle`, openSUSE variants →
+  `opensuse` — with the RHEL family truncated to its major release.
+
 ## v0.4.4 (2026-07-31)
 
 The biggest release yet, driven by a wave of new users: GitLab-hosted

--- a/crates/uvr-core/src/sysreqs.rs
+++ b/crates/uvr-core/src/sysreqs.rs
@@ -13,8 +13,9 @@ pub struct SysReq {
     pub package: String,
 }
 
-/// Detect the Linux distribution from `/etc/os-release`.
-/// Returns `(id, version_id)` like `("ubuntu", "22.04")`.
+/// Detect the Linux distribution from `/etc/os-release`, normalized onto the
+/// vocabulary the sysreqs catalogs use. Returns `id-version` like
+/// `"ubuntu-22.04"` or `"redhat-8"`.
 pub fn detect_linux_distro() -> Option<String> {
     let os = crate::os_release::detect()?;
     // Both halves are required here, unlike P3M slug detection: the sysreqs
@@ -25,7 +26,45 @@ pub fn detect_linux_distro() -> Option<String> {
     if os.id.is_empty() || os.version_id.is_empty() {
         return None;
     }
-    Some(format!("{}-{}", os.id, os.version_id))
+    let (distribution, release) = normalize_distro(&os.id, &os.version_id);
+    Some(format!("{distribution}-{release}"))
+}
+
+/// Map an `/etc/os-release` `(ID, VERSION_ID)` pair onto the names Posit's
+/// sysreqs API and the vendored `r-system-requirements` rules are written in.
+///
+/// Both catalogs speak the Posit vocabulary, not the os-release one, and both
+/// reject the raw values RHEL reports (#209):
+///
+/// ```text
+/// ?distribution=rhel&release=8.10  -> {"code":14,"error":"Unsupported system"}
+/// ?distribution=redhat&release=8   -> {"requirements":[{"name":"xml2", ...}]}
+/// ```
+///
+/// The vendored rules agree — every RHEL entry is written as `redhat` with
+/// `versions: ["8"]`, so a `rhel` / `8.10` host matched no rule either and the
+/// local fallback had nothing to offer once the API had bowed out. RHEL hosts
+/// therefore got no system dependencies from either source.
+///
+/// Only the RHEL family is truncated to its major: Ubuntu is keyed `22.04`,
+/// openSUSE `15.6` and SLE `12.3` in both catalogs.
+pub(crate) fn normalize_distro(id: &str, version_id: &str) -> (String, String) {
+    let distribution = match id {
+        "rhel" => "redhat",
+        // The RHEL rebuilds share Rocky's entries — same repos (crb /
+        // powertools), same package names.
+        "rocky" | "almalinux" => "rockylinux",
+        "sles" => "sle",
+        "opensuse-leap" | "opensuse-tumbleweed" => "opensuse",
+        other => other,
+    };
+    let release = match distribution {
+        "redhat" | "rockylinux" | "centos" | "fedora" => {
+            version_id.split('.').next().unwrap_or(version_id)
+        }
+        _ => version_id,
+    };
+    (distribution.to_string(), release.to_string())
 }
 
 /// Response from the Posit Package Manager sysreqs API.
@@ -330,6 +369,71 @@ mod tests {
         let check = check_system_deps(&client, &queries, "ubuntu-22.04").await;
         assert!(!check.lookup_failed, "no API contact → no failed lookups");
         assert!(!check.unsupported_distro);
+    }
+
+    #[test]
+    fn rhel_normalizes_to_the_posit_vocabulary() {
+        // #209: UBI/RHEL report ID="rhel", VERSION_ID="8.10". Posit's API
+        // answers only for redhat/8, and every vendored rule is written as
+        // `redhat` with versions ["8"] — so the raw pair matched neither.
+        assert_eq!(
+            normalize_distro("rhel", "8.10"),
+            ("redhat".to_string(), "8".to_string())
+        );
+        assert_eq!(
+            normalize_distro("rocky", "9.3"),
+            ("rockylinux".to_string(), "9".to_string())
+        );
+        assert_eq!(
+            normalize_distro("almalinux", "10.0"),
+            ("rockylinux".to_string(), "10".to_string())
+        );
+        assert_eq!(
+            normalize_distro("sles", "12.3"),
+            ("sle".to_string(), "12.3".to_string())
+        );
+    }
+
+    #[test]
+    fn non_rhel_distros_keep_their_full_version() {
+        // Ubuntu is keyed "22.04" and openSUSE "15.6" in both catalogs;
+        // truncating either to a major would match nothing.
+        assert_eq!(
+            normalize_distro("ubuntu", "22.04"),
+            ("ubuntu".to_string(), "22.04".to_string())
+        );
+        assert_eq!(
+            normalize_distro("opensuse-leap", "15.6"),
+            ("opensuse".to_string(), "15.6".to_string())
+        );
+        assert_eq!(
+            normalize_distro("debian", "12"),
+            ("debian".to_string(), "12".to_string())
+        );
+        // Alpine keeps its patch version; `resolve_local` truncates it to
+        // major.minor when matching rules (#30).
+        assert_eq!(
+            normalize_distro("alpine", "3.24.1"),
+            ("alpine".to_string(), "3.24.1".to_string())
+        );
+    }
+
+    #[test]
+    fn normalized_rhel_resolves_against_the_local_rules() {
+        // The other half of #209: with the normalized pair the vendored rules
+        // finally match, so the local fallback works even when the API can't
+        // be reached.
+        let (distribution, release) = normalize_distro("rhel", "8.10");
+        let pkgs = sysreqs_rules::resolve_local("libxml2 (>= 2.6.3)", &distribution, &release);
+        assert!(
+            pkgs.iter().any(|p| p == "libxml2-devel"),
+            "expected libxml2-devel for rhel-8.10, got {pkgs:?}"
+        );
+        let gdal = sysreqs_rules::resolve_local("GDAL (>= 2.2.3)", &distribution, &release);
+        assert!(
+            gdal.iter().any(|p| p == "gdal-devel"),
+            "expected gdal-devel for rhel-8.10, got {gdal:?}"
+        );
     }
 
     #[test]

--- a/crates/uvr-core/src/sysreqs.rs
+++ b/crates/uvr-core/src/sysreqs.rs
@@ -20,9 +20,13 @@ pub fn detect_linux_distro() -> Option<String> {
     let os = crate::os_release::detect()?;
     // Both halves are required here, unlike P3M slug detection: the sysreqs
     // API and the vendored rules are keyed by `id-version`, and there is no
-    // sensible query for a rolling release that publishes no version. Arch
-    // and CachyOS land here and the caller skips the check — the safe
-    // direction to fail, since a wrong answer only produces a wrong hint.
+    // sensible query for a distro that publishes no version at all — the
+    // caller skips the check, the safe direction to fail, since a wrong
+    // answer only produces a wrong hint. Note this is a narrower net than it
+    // looks: rolling releases do not necessarily land here. `archlinux`
+    // containers report a snapshot `VERSION_ID` (e.g. `20260726.0.562117`)
+    // and so reach the catalogs as `arch`/<snapshot>, which simply matches
+    // nothing (reported by @gdevenyi on #209).
     if os.id.is_empty() || os.version_id.is_empty() {
         return None;
     }
@@ -48,9 +52,23 @@ pub fn detect_linux_distro() -> Option<String> {
 ///
 /// Only the RHEL family is truncated to its major: Ubuntu is keyed `22.04`,
 /// openSUSE `15.6` and SLE `12.3` in both catalogs.
+///
+/// Mapping onto a name a catalog knows is not the same as full API coverage —
+/// the two catalogs disagree about which distros they serve, and the local
+/// rules remain the backstop (measurements by @gdevenyi on #209):
+///
+/// - `rockylinux` is served by the API for 9 and 10 but not 8, so Rocky/Alma 8
+///   still resolves via the local rules and still prints the degraded-check
+///   warning. That is the pre-existing behaviour, not a regression from this
+///   mapping.
+/// - `fedora` and `alpine` are rejected by the API at every release; they are
+///   local-rules-only by design.
 pub(crate) fn normalize_distro(id: &str, version_id: &str) -> (String, String) {
     let distribution = match id {
-        "rhel" => "redhat",
+        // Oracle Linux is a straight RHEL rebuild and reports `ID="ol"`, which
+        // neither catalog knows (#209). Note this only routes its *sysreqs*;
+        // P3M binary selection keys off a separate slug in `downloader.rs`.
+        "rhel" | "ol" => "redhat",
         // The RHEL rebuilds share Rocky's entries — same repos (crb /
         // powertools), same package names.
         "rocky" | "almalinux" => "rockylinux",
@@ -391,6 +409,41 @@ mod tests {
         assert_eq!(
             normalize_distro("sles", "12.3"),
             ("sle".to_string(), "12.3".to_string())
+        );
+    }
+
+    #[test]
+    fn oracle_linux_is_treated_as_a_rhel_rebuild() {
+        // #209, from @gdevenyi's image sweep: `oraclelinux:8` reports
+        // ID="ol", VERSION_ID="8.10" — unknown to both catalogs, so OL
+        // resolved nothing at all.
+        assert_eq!(
+            normalize_distro("ol", "8.10"),
+            ("redhat".to_string(), "8".to_string())
+        );
+        let (distribution, release) = normalize_distro("ol", "8.10");
+        let pkgs = sysreqs_rules::resolve_local("libxml2 (>= 2.6.3)", &distribution, &release);
+        assert!(
+            pkgs.iter().any(|p| p == "libxml2-devel"),
+            "expected libxml2-devel for ol-8.10, got {pkgs:?}"
+        );
+    }
+
+    #[test]
+    fn centos_keeps_its_own_identity() {
+        // CentOS has its own rule entries (epel / powertools pre-installs) and
+        // the API rejects it at every release, so it stays local-rules-only
+        // rather than being folded into `redhat` here. Mapping Stream >= 9 to
+        // `redhat` would upgrade it to API answers, but that is a behaviour
+        // change with a 7/8 boundary to argue, not part of this fix.
+        assert_eq!(
+            normalize_distro("centos", "9"),
+            ("centos".to_string(), "9".to_string())
+        );
+        let pkgs = sysreqs_rules::resolve_local("libxml2 (>= 2.6.3)", "centos", "9");
+        assert!(
+            pkgs.iter().any(|p| p == "libxml2-devel"),
+            "expected the version-less centos rules to still resolve, got {pkgs:?}"
         );
     }
 


### PR DESCRIPTION
Fixes #209.

## Problem

`detect_linux_distro()` hands the raw `/etc/os-release` identity to both sysreqs catalogs, and neither is keyed that way on RHEL.
UBI 8 reports `ID="rhel"`, `VERSION_ID="8.10"`; Posit's API answers only for `redhat`/`8`, and every vendored RHEL rule is written as `"distribution": "redhat"` with `"versions": ["8"]`.

So a RHEL host gets `Unsupported system` from the API, then falls through to a local rule table where neither half matches (`rhel` ≠ `redhat`, and `truncate_to_minor` only strips a third component so `8.10` never becomes `8`).
Both sources come back empty and the user sees:

```
 ! WARN  System dependency check skipped on rhel-8.10
  Posit's sysreqs catalog doesn't cover this distribution, and the local fallback had no applicable rules.
```

Verified against the live API:

```
?pkgname=xml2&distribution=rhel&release=8.10   -> {"code":14,"error":"Unsupported system","payload":null}
?pkgname=xml2&distribution=redhat&release=8    -> {"requirements":[{"name":"xml2","requirements":{"packages":["libxml2-devel"], ...}}]}
```

## Fix

Map the pair onto the vocabulary both catalogs are written in, once, before either is consulted:

- `rhel` → `redhat`
- `rocky` / `almalinux` → `rockylinux` (same repos, same package names as Rocky's entries)
- `sles` → `sle`, `opensuse-leap` / `opensuse-tumbleweed` → `opensuse`
- RHEL family only: version truncated to its major release

Everything else passes through untouched. The truncation is deliberately family-scoped — Ubuntu is keyed `22.04`, openSUSE `15.6` and SLE `12.3` in both catalogs, so a blanket major-truncation would break them.

Doing this in `detect_linux_distro()` fixes both paths at once: RHEL now gets the authoritative API answer rather than only a local-rules approximation, and the local fallback works too when the API is unreachable.

One visible side effect: warnings that name the distro now say `redhat-8` rather than `rhel-8.10`.

## Verification

`cargo test --workspace` green, `clippy --all-targets` clean, `fmt --check` clean.
Four tests added: the RHEL-family mapping, the non-RHEL pass-through (Ubuntu/openSUSE/Debian/Alpine keep their full version), and one end-of-chain check that the normalized pair resolves `libxml2` → `libxml2-devel` and `GDAL` → `gdal-devel` against the vendored rules.

Independent of #207, though that one is what made this visible: with no `SystemRequirements` reaching the resolver, the local rules had nothing to match anyway and the naming gap never surfaced.
