### PR TITLE
ci: run the full test suite natively in every supported distro

### DIFF
--- a/.github/workflows/distro-suite.yml
+++ b/.github/workflows/distro-suite.yml
@@ -1,0 +1,161 @@
+name: Distro suite
+
+# The full test suite, compiled and run natively inside every Linux
+# distribution uvr supports.
+#
+# Why this exists: uvr maps /etc/os-release onto three third-party
+# vocabularies (portable-R target, P3M binary repo, sysreqs catalog) and the
+# names differ per axis. #175 and #209 were both "we asked under a name that
+# side doesn't use", and neither was reachable from a test running on
+# ubuntu-latest. The only way to know what a distro reports is to ask it.
+#
+# The matrix is generated from crates/uvr-core/tests/distro_matrix.json —
+# adding a distro means adding an entry there, not editing this file.
+
+on:
+  schedule:
+    # Nightly, after the catalogs' business hours. The full matrix is too slow
+    # to gate every PR and its failures are often upstream drift rather than
+    # anything a PR did.
+    - cron: "0 5 * * *"
+  workflow_dispatch:
+    inputs:
+      keys:
+        description: 'Space-separated distro keys, or "all" / "pr"'
+        default: "all"
+        type: string
+  pull_request:
+    # On PRs, only when something that could change distro identification moves.
+    paths:
+      - "crates/uvr-core/src/sysreqs.rs"
+      - "crates/uvr-core/src/sysreqs_rules.rs"
+      - "crates/uvr-core/src/os_release.rs"
+      - "crates/uvr-core/src/registry/p3m.rs"
+      - "crates/uvr-core/src/r_version/downloader.rs"
+      - "crates/uvr-core/vendor/r-system-requirements/**"
+      - "crates/uvr-core/tests/distro_matrix.json"
+      - "ci/distro-suite.sh"
+      - ".github/workflows/distro-suite.yml"
+
+concurrency:
+  group: distro-suite-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  # One R version here, not the two the main CI matrix uses: this job's subject
+  # is the distro, and the R-version axis is already covered on ubuntu/macOS/
+  # Windows by ci.yml.
+  R_VERSIONS: "4.5.1"
+  SMOKE_PKG: xml2
+
+jobs:
+  # Which images to run: the `pr` subset on pull requests (one per package
+  # manager family plus musl), everything on a schedule, and whatever was asked
+  # for on a manual dispatch.
+  select:
+    name: Select distros
+    runs-on: ubuntu-latest
+    outputs:
+      entries: ${{ steps.pick.outputs.entries }}
+      count: ${{ steps.pick.outputs.count }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: pick
+        run: |
+          set -euo pipefail
+          matrix=crates/uvr-core/tests/distro_matrix.json
+          want='${{ github.event_name == 'pull_request' && 'pr' || inputs.keys || 'all' }}'
+          case "$want" in
+            all) sel="$(jq -c '[.distros[]]' "$matrix")" ;;
+            pr)  sel="$(jq -c '[.distros[] | select(.lane == "pr")]' "$matrix")" ;;
+            *)   sel="$(jq -c --arg k "$want" '[.distros[] | select(.key as $x | ($k | split(" ")) | index($x))]' "$matrix")" ;;
+          esac
+          echo "entries=$sel" >> "$GITHUB_OUTPUT"
+          echo "count=$(jq 'length' <<<"$sel")" >> "$GITHUB_OUTPUT"
+          jq -r '.[].key' <<<"$sel" | tr '\n' ' '
+
+  suite:
+    name: ${{ matrix.entry.key }}
+    needs: select
+    if: needs.select.outputs.count != '0'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    strategy:
+      # Every distro is an independent question; one answer must not suppress
+      # the other 28.
+      fail-fast: false
+      max-parallel: 12
+      matrix:
+        entry: ${{ fromJSON(needs.select.outputs.entries) }}
+    steps:
+      - uses: actions/checkout@v4
+
+      # `docker run` rather than a `container:` job: actions/checkout runs a
+      # node binary that needs a glibc the musl and minimal images don't have.
+      # Checking out on the host and mounting the tree in gives one shape that
+      # works for all 29 images.
+      - name: Full suite in ${{ matrix.entry.image }}
+        run: |
+          docker run --rm \
+            -v "$PWD:/work" -w /work \
+            -e "R_VERSIONS=${R_VERSIONS}" \
+            -e "SMOKE_PKG=${SMOKE_PKG}" \
+            "${{ matrix.entry.image }}" \
+            sh ci/distro-suite.sh
+
+      # The identity the suite ran under must be the identity the matrix
+      # claims. Cheap, and it is the assertion that keeps the offline
+      # conformance tests honest — a fixture nobody re-checks is how #209
+      # survived.
+      - name: Identity matches the matrix entry
+        run: |
+          set -euo pipefail
+          docker run --rm --entrypoint "" "${{ matrix.entry.image }}" \
+            sh -c 'grep -E "^(ID|VERSION_ID)=" /etc/os-release' > got.env
+          got_id=$(sed -n 's/^ID=//p' got.env | tail -1 | tr -d '"')
+          got_ver=$(sed -n 's/^VERSION_ID=//p' got.env | tail -1 | tr -d '"')
+          want_id='${{ matrix.entry.os_release.id }}'
+          want_ver='${{ matrix.entry.os_release.version_id }}'
+          [ "$got_id" = "$want_id" ] || {
+            echo "::error::${{ matrix.entry.key }}: image reports ID=$got_id, matrix says $want_id"
+            exit 1
+          }
+          # "*" = rolling release, version deliberately not asserted.
+          if [ "$want_ver" != "*" ] && [ "$got_ver" != "$want_ver" ]; then
+            echo "::error::${{ matrix.entry.key }}: image reports VERSION_ID=$got_ver, matrix says $want_ver — recapture with ci/capture-os-release.sh"
+            exit 1
+          fi
+
+  # Upstream images drift on their own schedule — rockylinux:9 was 9.3 and is
+  # now 9.8. That is a maintenance ticket, not a broken build, so the nightly
+  # reports it instead of turning the tree red.
+  report-drift:
+    name: Report matrix drift
+    needs: [select, suite]
+    if: failure() && github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Open or update the drift issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          title="Distro suite failing on the nightly matrix"
+          body="The nightly distro suite failed: $RUN_URL
+
+          If the failure is an identity mismatch, an upstream image moved and the
+          matrix needs recapturing:
+
+              ci/capture-os-release.sh <key>
+
+          If it is a suite failure, that distro is genuinely broken for users."
+          existing=$(gh issue list --state open --search "$title in:title" --json number --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "$body"
+          else
+            gh issue create --title "$title" --body "$body"
+          fi

--- a/.github/workflows/distro-suite.yml
+++ b/.github/workflows/distro-suite.yml
@@ -119,10 +119,6 @@ jobs:
     if: needs.select.outputs.count != '0'
     runs-on: ubuntu-latest
     timeout-minutes: 45
-    # Entries carrying `known_failure` reproduce an open issue. They still run
-    # and still show what they found — they just don't block, until the issue
-    # they name is fixed and the field comes off.
-    continue-on-error: ${{ matrix.entry.known_failure != '' }}
     strategy:
       # Every distro is an independent question; one answer must not suppress
       # the other 28.

--- a/.github/workflows/distro-suite.yml
+++ b/.github/workflows/distro-suite.yml
@@ -119,6 +119,10 @@ jobs:
     if: needs.select.outputs.count != '0'
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    # Entries carrying `known_failure` reproduce an open issue. They still run
+    # and still show what they found — they just don't block, until the issue
+    # they name is fixed and the field comes off.
+    continue-on-error: ${{ matrix.entry.known_failure != '' }}
     strategy:
       # Every distro is an independent question; one answer must not suppress
       # the other 28.

--- a/.github/workflows/distro-suite.yml
+++ b/.github/workflows/distro-suite.yml
@@ -49,7 +49,11 @@ env:
   # is the distro, and the R-version axis is already covered on ubuntu/macOS/
   # Windows by ci.yml.
   R_VERSIONS: "4.5.1"
-  SMOKE_PKG: xml2
+  # The binary stage tests repo *selection*, so it needs a package P3M builds
+  # for every repo; the sysreqs stage tests devel-package resolution, so it
+  # needs one with an external system library. See ci/distro-suite.sh.
+  BINARY_PKG: jsonlite
+  SYSREQS_PKG: xml2
 
 jobs:
   # Which images to run: the `pr` subset on pull requests (one per package
@@ -162,12 +166,20 @@ jobs:
         # there and let the earlier stages carry them.
         env:
           SKIP_STAGES: ${{ !matrix.entry.sysreqs.api && !matrix.entry.sysreqs.local && 'sysreqs' || '' }}
+          # Entries the matrix records as unsupported assert the refusal rather
+          # than skipping the stage — see `expect_fail` in ci/distro-suite.sh.
+          # Absent `expect` yields empty strings, which disables it.
+          EXPECT_FAIL_STAGE: ${{ matrix.entry.expect.stage }}
+          EXPECT_FAIL_MESSAGE: ${{ matrix.entry.expect.message }}
         run: |
           docker run --rm \
             -v "$PWD:/work" -w /work \
             -e "R_VERSIONS=${R_VERSIONS}" \
-            -e "SMOKE_PKG=${SMOKE_PKG}" \
+            -e "BINARY_PKG=${BINARY_PKG}" \
+            -e "SYSREQS_PKG=${SYSREQS_PKG}" \
             -e "SKIP_STAGES=${SKIP_STAGES}" \
+            -e "EXPECT_FAIL_STAGE=${EXPECT_FAIL_STAGE}" \
+            -e "EXPECT_FAIL_MESSAGE=${EXPECT_FAIL_MESSAGE}" \
             "${{ matrix.entry.image }}" \
             sh ci/distro-suite.sh
 

--- a/.github/workflows/distro-suite.yml
+++ b/.github/workflows/distro-suite.yml
@@ -99,11 +99,17 @@ jobs:
             target
           key: distro-suite-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: distro-suite-cargo-
+      # The gnu build goes through the same script the release workflow uses,
+      # so the matrix exercises the artifact users actually receive — glibc
+      # floor and all. Building it any other way here would test a binary that
+      # never ships, which is the mistake this whole workflow exists to catch.
+      # musl needs no floor: it is statically linked by construction.
       - name: Build
         run: |
           set -euxo pipefail
+          sh ci/build-linux-gnu.sh x86_64-unknown-linux-gnu
+          cargo build --release --target x86_64-unknown-linux-musl --bin uvr
           for t in x86_64-unknown-linux-gnu x86_64-unknown-linux-musl; do
-            cargo build --release --target "$t" --bin uvr
             mkdir -p "dist/uvr-$t"
             cp "target/$t/release/uvr" "dist/uvr-$t/uvr"
           done

--- a/.github/workflows/distro-suite.yml
+++ b/.github/workflows/distro-suite.yml
@@ -64,10 +64,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - id: pick
+        # Through the environment rather than interpolated into the script:
+        # `inputs.keys` is free text supplied at dispatch time, and pasting it
+        # between quotes in a shell line lets it close the quote and run the
+        # rest.
+        env:
+          WANT: ${{ github.event_name == 'pull_request' && 'pr' || inputs.keys || 'all' }}
         run: |
           set -euo pipefail
           matrix=crates/uvr-core/tests/distro_matrix.json
-          want='${{ github.event_name == 'pull_request' && 'pr' || inputs.keys || 'all' }}'
+          want="$WANT"
           case "$want" in
             all) sel="$(jq -c '[.distros[]]' "$matrix")" ;;
             pr)  sel="$(jq -c '[.distros[] | select(.lane == "pr")]' "$matrix")" ;;
@@ -148,11 +154,20 @@ jobs:
       # Checking out on the host and mounting the tree in gives one shape that
       # works for all 29 images.
       - name: Suite in ${{ matrix.entry.image }}
+        # `arch` and `amazonlinux-2023` are in the matrix precisely because
+        # neither sysreqs catalog covers them — `api: false, local: false`. The
+        # sysreqs stage asserts that uvr names this distro's libxml2 devel
+        # package, which for those two it correctly cannot, so running the
+        # stage would assert the opposite of what the matrix records. Skip it
+        # there and let the earlier stages carry them.
+        env:
+          SKIP_STAGES: ${{ !matrix.entry.sysreqs.api && !matrix.entry.sysreqs.local && 'sysreqs' || '' }}
         run: |
           docker run --rm \
             -v "$PWD:/work" -w /work \
             -e "R_VERSIONS=${R_VERSIONS}" \
             -e "SMOKE_PKG=${SMOKE_PKG}" \
+            -e "SKIP_STAGES=${SKIP_STAGES}" \
             "${{ matrix.entry.image }}" \
             sh ci/distro-suite.sh
 

--- a/.github/workflows/distro-suite.yml
+++ b/.github/workflows/distro-suite.yml
@@ -1,7 +1,10 @@
 name: Distro suite
 
-# The full test suite, compiled and run natively inside every Linux
-# distribution uvr supports.
+# Every Linux distribution uvr supports, exercised with the binary that ships.
+#
+# The suite installs nothing from source and builds no code inside the images:
+# users get a release binary from install.sh, so that is what runs here, picked
+# per-image by the same libc rule install.sh applies.
 #
 # Why this exists: uvr maps /etc/os-release onto three third-party
 # vocabularies (portable-R target, P3M binary repo, sysreqs catalog) and the
@@ -74,9 +77,45 @@ jobs:
           echo "count=$(jq 'length' <<<"$sel")" >> "$GITHUB_OUTPUT"
           jq -r '.[].key' <<<"$sel" | tr '\n' ' '
 
+  # The artifact under test is the one that ships. Both Linux targets are built
+  # once here and handed to every image; each container then picks between them
+  # with the same libc rule install.sh uses, so the selection is under test too.
+  build:
+    name: Build release binaries
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-unknown-linux-gnu, x86_64-unknown-linux-musl
+      - name: Install musl toolchain
+        run: sudo apt-get update && sudo apt-get install -y musl-tools
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: distro-suite-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: distro-suite-cargo-
+      - name: Build
+        run: |
+          set -euxo pipefail
+          for t in x86_64-unknown-linux-gnu x86_64-unknown-linux-musl; do
+            cargo build --release --target "$t" --bin uvr
+            mkdir -p "dist/uvr-$t"
+            cp "target/$t/release/uvr" "dist/uvr-$t/uvr"
+          done
+      - uses: actions/upload-artifact@v4
+        with:
+          name: uvr-linux-release
+          path: dist/
+          retention-days: 1
+
   suite:
     name: ${{ matrix.entry.key }}
-    needs: select
+    needs: [select, build]
     if: needs.select.outputs.count != '0'
     runs-on: ubuntu-latest
     timeout-minutes: 45
@@ -90,11 +129,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: actions/download-artifact@v4
+        with:
+          name: uvr-linux-release
+          path: dist
+
+      - name: Restore the executable bit
+        run: chmod +x dist/*/uvr
+
       # `docker run` rather than a `container:` job: actions/checkout runs a
       # node binary that needs a glibc the musl and minimal images don't have.
       # Checking out on the host and mounting the tree in gives one shape that
       # works for all 29 images.
-      - name: Full suite in ${{ matrix.entry.image }}
+      - name: Suite in ${{ matrix.entry.image }}
         run: |
           docker run --rm \
             -v "$PWD:/work" -w /work \

--- a/ci/capture-os-release.sh
+++ b/ci/capture-os-release.sh
@@ -21,7 +21,7 @@ runtime="${CONTAINER_RUNTIME:-docker}"
 
 keys="$*"
 
-jq -r '.[] | "\(.key)\t\(.image)"' "$matrix" | while IFS="$(printf '\t')" read -r key image; do
+jq -r '.distros[] | "\(.key)\t\(.image)"' "$matrix" | while IFS="$(printf '\t')" read -r key image; do
     if [ -n "$keys" ]; then
         case " $keys " in
             *" $key "*) ;;

--- a/ci/capture-os-release.sh
+++ b/ci/capture-os-release.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+# Capture the verbatim /etc/os-release identity from every image in the distro
+# matrix.
+#
+# The whole point of the matrix is that uvr's idea of what a host reports must
+# match what it actually reports — #209 was `VERSION_ID=8.10` where uvr assumed
+# `8`. So these values are never hand-written: they are captured from the real
+# image, here and in the nightly drift job.
+#
+# Usage:
+#   ci/capture-os-release.sh                    # every image in the matrix
+#   ci/capture-os-release.sh rhel-8 rocky-9     # only these keys
+#
+# Prints one JSON object per line: {"key":..,"image":..,"id":..,"version_id":..}
+# Images pulled by this script are removed again; images already present are
+# left alone.
+set -eu
+
+matrix="$(dirname "$0")/../crates/uvr-core/tests/distro_matrix.json"
+runtime="${CONTAINER_RUNTIME:-docker}"
+
+keys="$*"
+
+jq -r '.[] | "\(.key)\t\(.image)"' "$matrix" | while IFS="$(printf '\t')" read -r key image; do
+    if [ -n "$keys" ]; then
+        case " $keys " in
+            *" $key "*) ;;
+            *) continue ;;
+        esac
+    fi
+
+    had_image=yes
+    "$runtime" image inspect "$image" >/dev/null 2>&1 || had_image=no
+
+    if ! out="$("$runtime" run --rm --entrypoint "" "$image" cat /etc/os-release 2>/dev/null)"; then
+        printf '{"key":"%s","image":"%s","error":"could not read /etc/os-release"}\n' "$key" "$image"
+        [ "$had_image" = no ] && "$runtime" rmi -f "$image" >/dev/null 2>&1 || true
+        continue
+    fi
+
+    # Same parse as crate::os_release: last wins, quotes stripped.
+    id="$(printf '%s\n' "$out" | sed -n 's/^ID=//p' | tail -1 | tr -d '"'"'"'')"
+    version_id="$(printf '%s\n' "$out" | sed -n 's/^VERSION_ID=//p' | tail -1 | tr -d '"'"'"'')"
+    printf '{"key":"%s","image":"%s","id":"%s","version_id":"%s"}\n' \
+        "$key" "$image" "$id" "$version_id"
+
+    [ "$had_image" = no ] && "$runtime" rmi -f "$image" >/dev/null 2>&1 || true
+done

--- a/ci/distro-suite.sh
+++ b/ci/distro-suite.sh
@@ -32,6 +32,16 @@ R_LATEST="${R_VERSIONS##* }"
 # Where the tree is mounted; stages cd into scratch projects and back.
 ROOT="$(pwd)"
 
+# Resolve DIST against ROOT now, while we are still standing in it. Every stage
+# below cds into a scratch project under /tmp before invoking $UVR, and a
+# relative ./dist stops resolving the moment it does — the shell then reports
+# the binary as "not found" (exit 127), which reads like a missing artifact
+# rather than a missing directory.
+case "$DIST" in
+    /*) ;;
+    *) DIST="$ROOT/${DIST#./}" ;;
+esac
+
 # ---------------------------------------------------------------- helpers ---
 
 group() { printf '::group::%s\n' "$*"; }
@@ -134,12 +144,14 @@ xz_pkg() {
     esac
 }
 
-# uvr's auto-installer knows apk/dnf/apt-get (sync.rs::pick_sysreqs_installer).
-# On zypper/pacman hosts it would shell out to a package manager that isn't
-# there, so those distros assert the *diagnosis* instead of the install.
+# uvr's auto-installer knows apk/dnf/apt-get (sync.rs::pick_sysreqs_installer)
+# and nothing else — its last branch is an unconditional apt-get, so a host
+# without one of those three gets a command that isn't there. That includes
+# yum-only images: `dnf` is absent, so uvr falls through to apt-get, which is
+# also absent. Those distros assert the *diagnosis* instead of the install.
 sysreqs_autoinstall_supported() {
     case "$PM" in
-        apt-get|dnf|yum|apk) return 0 ;;
+        apt-get|dnf|apk) return 0 ;;
         *) return 1 ;;
     esac
 }

--- a/ci/distro-suite.sh
+++ b/ci/distro-suite.sh
@@ -109,7 +109,9 @@ build_prereqs() {
         apt-get) echo "build-essential pkg-config" ;;
         dnf|yum|microdnf) echo "gcc gcc-c++ make pkgconf-pkg-config" ;;
         zypper) echo "gcc gcc-c++ make pkg-config" ;;
-        apk) echo "build-base musl-dev" ;;
+        # build-base does not pull pkgconf on Alpine, and R's anticonf
+        # configure scripts need it to find libxml-2.0.
+        apk) echo "build-base musl-dev pkgconf" ;;
         pacman) echo "gcc make pkgconf" ;;
     esac
 }
@@ -200,7 +202,15 @@ fi
 # There is still no compiler on this image, so a "binary" install that quietly
 # falls back to a source build fails here instead of passing for the wrong
 # reason.
-if ! skipped binary; then
+#
+# musl hosts sit this one out: P3M publishes no musl repo and the portable
+# manylinux fallback needs glibc, so there is no binary to select and `uvr add`
+# correctly compiles from source — which is the *next* stage's subject, on an
+# image that by then has a compiler. Alpine's coverage is the sysreqs path
+# (#30), not this one.
+if [ "$libc" = musl ]; then
+    note "skipping the binary stage: no binary repo exists for musl"
+elif ! skipped binary; then
     group "Binary package install ($SMOKE_PKG)"
     work=/tmp/binary-smoke
     rm -rf "$work" && mkdir -p "$work" && cd "$work"

--- a/ci/distro-suite.sh
+++ b/ci/distro-suite.sh
@@ -1,0 +1,267 @@
+#!/bin/sh
+# Run uvr's full test suite natively inside one Linux distribution.
+#
+# Invoked by .github/workflows/distro-suite.yml, once per image in
+# crates/uvr-core/tests/distro_matrix.json, via:
+#
+#   docker run --rm -v "$PWD:/work" -w /work <image> sh ci/distro-suite.sh
+#
+# `docker run` rather than a `container:` job on purpose: node-based actions
+# need a glibc the minimal and musl images don't have, so the checkout happens
+# on the host and the source tree is mounted in. One shape for every image.
+#
+# Everything is compiled and executed with the distro's own toolchain against
+# its own libc — cross-compiled or statically linked binaries would test the
+# build host, which is the opposite of the point.
+#
+# Env:
+#   R_VERSIONS   space-separated R versions to install (default: 4.5.1)
+#   SMOKE_PKG    package with an external system library (default: xml2)
+#   SKIP_STAGES  space-separated stage names to skip (default: none)
+set -eu
+
+R_VERSIONS="${R_VERSIONS:-4.5.1}"
+SMOKE_PKG="${SMOKE_PKG:-xml2}"
+SKIP_STAGES="${SKIP_STAGES:-}"
+R_LATEST="${R_VERSIONS##* }"
+# Where the source tree is mounted; stages cd into scratch projects and back.
+ROOT="$(pwd)"
+
+# ---------------------------------------------------------------- helpers ---
+
+group() { printf '::group::%s\n' "$*"; }
+endgroup() { printf '::endgroup::\n'; }
+note() { printf '\n>>> %s\n' "$*"; }
+fail() { printf '\n!!! FAIL: %s\n' "$*" >&2; exit 1; }
+
+skipped() {
+    for s in $SKIP_STAGES; do
+        [ "$s" = "$1" ] && return 0
+    done
+    return 1
+}
+
+# --------------------------------------------------------- distro plumbing ---
+
+# The one place that knows package-manager dialects. Adding a distro to the
+# matrix must not mean adding a line of YAML — if its package manager is
+# already known here, the image just works.
+detect_pm() {
+    for pm in apt-get dnf microdnf zypper apk pacman yum; do
+        if command -v "$pm" >/dev/null 2>&1; then
+            echo "$pm"
+            return 0
+        fi
+    done
+    fail "no supported package manager found in this image"
+}
+
+PM="$(detect_pm)"
+note "package manager: $PM"
+
+pm_install() {
+    case "$PM" in
+        apt-get) DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends "$@" ;;
+        dnf|yum) "$PM" -y install "$@" ;;
+        microdnf) microdnf -y install "$@" ;;
+        zypper) zypper --non-interactive --gpg-auto-import-keys install -y "$@" ;;
+        apk) apk add --no-cache "$@" ;;
+        pacman) pacman -S --noconfirm --needed "$@" ;;
+    esac
+}
+
+pm_refresh() {
+    case "$PM" in
+        apt-get) apt-get update ;;
+        zypper) zypper --non-interactive --gpg-auto-import-keys refresh ;;
+        pacman) pacman -Sy --noconfirm ;;
+        *) : ;;
+    esac
+}
+
+# Base prerequisites, per family:
+#   compiler + make + pkg-config  build uvr and any source R package
+#   ca-certificates               rustup, the R tarball, CRAN over TLS
+#   fontconfig (+ a font on musl) R's graphics device probes these at startup
+#   libxml2 runtime               load the binary SMOKE_PKG
+# Deliberately absent: libxml2's *headers*. Their absence is what the sysreqs
+# stage below is testing.
+prereqs() {
+    case "$PM" in
+        apt-get) echo "build-essential pkg-config ca-certificates fontconfig libxml2 procps" ;;
+        dnf|yum|microdnf) echo "gcc gcc-c++ make pkgconf-pkg-config which ca-certificates fontconfig libxml2 findutils" ;;
+        zypper) echo "gcc gcc-c++ make pkg-config which ca-certificates fontconfig libxml2-2" ;;
+        apk) echo "build-base musl-dev ca-certificates fontconfig ttf-dejavu libxml2" ;;
+        pacman) echo "gcc make pkgconf which ca-certificates fontconfig libxml2" ;;
+    esac
+}
+
+# curl and the tarball tools are requested by *command*, not by package: the
+# RHEL images ship `curl-minimal`, and asking for `curl` there is a package
+# conflict rather than a no-op. Only name a package when its command is
+# genuinely absent.
+tools() {
+    for pair in "curl curl" "tar tar" "gzip gzip" "xz $(xz_pkg)"; do
+        cmd=${pair%% *}
+        pkg=${pair#* }
+        command -v "$cmd" >/dev/null 2>&1 || printf '%s ' "$pkg"
+    done
+}
+
+xz_pkg() {
+    case "$PM" in
+        apt-get) echo "xz-utils" ;;
+        *) echo "xz" ;;
+    esac
+}
+
+# uvr's auto-installer knows apk/dnf/apt-get (sync.rs::pick_sysreqs_installer).
+# On zypper/pacman hosts it would shell out to a package manager that isn't
+# there, so those distros assert the *diagnosis* instead of the install.
+sysreqs_autoinstall_supported() {
+    case "$PM" in
+        apt-get|dnf|yum|apk) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+# ------------------------------------------------------------- stage: deps ---
+
+if ! skipped prereqs; then
+    group "Install prerequisites ($PM)"
+    pm_refresh
+    # shellcheck disable=SC2046  # deliberate word splitting: a package list
+    pm_install $(prereqs) $(tools)
+    endgroup
+fi
+
+# ------------------------------------------------------------- stage: rust ---
+
+if ! skipped rust; then
+    group "Install Rust toolchain"
+    if command -v cargo >/dev/null 2>&1; then
+        note "cargo already present: $(cargo --version)"
+    elif [ "$PM" = apk ]; then
+        # rustup-init from the distro so the toolchain links against musl.
+        apk add --no-cache rustup
+        rustup-init -y --default-toolchain stable --profile minimal --no-modify-path
+    else
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+            | sh -s -- -y --default-toolchain stable --profile minimal --no-modify-path
+    fi
+    endgroup
+fi
+
+if [ -f "$HOME/.cargo/env" ]; then
+    # shellcheck disable=SC1091
+    . "$HOME/.cargo/env"
+fi
+cargo --version || fail "no cargo on PATH after toolchain install"
+
+# Keep each distro's build products apart: the mounted source tree is shared
+# with the host and with every other distro in the matrix, and objects linked
+# against one libc must never be picked up by another.
+CARGO_TARGET_DIR="/tmp/uvr-target"
+export CARGO_TARGET_DIR
+UVR="$CARGO_TARGET_DIR/debug/uvr"
+
+# ------------------------------------------------------ stage: build + test ---
+
+# Unconditional: every stage below runs the binary this produces, so there is
+# nothing left to skip to if it is missing.
+group "cargo build --all"
+cargo build --all
+endgroup
+
+if ! skipped test; then
+    # The whole suite, natively. Most of it is distro-independent logic, but it
+    # is a few seconds once the tree is built and it is the only way to catch
+    # the parts that are not: package-manager probing (sysreqs::filter_missing),
+    # shell activation, path and permission handling.
+    #
+    # The *_live.rs tests are #[ignore]d and stay that way here; catalog
+    # conformance is its own job and must not make this one flaky.
+    group "cargo test --all"
+    cargo test --all
+    endgroup
+fi
+
+# --------------------------------------------------------------- stage: R ---
+
+if ! skipped r; then
+    group "Install R ($R_VERSIONS)"
+    for v in $R_VERSIONS; do
+        "$UVR" r install "$v"
+    done
+    "$UVR" r list --all
+    endgroup
+
+    # Activation resolves an R interpreter, so these skipped in `cargo test`
+    # above — R did not exist yet. Re-run them now that it does. Shell-specific
+    # cases self-skip when their shell is absent, which is the common case in a
+    # minimal image.
+    group "Activation tests against installed R"
+    rroot="$HOME/.uvr/r-versions/$R_LATEST"
+    PATH="$rroot/bin:$PATH"
+    export PATH
+    R --version
+    cargo test --test cli_tests activate
+    endgroup
+fi
+
+# ---------------------------------------------------- stage: binary package ---
+
+# #175: a binary from the wrong distro's repo installs happily and only fails
+# at library() — so the assertion has to load the package, not just install it.
+if ! skipped binary; then
+    group "Binary package install ($SMOKE_PKG)"
+    "$UVR" doctor || true
+    work=/tmp/binary-smoke
+    rm -rf "$work" && mkdir -p "$work" && cd "$work"
+    "$UVR" init --here binary-smoke --r-version "$R_LATEST"
+    printf 'library(%s); cat("binary-smoke-ok\\n")\n' "$SMOKE_PKG" > check.R
+    "$UVR" add "$SMOKE_PKG"
+    "$UVR" run check.R
+    cd "$ROOT"
+    endgroup
+fi
+
+# --------------------------------------------------------- stage: sysreqs ---
+
+# The #209 regression test, at the real end of the chain.
+#
+# The image has libxml2's runtime library but not its headers, so a source
+# build of xml2 cannot succeed unless uvr correctly resolves the distro's
+# devel package and installs it. Nothing here greps a warning string: the
+# source build either compiles or it does not, and it only compiles if every
+# link in the chain — os-release parse, catalog naming, package-manager probe,
+# installer dialect — is right for this distro.
+#
+# Which is exactly what #209 broke: RHEL asked the catalog under a name it
+# does not publish, got nothing back, installed nothing, and the build failed.
+if ! skipped sysreqs; then
+    group "System dependency resolution ($SMOKE_PKG from source)"
+    work=/tmp/sysreqs-smoke
+    rm -rf "$work" && mkdir -p "$work" && cd "$work"
+    "$UVR" init --here sysreqs-smoke --r-version "$R_LATEST"
+    printf 'library(%s); cat("sysreqs-smoke-ok\\n")\n' "$SMOKE_PKG" > check.R
+
+    if sysreqs_autoinstall_supported; then
+        UVR_INSTALL_SYSREQS=1 "$UVR" add "$SMOKE_PKG" --no-binary 2>&1 | tee add.log
+        "$UVR" run check.R
+    else
+        # zypper/pacman: uvr cannot run the install itself, so assert it at
+        # least named the package a human would then install.
+        "$UVR" add "$SMOKE_PKG" --no-binary > add.log 2>&1 || true
+        grep -Eq 'libxml2-dev(el)?' add.log \
+            || fail "uvr did not name libxml2's devel package; see add.log"
+    fi
+
+    grep -q 'System dependency check skipped' add.log \
+        && fail "uvr skipped the sysreqs check on this distro (#209 shape)"
+
+    cd "$ROOT"
+    endgroup
+fi
+
+note "distro suite complete"

--- a/ci/distro-suite.sh
+++ b/ci/distro-suite.sh
@@ -87,6 +87,15 @@ skipped() {
 # unnoticed.
 expect_fail() { [ "$EXPECT_FAIL_STAGE" = "$1" ]; }
 
+# An expectation with no message would match *any* failure, quietly turning the
+# strongest assertion in the suite into "this distro may fail for any reason".
+# Refuse it at the top rather than pass a distro for the wrong reason.
+if [ -n "$EXPECT_FAIL_STAGE" ] && [ -z "$EXPECT_FAIL_MESSAGE" ]; then
+    fail "expect.stage=$EXPECT_FAIL_STAGE with no expect.message: an expectation
+       that matches any failure is not an assertion. Add the substring uvr must
+       print to this entry in distro_matrix.json."
+fi
+
 # --------------------------------------------------------- distro plumbing ---
 
 # The one place that knows package-manager dialects. Adding a distro to the

--- a/ci/distro-suite.sh
+++ b/ci/distro-suite.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Run uvr's full test suite natively inside one Linux distribution.
+# Exercise a *released* uvr binary in one Linux distribution.
 #
 # Invoked by .github/workflows/distro-suite.yml, once per image in
 # crates/uvr-core/tests/distro_matrix.json, via:
@@ -8,23 +8,28 @@
 #
 # `docker run` rather than a `container:` job on purpose: node-based actions
 # need a glibc the minimal and musl images don't have, so the checkout happens
-# on the host and the source tree is mounted in. One shape for every image.
+# on the host and the tree is mounted in. One shape for every image.
 #
-# Everything is compiled and executed with the distro's own toolchain against
-# its own libc — cross-compiled or statically linked binaries would test the
-# build host, which is the opposite of the point.
+# This deliberately does not build uvr here. Users don't cargo build it —
+# install.sh drops a release binary onto their machine — so the artifact under
+# test is the one that ships, selected by the same libc rule install.sh uses.
+# Building from source in each container would paper over exactly the failures
+# that matter: a gnu binary whose glibc floor is above what the distro ships,
+# or a musl binary picked on a glibc host.
 #
 # Env:
+#   DIST         directory of release builds (default: ./dist)
 #   R_VERSIONS   space-separated R versions to install (default: 4.5.1)
 #   SMOKE_PKG    package with an external system library (default: xml2)
 #   SKIP_STAGES  space-separated stage names to skip (default: none)
 set -eu
 
+DIST="${DIST:-./dist}"
 R_VERSIONS="${R_VERSIONS:-4.5.1}"
 SMOKE_PKG="${SMOKE_PKG:-xml2}"
 SKIP_STAGES="${SKIP_STAGES:-}"
 R_LATEST="${R_VERSIONS##* }"
-# Where the source tree is mounted; stages cd into scratch projects and back.
+# Where the tree is mounted; stages cd into scratch projects and back.
 ROOT="$(pwd)"
 
 # ---------------------------------------------------------------- helpers ---
@@ -79,29 +84,41 @@ pm_refresh() {
     esac
 }
 
-# Base prerequisites, per family:
-#   compiler + make + pkg-config  build uvr and any source R package
-#   ca-certificates               rustup, the R tarball, CRAN over TLS
-#   fontconfig (+ a font on musl) R's graphics device probes these at startup
-#   libxml2 runtime               load the binary SMOKE_PKG
-# Deliberately absent: libxml2's *headers*. Their absence is what the sysreqs
-# stage below is testing.
-prereqs() {
+# Runtime only — what a user has before they compile anything:
+#   ca-certificates                TLS to the CDN and CRAN
+#   fontconfig (+ a font on musl)  R probes these at startup
+#   which                          R's `utils` calls system(which ...) in
+#                                  .onLoad and fails to load without it; the
+#                                  minimal RPM images ship no `which`, Debian
+#                                  and busybox do
+#   libxml2 runtime                load the binary SMOKE_PKG
+# Deliberately absent: a compiler, and libxml2's *headers*. The stages below
+# run on a bare image precisely to prove the shipped binary needs neither.
+runtime_prereqs() {
     case "$PM" in
-        apt-get) echo "build-essential pkg-config ca-certificates fontconfig libxml2 procps" ;;
-        dnf|yum|microdnf) echo "gcc gcc-c++ make pkgconf-pkg-config which ca-certificates fontconfig libxml2 findutils" ;;
-        zypper) echo "gcc gcc-c++ make pkg-config which ca-certificates fontconfig libxml2-2" ;;
-        apk) echo "build-base musl-dev ca-certificates fontconfig ttf-dejavu libxml2" ;;
-        pacman) echo "gcc make pkgconf which ca-certificates fontconfig libxml2" ;;
+        apt-get) echo "ca-certificates fontconfig libxml2" ;;
+        dnf|yum|microdnf|pacman) echo "ca-certificates fontconfig libxml2 which" ;;
+        zypper) echo "ca-certificates fontconfig libxml2-2 which" ;;
+        apk) echo "ca-certificates fontconfig ttf-dejavu libxml2" ;;
     esac
 }
 
-# curl and the tarball tools are requested by *command*, not by package: the
-# RHEL images ship `curl-minimal`, and asking for `curl` there is a package
-# conflict rather than a no-op. Only name a package when its command is
-# genuinely absent.
+# Only for the source-build stage: R compiles C for xml2.
+build_prereqs() {
+    case "$PM" in
+        apt-get) echo "build-essential pkg-config" ;;
+        dnf|yum|microdnf) echo "gcc gcc-c++ make pkgconf-pkg-config" ;;
+        zypper) echo "gcc gcc-c++ make pkg-config" ;;
+        apk) echo "build-base musl-dev" ;;
+        pacman) echo "gcc make pkgconf" ;;
+    esac
+}
+
+# The tarball tools are requested by *command*, not by package: the RHEL images
+# ship curl-minimal, and asking for `curl` there is a package conflict rather
+# than a no-op. Only name a package when its command is genuinely absent.
 tools() {
-    for pair in "curl curl" "tar tar" "gzip gzip" "xz $(xz_pkg)"; do
+    for pair in "tar tar" "gzip gzip" "xz $(xz_pkg)"; do
         cmd=${pair%% *}
         pkg=${pair#* }
         command -v "$cmd" >/dev/null 2>&1 || printf '%s ' "$pkg"
@@ -128,63 +145,42 @@ sysreqs_autoinstall_supported() {
 # ------------------------------------------------------------- stage: deps ---
 
 if ! skipped prereqs; then
-    group "Install prerequisites ($PM)"
+    group "Install runtime prerequisites ($PM)"
     pm_refresh
     # shellcheck disable=SC2046  # deliberate word splitting: a package list
-    pm_install $(prereqs) $(tools)
+    pm_install $(runtime_prereqs) $(tools)
     endgroup
 fi
 
-# ------------------------------------------------------------- stage: rust ---
+# ------------------------------------------------- stage: pick the artifact ---
 
-if ! skipped rust; then
-    group "Install Rust toolchain"
-    if command -v cargo >/dev/null 2>&1; then
-        note "cargo already present: $(cargo --version)"
-    elif [ "$PM" = apk ]; then
-        # rustup-init from the distro so the toolchain links against musl.
-        apk add --no-cache rustup
-        rustup-init -y --default-toolchain stable --profile minimal --no-modify-path
-    else
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
-            | sh -s -- -y --default-toolchain stable --profile minimal --no-modify-path
-    fi
-    endgroup
+# The same rule install.sh applies, so the matrix exercises the binary a user
+# on this distro would actually receive — including the choice itself.
+libc=gnu
+if command -v ldd >/dev/null 2>&1 && ldd --version 2>&1 | grep -qi musl; then
+    libc=musl
+elif [ -f /etc/alpine-release ]; then
+    libc=musl
 fi
+arch="$(uname -m)"
+[ "$arch" = arm64 ] && arch=aarch64
+TARGET="${arch}-unknown-linux-${libc}"
+UVR="$DIST/uvr-$TARGET/uvr"
 
-if [ -f "$HOME/.cargo/env" ]; then
-    # shellcheck disable=SC1091
-    . "$HOME/.cargo/env"
-fi
-cargo --version || fail "no cargo on PATH after toolchain install"
+note "install.sh would fetch: uvr-$TARGET.tar.gz"
+[ -x "$UVR" ] || fail "no release build for $TARGET under $DIST"
 
-# Keep each distro's build products apart: the mounted source tree is shared
-# with the host and with every other distro in the matrix, and objects linked
-# against one libc must never be picked up by another.
-CARGO_TARGET_DIR="/tmp/uvr-target"
-export CARGO_TARGET_DIR
-UVR="$CARGO_TARGET_DIR/debug/uvr"
-
-# ------------------------------------------------------ stage: build + test ---
-
-# Unconditional: every stage below runs the binary this produces, so there is
-# nothing left to skip to if it is missing.
-group "cargo build --all"
-cargo build --all
+# `--version` on a bare image is the whole glibc-floor question in one line: a
+# gnu binary linked against a newer glibc than this distro ships dies right
+# here, which is what a user hits seconds after running install.sh.
+group "uvr --version ($TARGET)"
+"$UVR" --version || fail "the $TARGET release binary does not run on this distro"
+"$UVR" --help > /dev/null
 endgroup
 
-if ! skipped test; then
-    # The whole suite, natively. Most of it is distro-independent logic, but it
-    # is a few seconds once the tree is built and it is the only way to catch
-    # the parts that are not: package-manager probing (sysreqs::filter_missing),
-    # shell activation, path and permission handling.
-    #
-    # The *_live.rs tests are #[ignore]d and stay that way here; catalog
-    # conformance is its own job and must not make this one flaky.
-    group "cargo test --all"
-    cargo test --all
-    endgroup
-fi
+group "uvr doctor"
+"$UVR" doctor || true
+endgroup
 
 # --------------------------------------------------------------- stage: R ---
 
@@ -195,27 +191,17 @@ if ! skipped r; then
     done
     "$UVR" r list --all
     endgroup
-
-    # Activation resolves an R interpreter, so these skipped in `cargo test`
-    # above — R did not exist yet. Re-run them now that it does. Shell-specific
-    # cases self-skip when their shell is absent, which is the common case in a
-    # minimal image.
-    group "Activation tests against installed R"
-    rroot="$HOME/.uvr/r-versions/$R_LATEST"
-    PATH="$rroot/bin:$PATH"
-    export PATH
-    R --version
-    cargo test --test cli_tests activate
-    endgroup
 fi
 
 # ---------------------------------------------------- stage: binary package ---
 
 # #175: a binary from the wrong distro's repo installs happily and only fails
 # at library() — so the assertion has to load the package, not just install it.
+# There is still no compiler on this image, so a "binary" install that quietly
+# falls back to a source build fails here instead of passing for the wrong
+# reason.
 if ! skipped binary; then
     group "Binary package install ($SMOKE_PKG)"
-    "$UVR" doctor || true
     work=/tmp/binary-smoke
     rm -rf "$work" && mkdir -p "$work" && cd "$work"
     "$UVR" init --here binary-smoke --r-version "$R_LATEST"
@@ -231,16 +217,22 @@ fi
 # The #209 regression test, at the real end of the chain.
 #
 # The image has libxml2's runtime library but not its headers, so a source
-# build of xml2 cannot succeed unless uvr correctly resolves the distro's
-# devel package and installs it. Nothing here greps a warning string: the
-# source build either compiles or it does not, and it only compiles if every
-# link in the chain — os-release parse, catalog naming, package-manager probe,
-# installer dialect — is right for this distro.
+# build of xml2 cannot succeed unless uvr resolves this distro's devel package
+# and installs it. Nothing here greps a warning string: the build either
+# compiles or it does not, and it only compiles if every link — os-release
+# parse, catalog naming, package-manager probe, installer dialect — is right
+# for this distro.
 #
-# Which is exactly what #209 broke: RHEL asked the catalog under a name it
-# does not publish, got nothing back, installed nothing, and the build failed.
+# Which is exactly what #209 broke: RHEL asked the catalog under a name it does
+# not publish, got nothing back, installed nothing, and the build failed. A
+# pre-fix binary fails this stage with `libxml/tree.h: No such file or
+# directory` having printed no warning at all — which is why the assertion is
+# "the build works" rather than "the warning is absent".
 if ! skipped sysreqs; then
     group "System dependency resolution ($SMOKE_PKG from source)"
+    # shellcheck disable=SC2046  # deliberate word splitting: a package list
+    pm_install $(build_prereqs)
+
     work=/tmp/sysreqs-smoke
     rm -rf "$work" && mkdir -p "$work" && cd "$work"
     "$UVR" init --here sysreqs-smoke --r-version "$R_LATEST"

--- a/ci/distro-suite.sh
+++ b/ci/distro-suite.sh
@@ -18,16 +18,39 @@
 # or a musl binary picked on a glibc host.
 #
 # Env:
-#   DIST         directory of release builds (default: ./dist)
-#   R_VERSIONS   space-separated R versions to install (default: 4.5.1)
-#   SMOKE_PKG    package with an external system library (default: xml2)
-#   SKIP_STAGES  space-separated stage names to skip (default: none)
+#   DIST                 directory of release builds (default: ./dist)
+#   R_VERSIONS           space-separated R versions to install (default: 4.5.1)
+#   BINARY_PKG           package for the binary stage (default: jsonlite)
+#   SYSREQS_PKG          package with an external system library (default: xml2)
+#   SKIP_STAGES          space-separated stage names to skip (default: none)
+#   EXPECT_FAIL_STAGE    stage the matrix records as unsupported here
+#   EXPECT_FAIL_MESSAGE  substring uvr must print when it refuses
 set -eu
 
 DIST="${DIST:-./dist}"
 R_VERSIONS="${R_VERSIONS:-4.5.1}"
-SMOKE_PKG="${SMOKE_PKG:-xml2}"
+# Two packages, because the two stages ask different questions and only one of
+# them is about system libraries.
+#
+# The binary stage asks "did uvr pick a repo whose binaries run here", so it
+# needs a package P3M builds for every repo. The sysreqs stage asks "did uvr
+# resolve this distro's *devel* package", so it needs one with an external
+# system library whose headers the image deliberately lacks.
+#
+# Sharing one package made the binary stage depend on Posit's per-package build
+# queue, which is not a property of the distro and not something uvr controls:
+# P3M's Linux `PACKAGES` index lists every package whether or not a binary
+# exists, and the binary-vs-source choice is made at download time from the R
+# User-Agent. A recently released version can therefore be indexed everywhere
+# and built only for the busiest repos — xml2 1.6.0 (2026-06-22) has a jammy
+# binary and serves *source* on opensuse156, bookworm, bullseye, focal and
+# centos7. jsonlite is what ci.yml already uses for this: small, compiled
+# component, and built for every repo in the matrix.
+BINARY_PKG="${BINARY_PKG:-jsonlite}"
+SYSREQS_PKG="${SYSREQS_PKG:-xml2}"
 SKIP_STAGES="${SKIP_STAGES:-}"
+EXPECT_FAIL_STAGE="${EXPECT_FAIL_STAGE:-}"
+EXPECT_FAIL_MESSAGE="${EXPECT_FAIL_MESSAGE:-}"
 R_LATEST="${R_VERSIONS##* }"
 # Where the tree is mounted; stages cd into scratch projects and back.
 ROOT="$(pwd)"
@@ -55,6 +78,14 @@ skipped() {
     done
     return 1
 }
+
+# A stage the matrix records as unsupported on this distro. The expectation is
+# asserted rather than skipped: skipping hides a limitation, asserting keeps it
+# visible *and* checked, so the lane turns red if uvr stops refusing, or starts
+# refusing for a different reason. A permanently-red job nobody reads is how a
+# real failure hides, and a silently-skipped one is how a fixed limitation goes
+# unnoticed.
+expect_fail() { [ "$EXPECT_FAIL_STAGE" = "$1" ]; }
 
 # --------------------------------------------------------- distro plumbing ---
 
@@ -101,7 +132,8 @@ pm_refresh() {
 #                                  .onLoad and fails to load without it; the
 #                                  minimal RPM images ship no `which`, Debian
 #                                  and busybox do
-#   libxml2 runtime                load the binary SMOKE_PKG
+#   libxml2 runtime                load SYSREQS_PKG once it is built; only its
+#                                  *headers* are withheld, which is the point
 # Deliberately absent: a compiler, and libxml2's *headers*. The stages below
 # run on a bare image precisely to prove the shipped binary needs neither.
 runtime_prereqs() {
@@ -198,7 +230,30 @@ endgroup
 
 # --------------------------------------------------------------- stage: R ---
 
-if ! skipped r; then
+if ! skipped r && expect_fail r; then
+    # Distros below the portable builds' glibc floor (#212). The matrix used to
+    # record this in prose, which meant every PR touching these paths carried a
+    # permanently red check that meant nothing — and a red check nobody reads is
+    # how a real failure hides. Assert the refusal instead.
+    group "Install R ($R_LATEST) — expected to fail on this distro"
+    if out="$("$UVR" r install "$R_LATEST" 2>&1)"; then
+        printf '%s\n' "$out"
+        fail "uvr installed R here, but the matrix records this distro as unsupported.
+       If the floor moved or portable builds gained coverage, drop the
+       'expect' block from this entry in distro_matrix.json."
+    fi
+    printf '%s\n' "$out"
+    printf '%s\n' "$out" | grep -qF "$EXPECT_FAIL_MESSAGE" || fail \
+        "uvr refused to install R, but not for the documented reason.
+       wanted: $EXPECT_FAIL_MESSAGE
+       This is the #212 message regressing into something a user cannot act on."
+    endgroup
+    note "expected failure confirmed: $EXPECT_FAIL_MESSAGE"
+    # Every stage below needs a working R, so there is nothing further to ask
+    # this distro. Stopping here is the answer, not a truncation.
+    note "distro suite complete (no R on this platform, as recorded)"
+    exit 0
+elif ! skipped r; then
     group "Install R ($R_VERSIONS)"
     for v in $R_VERSIONS; do
         "$UVR" r install "$v"
@@ -223,12 +278,12 @@ fi
 if [ "$libc" = musl ]; then
     note "skipping the binary stage: no binary repo exists for musl"
 elif ! skipped binary; then
-    group "Binary package install ($SMOKE_PKG)"
+    group "Binary package install ($BINARY_PKG)"
     work=/tmp/binary-smoke
     rm -rf "$work" && mkdir -p "$work" && cd "$work"
     "$UVR" init --here binary-smoke --r-version "$R_LATEST"
-    printf 'library(%s); cat("binary-smoke-ok\\n")\n' "$SMOKE_PKG" > check.R
-    "$UVR" add "$SMOKE_PKG"
+    printf 'library(%s); cat("binary-smoke-ok\\n")\n' "$BINARY_PKG" > check.R
+    "$UVR" add "$BINARY_PKG"
     "$UVR" run check.R
     cd "$ROOT"
     endgroup
@@ -251,22 +306,22 @@ fi
 # directory` having printed no warning at all — which is why the assertion is
 # "the build works" rather than "the warning is absent".
 if ! skipped sysreqs; then
-    group "System dependency resolution ($SMOKE_PKG from source)"
+    group "System dependency resolution ($SYSREQS_PKG from source)"
     # shellcheck disable=SC2046  # deliberate word splitting: a package list
     pm_install $(build_prereqs)
 
     work=/tmp/sysreqs-smoke
     rm -rf "$work" && mkdir -p "$work" && cd "$work"
     "$UVR" init --here sysreqs-smoke --r-version "$R_LATEST"
-    printf 'library(%s); cat("sysreqs-smoke-ok\\n")\n' "$SMOKE_PKG" > check.R
+    printf 'library(%s); cat("sysreqs-smoke-ok\\n")\n' "$SYSREQS_PKG" > check.R
 
     if sysreqs_autoinstall_supported; then
-        UVR_INSTALL_SYSREQS=1 "$UVR" add "$SMOKE_PKG" --no-binary 2>&1 | tee add.log
+        UVR_INSTALL_SYSREQS=1 "$UVR" add "$SYSREQS_PKG" --no-binary 2>&1 | tee add.log
         "$UVR" run check.R
     else
         # zypper/pacman: uvr cannot run the install itself, so assert it at
         # least named the package a human would then install.
-        "$UVR" add "$SMOKE_PKG" --no-binary > add.log 2>&1 || true
+        "$UVR" add "$SYSREQS_PKG" --no-binary > add.log 2>&1 || true
         grep -Eq 'libxml2-dev(el)?' add.log \
             || fail "uvr did not name libxml2's devel package; see add.log"
     fi

--- a/crates/uvr-core/tests/distro_matrix.json
+++ b/crates/uvr-core/tests/distro_matrix.json
@@ -35,7 +35,8 @@
         "release": "20.04",
         "api": true,
         "local": true
-      }
+      },
+      "note": "Expected to fail at `uvr r install`: the portable R builds need glibc 2.34 and uvr says so explicitly. #212 is what lets the CLI start here at all, so the failure is now a clear message instead of a linker error."
     },
     {
       "key": "ubuntu-2204",
@@ -92,7 +93,8 @@
         "release": "11",
         "api": true,
         "local": true
-      }
+      },
+      "note": "Expected to fail at `uvr r install`: the portable R builds need glibc 2.34 and uvr says so explicitly. #212 is what lets the CLI start here at all, so the failure is now a clear message instead of a linker error."
     },
     {
       "key": "debian-12",
@@ -136,7 +138,7 @@
       "key": "rhel-8",
       "image": "registry.access.redhat.com/ubi8:latest",
       "lane": "pr",
-      "note": "The #209 image. UBI is the only RHEL testable without a subscription; it reports the same ID/VERSION_ID as subscribed RHEL, which is the axis under test.",
+      "note": "The #209 image. UBI is the only RHEL testable without a subscription; it reports the same ID/VERSION_ID as subscribed RHEL, which is the axis under test. Expected to fail at `uvr r install`: the portable R builds need glibc 2.34 and uvr says so explicitly. #212 is what lets the CLI start here at all, so the failure is now a clear message instead of a linker error.",
       "os_release": {
         "id": "rhel",
         "version_id": "8.10"
@@ -194,7 +196,7 @@
       "key": "rocky-8",
       "image": "docker.io/rockylinux/rockylinux:8",
       "lane": "nightly",
-      "note": "api:false is real — Posit serves rockylinux 9 and 10 but not 8. Rocky 8 rides the local rules and reports a degraded check.",
+      "note": "api:false is the catalog fact — Posit serves rockylinux from 9 on. Since #214 uvr asks under redhat/8 and gets an authoritative answer; the local rules keep the rockylinux name, which resolves differently (leptonica-devel).",
       "os_release": {
         "id": "rocky",
         "version_id": "8.10"
@@ -265,7 +267,8 @@
         "release": "8",
         "api": false,
         "local": true
-      }
+      },
+      "note": "See rocky-8: rockylinux/8 is not published, so #214 asks under redhat/8."
     },
     {
       "key": "almalinux-9",
@@ -309,7 +312,7 @@
       "key": "centos-stream9",
       "image": "quay.io/centos/centos:stream9",
       "lane": "nightly",
-      "note": "The API stops at centos 8, but the vendored rules carry version-less centos constraints, so Stream resolves locally with a degraded-check warning.",
+      "note": "The catalog stops at centos 8. Since #214 uvr asks under redhat/9; the vendored rules keep the centos name, which resolves differently (libarchive-devel).",
       "os_release": {
         "id": "centos",
         "version_id": "9"
@@ -342,47 +345,48 @@
         "release": "10",
         "api": false,
         "local": true
-      }
+      },
+      "note": "See centos-stream9: asked under redhat/10 since #214."
     },
     {
       "key": "oracle-8",
       "image": "docker.io/library/oraclelinux:8",
       "lane": "nightly",
-      "gap": "ID=ol maps nowhere on either axis: no P3M binaries and no sysreqs from either source. Same shape as #209, still open.",
       "os_release": {
         "id": "ol",
         "version_id": "8.10"
       },
       "p3m": {
-        "slug": "ol-8.10",
-        "codename": null
+        "slug": "rhel-8",
+        "codename": "centos8"
       },
       "sysreqs": {
-        "distribution": "ol",
-        "release": "8.10",
-        "api": false,
-        "local": false
-      }
+        "distribution": "redhat",
+        "release": "8",
+        "api": true,
+        "local": true
+      },
+      "note": "ID=\"ol\" is aliased onto RHEL on both axes — sysreqs in #209, binaries in #214. Before those, Oracle hosts got neither."
     },
     {
       "key": "oracle-9",
       "image": "docker.io/library/oraclelinux:9",
       "lane": "nightly",
-      "gap": "See oracle-8.",
       "os_release": {
         "id": "ol",
         "version_id": "9.8"
       },
       "p3m": {
-        "slug": "ol-9.8",
-        "codename": null
+        "slug": "rhel-9",
+        "codename": "rhel9"
       },
       "sysreqs": {
-        "distribution": "ol",
-        "release": "9.8",
-        "api": false,
-        "local": false
-      }
+        "distribution": "redhat",
+        "release": "9",
+        "api": true,
+        "local": true
+      },
+      "note": "ID=\"ol\" is aliased onto RHEL on both axes — sysreqs in #209, binaries in #214. Before those, Oracle hosts got neither."
     },
     {
       "key": "opensuse-155",

--- a/crates/uvr-core/tests/distro_matrix.json
+++ b/crates/uvr-core/tests/distro_matrix.json
@@ -518,7 +518,8 @@
         "release": "3.20.10",
         "api": false,
         "local": true
-      }
+      },
+      "known_failure": "#207: CRAN PACKAGES carries no SystemRequirements, so the local-rules fallback resolves nothing — and the local rules are the only sysreqs source on Alpine. Reproduced by the sysreqs stage: xml2 fails to build with libxml2-dev never installed and no warning printed."
     },
     {
       "key": "alpine-321",
@@ -538,7 +539,8 @@
         "release": "3.21.7",
         "api": false,
         "local": true
-      }
+      },
+      "known_failure": "#207: CRAN PACKAGES carries no SystemRequirements, so the local-rules fallback resolves nothing — and the local rules are the only sysreqs source on Alpine. Reproduced by the sysreqs stage: xml2 fails to build with libxml2-dev never installed and no warning printed."
     },
     {
       "key": "alpine-322",
@@ -557,7 +559,8 @@
         "release": "3.22.5",
         "api": false,
         "local": true
-      }
+      },
+      "known_failure": "#207: CRAN PACKAGES carries no SystemRequirements, so the local-rules fallback resolves nothing — and the local rules are the only sysreqs source on Alpine. Reproduced by the sysreqs stage: xml2 fails to build with libxml2-dev never installed and no warning printed."
     },
     {
       "key": "amazonlinux-2023",

--- a/crates/uvr-core/tests/distro_matrix.json
+++ b/crates/uvr-core/tests/distro_matrix.json
@@ -523,13 +523,13 @@
         "api": false,
         "local": true
       },
-      "note": "musl: no P3M repo exists, so the binary stage is skipped and the sysreqs local-rules path (#30) is the coverage. Fails today — libxml2-dev is never installed and no warning is printed, which is open issue #207."
+      "note": "musl: no P3M repo exists, so the binary stage is skipped and the sysreqs local-rules path (#30) is the coverage. Passed as of #208 — before it, libxml2-dev was never installed and no warning was printed (#207)."
     },
     {
       "key": "alpine-321",
       "image": "docker.io/library/alpine:3.21",
       "lane": "pr",
-      "note": "musl: no P3M repo exists, so the binary stage is skipped and the sysreqs local-rules path (#30) is the coverage. Fails today — libxml2-dev is never installed and no warning is printed, which is open issue #207.",
+      "note": "musl: no P3M repo exists, so the binary stage is skipped and the sysreqs local-rules path (#30) is the coverage. Passed as of #208 — before it, libxml2-dev was never installed and no warning was printed (#207).",
       "os_release": {
         "id": "alpine",
         "version_id": "3.21.7"
@@ -563,7 +563,7 @@
         "api": false,
         "local": true
       },
-      "note": "musl: no P3M repo exists, so the binary stage is skipped and the sysreqs local-rules path (#30) is the coverage. Fails today — libxml2-dev is never installed and no warning is printed, which is open issue #207."
+      "note": "musl: no P3M repo exists, so the binary stage is skipped and the sysreqs local-rules path (#30) is the coverage. Passed as of #208 — before it, libxml2-dev was never installed and no warning was printed (#207)."
     },
     {
       "key": "amazonlinux-2023",

--- a/crates/uvr-core/tests/distro_matrix.json
+++ b/crates/uvr-core/tests/distro_matrix.json
@@ -36,7 +36,11 @@
         "api": true,
         "local": true
       },
-      "note": "Expected to fail at `uvr r install`: the portable R builds need glibc 2.34 and uvr says so explicitly. #212 is what lets the CLI start here at all, so the failure is now a clear message instead of a linker error."
+      "note": "#212 is what lets the CLI start here at all, so the failure is now a clear message instead of a linker error. The portable R builds need glibc 2.34; this distro is below that floor, so the `expect` block above asserts uvr refuses with the #212 message rather than leaving the job permanently red.",
+      "expect": {
+        "stage": "r",
+        "message": "is too old for portable R builds"
+      }
     },
     {
       "key": "ubuntu-2204",
@@ -94,7 +98,11 @@
         "api": true,
         "local": true
       },
-      "note": "Expected to fail at `uvr r install`: the portable R builds need glibc 2.34 and uvr says so explicitly. #212 is what lets the CLI start here at all, so the failure is now a clear message instead of a linker error."
+      "note": "#212 is what lets the CLI start here at all, so the failure is now a clear message instead of a linker error. The portable R builds need glibc 2.34; this distro is below that floor, so the `expect` block above asserts uvr refuses with the #212 message rather than leaving the job permanently red.",
+      "expect": {
+        "stage": "r",
+        "message": "is too old for portable R builds"
+      }
     },
     {
       "key": "debian-12",
@@ -138,7 +146,7 @@
       "key": "rhel-8",
       "image": "registry.access.redhat.com/ubi8:latest",
       "lane": "pr",
-      "note": "The #209 image. UBI is the only RHEL testable without a subscription; it reports the same ID/VERSION_ID as subscribed RHEL, which is the axis under test. Expected to fail at `uvr r install`: the portable R builds need glibc 2.34 and uvr says so explicitly. #212 is what lets the CLI start here at all, so the failure is now a clear message instead of a linker error.",
+      "note": "The #209 image. UBI is the only RHEL testable without a subscription; it reports the same ID/VERSION_ID as subscribed RHEL, which is the axis under test. #212 is what lets the CLI start here at all, so the failure is now a clear message instead of a linker error. The portable R builds need glibc 2.34; this distro is below that floor, so the `expect` block above asserts uvr refuses with the #212 message rather than leaving the job permanently red.",
       "os_release": {
         "id": "rhel",
         "version_id": "8.10"
@@ -152,6 +160,10 @@
         "release": "8",
         "api": true,
         "local": true
+      },
+      "expect": {
+        "stage": "r",
+        "message": "is too old for portable R builds"
       }
     },
     {

--- a/crates/uvr-core/tests/distro_matrix.json
+++ b/crates/uvr-core/tests/distro_matrix.json
@@ -1,0 +1,583 @@
+{
+  "_comment": [
+    "Every Linux distribution uvr claims to work on, the image it is exercised in,",
+    "and what each of uvr's three distro-keyed axes must resolve to there.",
+    "",
+    "os_release is CAPTURED, never hand-written: run ci/capture-os-release.sh.",
+    "#209 was a hand-reasoned assumption that RHEL reports VERSION_ID=8, when it",
+    "reports 8.10 — a fixture invented at a desk would have made every offline",
+    "test pass while production stayed broken.",
+    "",
+    "sysreqs.api and sysreqs.local are separate booleans because the two sources",
+    "genuinely disagree: Posit's API serves rockylinux 9 but not 8, and serves no",
+    "fedora or alpine at all, while the vendored rules cover all of them.",
+    "",
+    "\"*\" means not asserted — rolling releases whose VERSION_ID changes on every",
+    "image rebuild.",
+    "",
+    "Verified 2026-07-31 against the live API and the vendored rules."
+  ],
+  "distros": [
+    {
+      "key": "ubuntu-2004",
+      "image": "docker.io/library/ubuntu:20.04",
+      "lane": "nightly",
+      "os_release": {
+        "id": "ubuntu",
+        "version_id": "20.04"
+      },
+      "p3m": {
+        "slug": "ubuntu-2004",
+        "codename": "focal"
+      },
+      "sysreqs": {
+        "distribution": "ubuntu",
+        "release": "20.04",
+        "api": true,
+        "local": true
+      }
+    },
+    {
+      "key": "ubuntu-2204",
+      "image": "docker.io/library/ubuntu:22.04",
+      "lane": "pr",
+      "os_release": {
+        "id": "ubuntu",
+        "version_id": "22.04"
+      },
+      "p3m": {
+        "slug": "ubuntu-2204",
+        "codename": "jammy"
+      },
+      "sysreqs": {
+        "distribution": "ubuntu",
+        "release": "22.04",
+        "api": true,
+        "local": true
+      }
+    },
+    {
+      "key": "ubuntu-2404",
+      "image": "docker.io/library/ubuntu:24.04",
+      "lane": "nightly",
+      "os_release": {
+        "id": "ubuntu",
+        "version_id": "24.04"
+      },
+      "p3m": {
+        "slug": "ubuntu-2404",
+        "codename": "noble"
+      },
+      "sysreqs": {
+        "distribution": "ubuntu",
+        "release": "24.04",
+        "api": true,
+        "local": true
+      }
+    },
+    {
+      "key": "debian-11",
+      "image": "docker.io/library/debian:11",
+      "lane": "nightly",
+      "os_release": {
+        "id": "debian",
+        "version_id": "11"
+      },
+      "p3m": {
+        "slug": "debian-11",
+        "codename": "bullseye"
+      },
+      "sysreqs": {
+        "distribution": "debian",
+        "release": "11",
+        "api": true,
+        "local": true
+      }
+    },
+    {
+      "key": "debian-12",
+      "image": "docker.io/library/debian:12",
+      "lane": "nightly",
+      "os_release": {
+        "id": "debian",
+        "version_id": "12"
+      },
+      "p3m": {
+        "slug": "debian-12",
+        "codename": "bookworm"
+      },
+      "sysreqs": {
+        "distribution": "debian",
+        "release": "12",
+        "api": true,
+        "local": true
+      }
+    },
+    {
+      "key": "debian-13",
+      "image": "docker.io/library/debian:13",
+      "lane": "nightly",
+      "os_release": {
+        "id": "debian",
+        "version_id": "13"
+      },
+      "p3m": {
+        "slug": "debian-13",
+        "codename": "trixie"
+      },
+      "sysreqs": {
+        "distribution": "debian",
+        "release": "13",
+        "api": true,
+        "local": true
+      }
+    },
+    {
+      "key": "rhel-8",
+      "image": "registry.access.redhat.com/ubi8:latest",
+      "lane": "pr",
+      "note": "The #209 image. UBI is the only RHEL testable without a subscription; it reports the same ID/VERSION_ID as subscribed RHEL, which is the axis under test.",
+      "os_release": {
+        "id": "rhel",
+        "version_id": "8.10"
+      },
+      "p3m": {
+        "slug": "rhel-8",
+        "codename": "centos8"
+      },
+      "sysreqs": {
+        "distribution": "redhat",
+        "release": "8",
+        "api": true,
+        "local": true
+      }
+    },
+    {
+      "key": "rhel-9",
+      "image": "registry.access.redhat.com/ubi9:latest",
+      "lane": "nightly",
+      "os_release": {
+        "id": "rhel",
+        "version_id": "9.8"
+      },
+      "p3m": {
+        "slug": "rhel-9",
+        "codename": "rhel9"
+      },
+      "sysreqs": {
+        "distribution": "redhat",
+        "release": "9",
+        "api": true,
+        "local": true
+      }
+    },
+    {
+      "key": "rhel-10",
+      "image": "registry.access.redhat.com/ubi10:latest",
+      "lane": "nightly",
+      "os_release": {
+        "id": "rhel",
+        "version_id": "10.2"
+      },
+      "p3m": {
+        "slug": "rhel-10",
+        "codename": "rhel10"
+      },
+      "sysreqs": {
+        "distribution": "redhat",
+        "release": "10",
+        "api": true,
+        "local": true
+      }
+    },
+    {
+      "key": "rocky-8",
+      "image": "docker.io/rockylinux/rockylinux:8",
+      "lane": "nightly",
+      "note": "api:false is real — Posit serves rockylinux 9 and 10 but not 8. Rocky 8 rides the local rules and reports a degraded check.",
+      "os_release": {
+        "id": "rocky",
+        "version_id": "8.10"
+      },
+      "p3m": {
+        "slug": "rhel-8",
+        "codename": "centos8"
+      },
+      "sysreqs": {
+        "distribution": "rockylinux",
+        "release": "8",
+        "api": false,
+        "local": true
+      }
+    },
+    {
+      "key": "rocky-9",
+      "image": "docker.io/rockylinux/rockylinux:9",
+      "lane": "pr",
+      "os_release": {
+        "id": "rocky",
+        "version_id": "9.8"
+      },
+      "p3m": {
+        "slug": "rhel-9",
+        "codename": "rhel9"
+      },
+      "sysreqs": {
+        "distribution": "rockylinux",
+        "release": "9",
+        "api": true,
+        "local": true
+      }
+    },
+    {
+      "key": "rocky-10",
+      "image": "docker.io/rockylinux/rockylinux:10",
+      "lane": "nightly",
+      "os_release": {
+        "id": "rocky",
+        "version_id": "10.2"
+      },
+      "p3m": {
+        "slug": "rhel-10",
+        "codename": "rhel10"
+      },
+      "sysreqs": {
+        "distribution": "rockylinux",
+        "release": "10",
+        "api": true,
+        "local": true
+      }
+    },
+    {
+      "key": "almalinux-8",
+      "image": "docker.io/library/almalinux:8",
+      "lane": "nightly",
+      "os_release": {
+        "id": "almalinux",
+        "version_id": "8.10"
+      },
+      "p3m": {
+        "slug": "rhel-8",
+        "codename": "centos8"
+      },
+      "sysreqs": {
+        "distribution": "rockylinux",
+        "release": "8",
+        "api": false,
+        "local": true
+      }
+    },
+    {
+      "key": "almalinux-9",
+      "image": "docker.io/library/almalinux:9",
+      "lane": "nightly",
+      "os_release": {
+        "id": "almalinux",
+        "version_id": "9.8"
+      },
+      "p3m": {
+        "slug": "rhel-9",
+        "codename": "rhel9"
+      },
+      "sysreqs": {
+        "distribution": "rockylinux",
+        "release": "9",
+        "api": true,
+        "local": true
+      }
+    },
+    {
+      "key": "almalinux-10",
+      "image": "docker.io/library/almalinux:10",
+      "lane": "nightly",
+      "os_release": {
+        "id": "almalinux",
+        "version_id": "10.2"
+      },
+      "p3m": {
+        "slug": "rhel-10",
+        "codename": "rhel10"
+      },
+      "sysreqs": {
+        "distribution": "rockylinux",
+        "release": "10",
+        "api": true,
+        "local": true
+      }
+    },
+    {
+      "key": "centos-stream9",
+      "image": "quay.io/centos/centos:stream9",
+      "lane": "nightly",
+      "note": "The API stops at centos 8, but the vendored rules carry version-less centos constraints, so Stream resolves locally with a degraded-check warning.",
+      "os_release": {
+        "id": "centos",
+        "version_id": "9"
+      },
+      "p3m": {
+        "slug": "centos-9",
+        "codename": "rhel9"
+      },
+      "sysreqs": {
+        "distribution": "centos",
+        "release": "9",
+        "api": false,
+        "local": true
+      }
+    },
+    {
+      "key": "centos-stream10",
+      "image": "quay.io/centos/centos:stream10",
+      "lane": "nightly",
+      "os_release": {
+        "id": "centos",
+        "version_id": "10"
+      },
+      "p3m": {
+        "slug": "centos-10",
+        "codename": "rhel10"
+      },
+      "sysreqs": {
+        "distribution": "centos",
+        "release": "10",
+        "api": false,
+        "local": true
+      }
+    },
+    {
+      "key": "oracle-8",
+      "image": "docker.io/library/oraclelinux:8",
+      "lane": "nightly",
+      "gap": "ID=ol maps nowhere on either axis: no P3M binaries and no sysreqs from either source. Same shape as #209, still open.",
+      "os_release": {
+        "id": "ol",
+        "version_id": "8.10"
+      },
+      "p3m": {
+        "slug": "ol-8.10",
+        "codename": null
+      },
+      "sysreqs": {
+        "distribution": "ol",
+        "release": "8.10",
+        "api": false,
+        "local": false
+      }
+    },
+    {
+      "key": "oracle-9",
+      "image": "docker.io/library/oraclelinux:9",
+      "lane": "nightly",
+      "gap": "See oracle-8.",
+      "os_release": {
+        "id": "ol",
+        "version_id": "9.8"
+      },
+      "p3m": {
+        "slug": "ol-9.8",
+        "codename": null
+      },
+      "sysreqs": {
+        "distribution": "ol",
+        "release": "9.8",
+        "api": false,
+        "local": false
+      }
+    },
+    {
+      "key": "opensuse-155",
+      "image": "docker.io/opensuse/leap:15.5",
+      "lane": "nightly",
+      "os_release": {
+        "id": "opensuse-leap",
+        "version_id": "15.5"
+      },
+      "p3m": {
+        "slug": "opensuse-155",
+        "codename": "opensuse155"
+      },
+      "sysreqs": {
+        "distribution": "opensuse",
+        "release": "15.5",
+        "api": true,
+        "local": true
+      }
+    },
+    {
+      "key": "opensuse-156",
+      "image": "docker.io/opensuse/leap:15.6",
+      "lane": "pr",
+      "os_release": {
+        "id": "opensuse-leap",
+        "version_id": "15.6"
+      },
+      "p3m": {
+        "slug": "opensuse-156",
+        "codename": "opensuse156"
+      },
+      "sysreqs": {
+        "distribution": "opensuse",
+        "release": "15.6",
+        "api": true,
+        "local": true
+      }
+    },
+    {
+      "key": "sles-156",
+      "image": "registry.suse.com/bci/bci-base:15.6",
+      "lane": "nightly",
+      "note": "SLES takes openSUSE's binaries but its own sysreqs vocabulary (sle). The two axes diverging here is deliberate, and is why they are asserted separately.",
+      "os_release": {
+        "id": "sles",
+        "version_id": "15.6"
+      },
+      "p3m": {
+        "slug": "opensuse-156",
+        "codename": "opensuse156"
+      },
+      "sysreqs": {
+        "distribution": "sle",
+        "release": "15.6",
+        "api": true,
+        "local": true
+      }
+    },
+    {
+      "key": "fedora-41",
+      "image": "docker.io/library/fedora:41",
+      "lane": "nightly",
+      "note": "Posit serves no fedora sysreqs at all; the vendored rules do. Binaries degrade to manylinux_2_28 by design (#175).",
+      "os_release": {
+        "id": "fedora",
+        "version_id": "41"
+      },
+      "p3m": {
+        "slug": "fedora-41",
+        "codename": null
+      },
+      "sysreqs": {
+        "distribution": "fedora",
+        "release": "41",
+        "api": false,
+        "local": true
+      }
+    },
+    {
+      "key": "fedora-42",
+      "image": "docker.io/library/fedora:42",
+      "lane": "nightly",
+      "os_release": {
+        "id": "fedora",
+        "version_id": "42"
+      },
+      "p3m": {
+        "slug": "fedora-42",
+        "codename": null
+      },
+      "sysreqs": {
+        "distribution": "fedora",
+        "release": "42",
+        "api": false,
+        "local": true
+      }
+    },
+    {
+      "key": "arch",
+      "image": "docker.io/library/archlinux:latest",
+      "lane": "pr",
+      "note": "Unmapped by design (#175): must degrade to manylinux_2_28, never claim to be Ubuntu. The image sets VERSION_ID to a rolling snapshot (a bare-metal Arch install sets none), so neither it nor the slug is asserted.",
+      "os_release": {
+        "id": "arch",
+        "version_id": "*"
+      },
+      "p3m": {
+        "slug": "*",
+        "codename": null
+      },
+      "sysreqs": {
+        "distribution": "arch",
+        "release": "*",
+        "api": false,
+        "local": false
+      }
+    },
+    {
+      "key": "alpine-320",
+      "image": "docker.io/library/alpine:3.20",
+      "lane": "nightly",
+      "os_release": {
+        "id": "alpine",
+        "version_id": "3.20.10"
+      },
+      "p3m": {
+        "slug": "alpine-3.20",
+        "codename": null
+      },
+      "sysreqs": {
+        "distribution": "alpine",
+        "release": "3.20.10",
+        "api": false,
+        "local": true
+      }
+    },
+    {
+      "key": "alpine-321",
+      "image": "docker.io/library/alpine:3.21",
+      "lane": "pr",
+      "note": "musl: the R build, the libc probe and the local-rules sysreqs path (#30) all differ here.",
+      "os_release": {
+        "id": "alpine",
+        "version_id": "3.21.7"
+      },
+      "p3m": {
+        "slug": "alpine-3.21",
+        "codename": null
+      },
+      "sysreqs": {
+        "distribution": "alpine",
+        "release": "3.21.7",
+        "api": false,
+        "local": true
+      }
+    },
+    {
+      "key": "alpine-322",
+      "image": "docker.io/library/alpine:3.22",
+      "lane": "nightly",
+      "os_release": {
+        "id": "alpine",
+        "version_id": "3.22.5"
+      },
+      "p3m": {
+        "slug": "alpine-3.22",
+        "codename": null
+      },
+      "sysreqs": {
+        "distribution": "alpine",
+        "release": "3.22.5",
+        "api": false,
+        "local": true
+      }
+    },
+    {
+      "key": "amazonlinux-2023",
+      "image": "docker.io/library/amazonlinux:2023",
+      "lane": "nightly",
+      "gap": "ID=amzn maps nowhere on either axis. Unlike Oracle it is not a RHEL rebuild uvr could alias onto an existing entry, so this one is a decision, not an oversight.",
+      "os_release": {
+        "id": "amzn",
+        "version_id": "2023"
+      },
+      "p3m": {
+        "slug": "amzn-2023",
+        "codename": null
+      },
+      "sysreqs": {
+        "distribution": "amzn",
+        "release": "2023",
+        "api": false,
+        "local": false
+      }
+    }
+  ]
+}

--- a/crates/uvr-core/tests/distro_matrix.json
+++ b/crates/uvr-core/tests/distro_matrix.json
@@ -519,13 +519,13 @@
         "api": false,
         "local": true
       },
-      "known_failure": "#207: CRAN PACKAGES carries no SystemRequirements, so the local-rules fallback resolves nothing — and the local rules are the only sysreqs source on Alpine. Reproduced by the sysreqs stage: xml2 fails to build with libxml2-dev never installed and no warning printed."
+      "note": "musl: no P3M repo exists, so the binary stage is skipped and the sysreqs local-rules path (#30) is the coverage. Fails today — libxml2-dev is never installed and no warning is printed, which is open issue #207."
     },
     {
       "key": "alpine-321",
       "image": "docker.io/library/alpine:3.21",
       "lane": "pr",
-      "note": "musl: the R build, the libc probe and the local-rules sysreqs path (#30) all differ here.",
+      "note": "musl: no P3M repo exists, so the binary stage is skipped and the sysreqs local-rules path (#30) is the coverage. Fails today — libxml2-dev is never installed and no warning is printed, which is open issue #207.",
       "os_release": {
         "id": "alpine",
         "version_id": "3.21.7"
@@ -539,8 +539,7 @@
         "release": "3.21.7",
         "api": false,
         "local": true
-      },
-      "known_failure": "#207: CRAN PACKAGES carries no SystemRequirements, so the local-rules fallback resolves nothing — and the local rules are the only sysreqs source on Alpine. Reproduced by the sysreqs stage: xml2 fails to build with libxml2-dev never installed and no warning printed."
+      }
     },
     {
       "key": "alpine-322",
@@ -560,7 +559,7 @@
         "api": false,
         "local": true
       },
-      "known_failure": "#207: CRAN PACKAGES carries no SystemRequirements, so the local-rules fallback resolves nothing — and the local rules are the only sysreqs source on Alpine. Reproduced by the sysreqs stage: xml2 fails to build with libxml2-dev never installed and no warning printed."
+      "note": "musl: no P3M repo exists, so the binary stage is skipped and the sysreqs local-rules path (#30) is the coverage. Fails today — libxml2-dev is never installed and no warning is printed, which is open issue #207."
     },
     {
       "key": "amazonlinux-2023",

--- a/docs/design/2026-07-31-distro-conformance-ci-design.md
+++ b/docs/design/2026-07-31-distro-conformance-ci-design.md
@@ -11,9 +11,9 @@ Catch the class of bug #209 belongs to: **uvr identifies the host under a name s
 third-party catalog doesn't use, and nothing notices until a user on that distro files
 an issue.**
 
-Concretely: compile and run uvr's full test suite natively inside every Linux
-distribution uvr claims to support, and assert the three distro-keyed mappings against
-the images themselves rather than against what we assume they report.
+Concretely: run the uvr binary users actually receive inside every Linux distribution
+uvr claims to support, and assert the three distro-keyed mappings against the images
+themselves rather than against what we assume they report.
 
 ## The bug class
 
@@ -134,7 +134,7 @@ ignore-list with a reason. The forward tests find *wrong* mappings; only this on
 *missing* ones — it is what surfaces "the catalog publishes `rockylinux` but nothing
 resolves to it".
 
-### Lane B — the full suite, natively, in every distro
+### Lane B — the shipped binary, in every distro
 
 `ci/distro-suite.sh`, run once per image:
 
@@ -146,30 +146,41 @@ docker run --rm -v "$PWD:/work" -w /work <image> sh ci/distro-suite.sh
 binary needing a glibc the musl and minimal images don't have. Checking out on the host
 and mounting the tree in gives **one shape that works for all 29 images**.
 
-Everything is compiled and executed with the distro's own toolchain against its own
-libc. Cross-compiling or shipping a static binary would test the build host, which is
-the opposite of the point.
+**Nothing is built inside the images.** Users don't `cargo build` uvr — `install.sh`
+drops a release binary on their machine — so the artifact under test is the one that
+ships. Both Linux targets are built once in a `build` job, handed to every image, and
+each container picks between them with the same rule `install.sh` applies:
+
+```sh
+libc=gnu
+if command -v ldd && ldd --version 2>&1 | grep -qi musl; then libc=musl
+elif [ -f /etc/alpine-release ]; then libc=musl; fi
+```
+
+so the *selection* is under test too, not just the binary. Compiling in each container
+would hide exactly the failures that matter: a gnu build whose glibc floor sits above
+what the distro ships, or a musl build chosen on a glibc host. A from-source build
+succeeds in both cases and tells you nothing — it is linked against the libc that is
+present by construction.
 
 Stages, in order:
 
-1. **prereqs** — compiler, TLS roots, fontconfig, libxml2 *runtime*. The one place
-   that knows package-manager dialects (apt/dnf/microdnf/zypper/apk/pacman/yum), so
-   adding a distro means adding a JSON entry, not a line of YAML. Notably absent:
-   libxml2's headers — their absence is what stage 6 tests.
-2. **rust** — rustup, or the distro's own rustup on musl so the toolchain links
-   against musl.
-3. **test** — `cargo build --all` then `cargo test --all`. Most of the suite is
-   distro-independent logic, but it is seconds once built and it is the only way to
-   reach the parts that aren't: package-manager probing (`sysreqs::filter_missing`),
-   shell activation, path and permission handling. `*_live.rs` stays `#[ignore]`d —
-   catalog conformance is its own job and must not make this one flaky.
-4. **r** — install R, then re-run the activation tests with it on PATH. They skip
-   during `cargo test` because no R existed yet; shell-specific cases self-skip when
-   their shell is absent, which is the common case in a minimal image.
-5. **binary** — install and `library()` the smoke package. #175: a binary from the
+1. **prereqs** — TLS roots, fontconfig, libxml2 *runtime*, and the tarball tools. The
+   one place that knows package-manager dialects (apt/dnf/microdnf/zypper/apk/pacman/
+   yum), so adding a distro means adding a JSON entry, not a line of YAML. Notably
+   absent: a compiler and libxml2's headers — the next three stages run on a bare
+   image precisely to prove the shipped binary needs neither.
+2. **version** — `uvr --version` and `--help`. One line, and it is the whole
+   glibc-floor question: a binary linked above this distro's glibc dies right here,
+   which is what a user hits seconds after running `install.sh`.
+3. **r** — install R and list it. Exercises the portable-build download, extract and
+   `R --version` validation on this distro's libc.
+4. **binary** — install and `library()` the smoke package. #175: a binary from the
    wrong distro's repo installs happily and only fails at load, so the assertion has
-   to load it, not just install it.
-6. **sysreqs** — the #209 regression test at the real end of the chain:
+   to load it. With no compiler present, an install that quietly falls back to a
+   source build fails here rather than passing for the wrong reason.
+5. **sysreqs** — the #209 regression test at the real end of the chain. Installs a
+   compiler first, since this is the stage that needs one:
 
    ```sh
    UVR_INSTALL_SYSREQS=1 uvr add xml2 --no-binary
@@ -216,12 +227,13 @@ the 20-job concurrency limit.
 | Lane | Per job | Jobs | Wall clock |
 |---|---|---|---|
 | A | < 1s | 1 (folded into `cargo test`) | none |
-| B, PR subset | ~8 min | 6 | ~8 min |
-| B, nightly | ~8 min | 29 | ~25 min at `max-parallel: 12` |
+| build | ~4 min | 1, cached, shared by all images | — |
+| B, PR subset | ~4 min | 6 | ~8 min including the build |
+| B, nightly | ~4 min | 29 | ~15 min at `max-parallel: 12` |
 
-Roughly 4 runner-hours nightly. No cargo cache is shared between distros on purpose:
-objects linked against one libc must never be picked up by another, so each container
-builds into its own `/tmp` target dir from scratch.
+Roughly 2 runner-hours nightly. Not compiling in the containers is most of why: each
+image does a package-manager install, an R download and one package build, and nothing
+else.
 
 ## Delivery
 
@@ -245,9 +257,12 @@ the suite locally — that `curl` is a package conflict on RHEL images shipping
 
 - **No VM-based testing.** Containers cover every axis here; a VM adds systemd and a
   kernel, neither of which uvr touches.
-- **No prebuilt or cross-compiled test binaries.** Shipping one static binary to 29
-  containers would be far faster and would test the build host's libc instead of the
-  distro's — the exact substitution this whole design exists to prevent.
+- **No from-source build inside the images, and no `cargo test` there either.** Almost
+  all of the Rust suite is distro-independent logic that cannot fail differently on
+  RHEL than on Ubuntu, and running it 29 times would cost more than the rest of the
+  matrix combined while testing a binary no user will ever run. The distro-sensitive
+  behaviour — libc floor, package-manager probing, catalog naming, R extraction — is
+  reachable from the CLI, which is also how users reach it.
 - **No auto-generation of the mapping tables from the catalogs.** Tempting, and wrong:
   the mapping encodes judgement (AlmaLinux takes Rocky's entries; SLES takes openSUSE's
   *binaries* but its own *sysreqs*) that a scraper would flatten. Tests that fail

--- a/docs/design/2026-07-31-distro-conformance-ci-design.md
+++ b/docs/design/2026-07-31-distro-conformance-ci-design.md
@@ -177,10 +177,36 @@ Stages, in order:
    which is what a user hits seconds after running `install.sh`.
 3. **r** — install R and list it. Exercises the portable-build download, extract and
    `R --version` validation on this distro's libc.
-4. **binary** — install and `library()` the smoke package. #175: a binary from the
+
+   Three entries — `rhel-8`, `ubuntu-2004`, `debian-11` — sit below the portable
+   builds' glibc 2.34 floor and *cannot* pass this stage. They carry an `expect`
+   block naming the stage and the substring uvr must print:
+
+   ```json
+   "expect": { "stage": "r", "message": "is too old for portable R builds" }
+   ```
+
+   The stage then asserts the refusal instead of dying on it, and stops — nothing
+   downstream can run without R. Asserting rather than skipping is the point: a
+   skipped stage hides the limitation, and a permanently-red job nobody reads is how
+   a real failure hides. This way the lane is green, the limitation stays visible,
+   and it turns red in *both* directions — if uvr stops refusing (the floor moved,
+   update the matrix) or refuses for some other reason (#212's message regressed
+   into something a user can't act on).
+4. **binary** — install and `library()` `BINARY_PKG`. #175: a binary from the
    wrong distro's repo installs happily and only fails at load, so the assertion has
    to load it. With no compiler present, an install that quietly falls back to a
    source build fails here rather than passing for the wrong reason.
+
+   `BINARY_PKG` is `jsonlite`, deliberately *not* the `SYSREQS_PKG` this stage used
+   to share. The subject here is repo **selection**, and P3M's Linux `PACKAGES`
+   index lists every package whether or not a binary was built — the binary-vs-source
+   choice happens at download time from the R User-Agent. So a recently released
+   version can be indexed everywhere and built only for the busiest repos, which
+   made this stage depend on Posit's build queue rather than on anything uvr or the
+   distro does. xml2 1.6.0 (released 2026-06-22) is the live example: a `jammy`
+   binary, and *source* on `opensuse156`, `bookworm`, `bullseye`, `focal` and
+   `centos7`. jsonlite is built for every repo in the matrix.
 5. **sysreqs** — the #209 regression test at the real end of the chain. Installs a
    compiler first, since this is the stage that needs one:
 
@@ -285,10 +311,27 @@ Bugs this design surfaced before any of it ran in CI, and where each landed:
 | Alpine resolves no sysreqs at all — CRAN's `PACKAGES` carries no `SystemRequirements` | #208, closing #207 — re-verified green |
 | R's `utils` calls `system(which ...)` in `.onLoad` and won't load without `which` | prerequisite here; `uvr doctor` could say so |
 | `curl` is a package *conflict* on RHEL images shipping `curl-minimal` | requested by command, not package |
+| uvr tells a zypper host to run `apt-get install -y libxml2-devel` — the same unconditional final branch as the row above, but reaching the user as an instruction that cannot work | open, needs its own issue |
+| `uvr add` **fails outright** when P3M serves source where the index promised a binary: the Linux `PACKAGES` index lists every package regardless of build coverage, so uvr announces "3 binary" and then rejects the download | open, needs its own issue |
 
 The first four are why this document's own matrix data had to be rewritten before
 merge: a matrix that describes gaps as open after they are closed is worse than no
 matrix, because it reads as authority.
+
+The last two are what the openSUSE lane found once the `DIST` path fix let it run past
+the first `$UVR` call. The second is the more serious: it is not openSUSE-specific and
+not a repo-selection miss. P3M decides binary-vs-source at *download* time from the R
+User-Agent, and its per-package build coverage lags for the quieter repos — so any
+host whose repo has not been built for a given package version gets a hard error
+instead of the source build it should fall back to. Verified against the live service:
+
+```
+xml2 1.6.0 (2026-06-22)   jammy=BINARY   opensuse156=source   bookworm=source
+jsonlite 2.0.0            jammy=BINARY   opensuse156=BINARY   bookworm=BINARY
+```
+
+That is why the binary stage moved to `jsonlite`: gating the suite on xml2 measured
+Posit's build queue, not uvr.
 
 ## What this deliberately does not do
 

--- a/docs/design/2026-07-31-distro-conformance-ci-design.md
+++ b/docs/design/2026-07-31-distro-conformance-ci-design.md
@@ -282,7 +282,7 @@ Bugs this design surfaced before any of it ran in CI, and where each landed:
 | Oracle Linux (`ID="ol"`) maps nowhere on the binary axis | #214 |
 | `rockylinux` 8 and `centos` 9/10 are not published under those names | #214 |
 | `pick_sysreqs_installer` knows only apk/dnf/apt-get, so `--install-system-deps` cannot work on openSUSE, SLES or Arch | open |
-| Alpine resolves no sysreqs at all — CRAN's `PACKAGES` carries no `SystemRequirements` | open (#207) |
+| Alpine resolves no sysreqs at all — CRAN's `PACKAGES` carries no `SystemRequirements` | #208, closing #207 — re-verified green |
 | R's `utils` calls `system(which ...)` in `.onLoad` and won't load without `which` | prerequisite here; `uvr doctor` could say so |
 | `curl` is a package *conflict* on RHEL images shipping `curl-minimal` | requested by command, not package |
 

--- a/docs/design/2026-07-31-distro-conformance-ci-design.md
+++ b/docs/design/2026-07-31-distro-conformance-ci-design.md
@@ -244,9 +244,28 @@ else.
    and is independently the thing to paste into a bug report.
 2. **`ci/distro-suite.sh` + `distro-suite.yml`, PR lane only** (6 images).
 3. **Nightly lane + drift-to-issue** across all 29.
-4. **`sysreqs_live.rs`**, folded into `test-p3m-repos` renamed `test-catalogs`: probe
-   the live API for every entry marked `api: true`. Catches Posit adding or retiring
-   releases, which the offline tests cannot see.
+4. **`catalog_live.rs`**, folded into `test-p3m-repos` renamed `test-catalogs`. Posit
+   publishes the whole supported-distro list as one documented, versioned endpoint —
+   `GET /__api__/status`, described in the OpenAPI spec at `/__api__/swagger/doc.json`
+   (spec version tracks the server build; `2026.06.0` at the time of writing). Each
+   entry carries `distribution`, `release`, `binaryURL`, `sysReqs`, `binaries`,
+   `hidden` and `arch`:
+
+   ```
+   rhel8    redhat      8     centos8         sysReqs=true  binaries=true   x86_64
+   rhel9    rockylinux  9     rhel9           sysReqs=true  binaries=true   x86_64,arm64
+   sles156  sle         15.6  opensuse156     sysReqs=true  binaries=true   x86_64
+   buster   debian      10    buster          sysReqs=true  binaries=false  x86_64
+   ```
+
+   One request replaces per-pair probing and answers questions probing cannot: which
+   repos are `hidden` (retired from the dropdown but still served — exactly what
+   `p3m_repos_live.rs` keeps mappings for), and which have arm64 builds.
+
+   Cross-checked against the 29 hand-set `sysreqs.api` flags in the matrix: **29/29
+   agree**, including the non-obvious ones (`rockylinux` 9 and 10 but not 8; no
+   `fedora` or `alpine` at any release). The flags can now be derived from the
+   endpoint rather than maintained.
 
 Bugs this design has already surfaced, before any of it runs in CI: the Oracle Linux
 gap, the zypper/pacman installer gap, the `rockylinux` 8 API gap, and — from running
@@ -263,9 +282,30 @@ the suite locally — that `curl` is a package conflict on RHEL images shipping
   matrix combined while testing a binary no user will ever run. The distro-sensitive
   behaviour — libc floor, package-manager probing, catalog naming, R extraction — is
   reachable from the CLI, which is also how users reach it.
-- **No auto-generation of the mapping tables from the catalogs.** Tempting, and wrong:
-  the mapping encodes judgement (AlmaLinux takes Rocky's entries; SLES takes openSUSE's
-  *binaries* but its own *sysreqs*) that a scraper would flatten. Tests that fail
-  loudly are the right mechanism; codegen would just move the guess.
-- **No arm64 distro matrix.** All three axes are arch-independent below the R-build
-  layer, which `ubuntu-24.04-arm` already covers.
+- **No auto-generation of the forward mapping from the catalogs.** The os-release →
+  catalog direction encodes judgement a scraper would flatten: AlmaLinux takes Rocky's
+  entries, and SLES takes openSUSE's *binaries* but its own *sysreqs* vocabulary —
+  which `/__api__/status` confirms, listing `sles156` as distribution `sle` release
+  `15.6` with `binaryURL: opensuse156`. That stays hand-written and loudly tested.
+
+  The *reverse* direction is a different matter: "what does Posit support that uvr
+  doesn't map?" is answered exactly by `/__api__/status`, so Lane A's coverage test
+  should read the endpoint rather than an ignore-list maintained by hand.
+- **No arm64 distro matrix** — with one caveat this design now knows about. The three
+  identification axes are arch-independent, which `ubuntu-24.04-arm` already covers.
+  But `/__api__/status` shows only `rhel9`, `rhel10`, `noble`, `resolute` and
+  `manylinux_2_28` carry arm64 builds, and P3M routes by the R User-Agent: an arm64
+  host asking `jammy` is served **source**, while `manylinux_2_28` would have served
+  it an arm64 **binary**.
+
+  ```
+  jammy          aarch64  source  (no arm64 build)
+  manylinux_2_28 aarch64  BINARY  bin/4.5-manylinux_2_28-arm64
+  ```
+
+  uvr's slug → codename map has no arch dimension, so on arm64 Ubuntu 22.04, Debian
+  12, RHEL 8 or openSUSE it prefers a distro repo with no arm64 build and compiles
+  everything, when the portable repo would have handed it binaries. Not wrong — P3M
+  degrades to source rather than serving the wrong architecture, so nothing breaks the
+  way #175 did — but slow, and invisible. Worth its own issue; an arm64 lane in this
+  matrix is what would keep it honest.

--- a/docs/design/2026-07-31-distro-conformance-ci-design.md
+++ b/docs/design/2026-07-31-distro-conformance-ci-design.md
@@ -1,0 +1,256 @@
+# Distro conformance CI — design
+
+Status: proposed
+Author: gdevenyi
+Date: 2026-07-31
+Motivating bugs: #209 (RHEL gets no system dependencies), #175 (wrong binary repo on Arch)
+
+## Goal
+
+Catch the class of bug #209 belongs to: **uvr identifies the host under a name some
+third-party catalog doesn't use, and nothing notices until a user on that distro files
+an issue.**
+
+Concretely: compile and run uvr's full test suite natively inside every Linux
+distribution uvr claims to support, and assert the three distro-keyed mappings against
+the images themselves rather than against what we assume they report.
+
+## The bug class
+
+uvr maps `/etc/os-release` onto three *independent* third-party vocabularies:
+
+| Axis | Code path | Vocabulary | Coverage before this work |
+|---|---|---|---|
+| R interpreter build | libc + arch detection | manylinux / musllinux | good — `test`, `test-musl`, `test-musl-arm64` |
+| P3M binary packages | `detect_posit_distro_slug_from_os_release` → `ppm_linux_codename` | PPM codename (`jammy`, `rhel9`) | partial — `test-p3m-repos`, `test-distros` (4 images) |
+| System dependencies | `detect_linux_distro` → Posit sysreqs API + vendored rules | Posit sysreqs (`redhat`, `rockylinux`, `sle`) | **none** |
+
+Axis 1 is distro-independent, which is why it has never broken this way. Axes 2 and 3
+name the same host differently (`rhel-8` vs `redhat-8`), live in two separate match
+statements (`r_version/downloader.rs:288` and `sysreqs.rs::normalize_distro`), and no
+test compares them. #175 was axis 2. #209 was axis 3. There will be a third.
+
+Two failure modes, and the design has to cover both:
+
+- **Wrong name** — uvr asks under a name the catalog doesn't publish (`rhel` vs
+  `redhat`). Detectable offline.
+- **Wrong input** — uvr's idea of what a host reports doesn't match what it actually
+  reports (`VERSION_ID=8.10`, not `8`). *Only a real image can say.* This is the half
+  that let #209 survive: a hand-written fixture saying `VERSION_ID="8"` makes every
+  offline test pass while production stays broken.
+
+Everything below follows from that second point: **fixtures are captured, never
+reasoned about.**
+
+## What the images actually report
+
+Captured 2026-07-31 with `ci/capture-os-release.sh`, and each resulting pair probed
+against the live sysreqs API and the vendored rules. Findings that no desk-designed
+matrix would have produced:
+
+- **Oracle Linux is unmapped on both axes.** `oraclelinux:8` reports `ID="ol"`,
+  `VERSION_ID="8.10"` → slug `ol-8.10` → no P3M codename, and `("ol","8.10")` → no
+  local rules. Oracle users get neither binaries nor sysreqs. Same shape as #209,
+  still open. Two lines fix it (`"ol"` alongside `"rhel"` in both tables).
+- **The two sysreqs sources disagree about coverage.** The API serves `rockylinux` 9
+  and 10 but *not* 8; it serves no `fedora` at any release, and no `alpine` — all of
+  which the vendored rules do cover. So the table records `api` and `local` as separate
+  booleans, and a test that treats `systems.json` as a proxy for what the API serves
+  would be wrong in both directions.
+- **CentOS Stream is covered after all.** The API rejects `centos` 9 and 10, but the
+  vendored rules carry version-less `centos` constraints, so `resolve_local` returns
+  `libxml2-devel` for both. Stream users get local-rule results with a degraded-check
+  warning, not silence. (This corrects an earlier reading of the gap.)
+- **Arch in a container reports a version.** `archlinux:latest` sets
+  `VERSION_ID="20260726.0.562117"`; a bare-metal Arch install sets none. The
+  "rolling releases publish no version" reasoning in `detect_linux_distro` is right for
+  the metal and wrong for the image, so Arch reaches the API as
+  `arch`/`20260726.0.562117` rather than being skipped early. Harmless today — but it
+  is asserted as `"*"` in the matrix rather than pinned, since it changes on every
+  image rebuild.
+- **`pick_sysreqs_installer` knows only apk/dnf/apt-get.** On openSUSE, SLES and Arch
+  it falls through to `apt-get`, which isn't installed. `--install-system-deps` cannot
+  work there. Surfaced by writing the suite, not by reading the code.
+
+## Design
+
+One captured table, three assertions, two lanes.
+
+### The table — `crates/uvr-core/tests/distro_matrix.json`
+
+29 entries. Every distro uvr supports, the image it is exercised in, its verbatim
+os-release identity, and the expected output of all three axes:
+
+```json
+{
+  "key": "rhel-8",
+  "image": "registry.access.redhat.com/ubi8:latest",
+  "lane": "pr",
+  "os_release": { "id": "rhel", "version_id": "8.10" },
+  "p3m": { "slug": "rhel-8", "codename": "centos8" },
+  "sysreqs": { "distribution": "redhat", "release": "8", "api": true, "local": true }
+}
+```
+
+`null` on `p3m.codename` or `false` on both sysreqs sources means *not covered*, and
+carries a `gap` or `note` field explaining whether that is a decision or an open bug —
+so "this distro is unsupported" is recorded in review rather than looking identical to
+an oversight.
+
+JSON rather than a Rust `const` (which `p3m_repos_live.rs` uses today) for one reason:
+the GitHub Actions matrix is generated from it with `jq`, in a job that needs no Rust
+toolchain and no compile step. The Rust tests read it with `include_str!` +
+`serde_json`, both already dependencies.
+
+### Lane A — offline conformance (every PR, < 1s, no network)
+
+Three tests in `crates/uvr-core/tests/distro_conformance.rs`, all pure functions over
+files already in the repo.
+
+**A1 — sysreqs resolve.** For every entry with `sysreqs.local`, the normalized pair
+must actually resolve against the vendored rules:
+
+```rust
+let (d, r) = normalize_distro(&e.os_release.id, &e.os_release.version_id);
+assert_eq!((d.as_str(), r.as_str()), (e.sysreqs.distribution, e.sysreqs.release));
+assert!(
+    !sysreqs_rules::resolve_local("libxml2 (>= 2.6.3)", &d, &r).is_empty(),
+    "{}: normalized to {d}/{r}, which matches no vendored rule",
+    e.key
+);
+```
+
+Asserting through `resolve_local` rather than against `systems.json` membership is
+deliberate — it uses the crate's own version-matching semantics, so Alpine's
+`3.21.7` → `3.21` truncation is exercised rather than false-failing. This is the test
+that would have caught #209 on the day it was written.
+
+**A2 — P3M.** Same shape: `detect_posit_distro_slug_from_os_release` must produce
+`p3m.slug` and `ppm_linux_codename` must produce `p3m.codename`.
+
+**A3 — reverse coverage.** Every distribution/version in `systems.json` and every slug
+in `ppm_linux_codename` must be reachable from some table entry, or be on an explicit
+ignore-list with a reason. The forward tests find *wrong* mappings; only this one finds
+*missing* ones — it is what surfaces "the catalog publishes `rockylinux` but nothing
+resolves to it".
+
+### Lane B — the full suite, natively, in every distro
+
+`ci/distro-suite.sh`, run once per image:
+
+```
+docker run --rm -v "$PWD:/work" -w /work <image> sh ci/distro-suite.sh
+```
+
+`docker run` rather than a `container:` job because `actions/checkout` runs a node
+binary needing a glibc the musl and minimal images don't have. Checking out on the host
+and mounting the tree in gives **one shape that works for all 29 images**.
+
+Everything is compiled and executed with the distro's own toolchain against its own
+libc. Cross-compiling or shipping a static binary would test the build host, which is
+the opposite of the point.
+
+Stages, in order:
+
+1. **prereqs** — compiler, TLS roots, fontconfig, libxml2 *runtime*. The one place
+   that knows package-manager dialects (apt/dnf/microdnf/zypper/apk/pacman/yum), so
+   adding a distro means adding a JSON entry, not a line of YAML. Notably absent:
+   libxml2's headers — their absence is what stage 6 tests.
+2. **rust** — rustup, or the distro's own rustup on musl so the toolchain links
+   against musl.
+3. **test** — `cargo build --all` then `cargo test --all`. Most of the suite is
+   distro-independent logic, but it is seconds once built and it is the only way to
+   reach the parts that aren't: package-manager probing (`sysreqs::filter_missing`),
+   shell activation, path and permission handling. `*_live.rs` stays `#[ignore]`d —
+   catalog conformance is its own job and must not make this one flaky.
+4. **r** — install R, then re-run the activation tests with it on PATH. They skip
+   during `cargo test` because no R existed yet; shell-specific cases self-skip when
+   their shell is absent, which is the common case in a minimal image.
+5. **binary** — install and `library()` the smoke package. #175: a binary from the
+   wrong distro's repo installs happily and only fails at load, so the assertion has
+   to load it, not just install it.
+6. **sysreqs** — the #209 regression test at the real end of the chain:
+
+   ```sh
+   UVR_INSTALL_SYSREQS=1 uvr add xml2 --no-binary
+   uvr run check.R
+   ```
+
+   The image has libxml2's runtime but not its headers, so this compiles only if every
+   link works: os-release parse → catalog naming → package-manager probe → installer
+   dialect. Nothing greps a warning string; the build either succeeds or it doesn't.
+   That is exactly what #209 broke — RHEL asked under a name Posit doesn't publish, got
+   nothing, installed nothing, and the build failed.
+
+   On zypper/pacman hosts, where `pick_sysreqs_installer` can't run the install, the
+   stage asserts the *diagnosis* instead (uvr named `libxml2-devel`) and still fails if
+   uvr printed "System dependency check skipped".
+
+**Identity check.** After the suite, the workflow re-reads `/etc/os-release` from the
+image and compares it to the matrix entry. Cheap, and it is what keeps Lane A honest —
+a fixture nobody re-checks is how #209 survived.
+
+### Lanes and triggers
+
+| Trigger | Images | Why |
+|---|---|---|
+| every PR | Lane A only | free, catches everything offline-detectable |
+| PR touching `sysreqs*.rs`, `p3m.rs`, `downloader.rs`, `os_release.rs`, the vendored rules, or the matrix | 6 `lane: "pr"` images | one per package-manager dialect plus musl: ubuntu-2204, rhel-8, rocky-9, opensuse-156, arch, alpine-321 |
+| nightly cron | all 29 | upstream drift, catalog drift |
+| `workflow_dispatch` | any subset by key | debugging a specific distro |
+
+`fail-fast: false` — every distro is an independent question and one answer must not
+suppress the other 28. `max-parallel: 12` keeps the nightly from monopolising the
+runner pool.
+
+**Nightly failures open an issue rather than turning the tree red.** `rockylinux:9` was
+9.3 and is now 9.8; `redhat/ubi8` will one day report 8.11. Upstream images moving is a
+maintenance ticket, not a broken build, and a red main branch that nobody caused is a
+red branch everyone learns to ignore.
+
+## Cost
+
+Public repo, so standard-runner minutes are free; the constraints are wall clock and
+the 20-job concurrency limit.
+
+| Lane | Per job | Jobs | Wall clock |
+|---|---|---|---|
+| A | < 1s | 1 (folded into `cargo test`) | none |
+| B, PR subset | ~8 min | 6 | ~8 min |
+| B, nightly | ~8 min | 29 | ~25 min at `max-parallel: 12` |
+
+Roughly 4 runner-hours nightly. No cargo cache is shared between distros on purpose:
+objects linked against one libc must never be picked up by another, so each container
+builds into its own `/tmp` target dir from scratch.
+
+## Delivery
+
+1. **`distro_matrix.json` + `ci/capture-os-release.sh` + Lane A + `uvr doctor --json`.**
+   No CI cost, no network, closes the offline-detectable half. `doctor` currently prints
+   the P3M slug inside coloured prose and says nothing about the sysreqs identity, so
+   `--json` is what lets any later job assert on axis 3 without grepping ANSI output —
+   and is independently the thing to paste into a bug report.
+2. **`ci/distro-suite.sh` + `distro-suite.yml`, PR lane only** (6 images).
+3. **Nightly lane + drift-to-issue** across all 29.
+4. **`sysreqs_live.rs`**, folded into `test-p3m-repos` renamed `test-catalogs`: probe
+   the live API for every entry marked `api: true`. Catches Posit adding or retiring
+   releases, which the offline tests cannot see.
+
+Bugs this design has already surfaced, before any of it runs in CI: the Oracle Linux
+gap, the zypper/pacman installer gap, the `rockylinux` 8 API gap, and — from running
+the suite locally — that `curl` is a package conflict on RHEL images shipping
+`curl-minimal`, so tools must be requested by command rather than by package name.
+
+## What this deliberately does not do
+
+- **No VM-based testing.** Containers cover every axis here; a VM adds systemd and a
+  kernel, neither of which uvr touches.
+- **No prebuilt or cross-compiled test binaries.** Shipping one static binary to 29
+  containers would be far faster and would test the build host's libc instead of the
+  distro's — the exact substitution this whole design exists to prevent.
+- **No auto-generation of the mapping tables from the catalogs.** Tempting, and wrong:
+  the mapping encodes judgement (AlmaLinux takes Rocky's entries; SLES takes openSUSE's
+  *binaries* but its own *sysreqs*) that a scraper would flatten. Tests that fail
+  loudly are the right mechanism; codegen would just move the guess.
+- **No arm64 distro matrix.** All three axes are arch-independent below the R-build
+  layer, which `ubuntu-24.04-arm` already covers.

--- a/docs/design/2026-07-31-distro-conformance-ci-design.md
+++ b/docs/design/2026-07-31-distro-conformance-ci-design.md
@@ -50,8 +50,9 @@ matrix would have produced:
 
 - **Oracle Linux is unmapped on both axes.** `oraclelinux:8` reports `ID="ol"`,
   `VERSION_ID="8.10"` → slug `ol-8.10` → no P3M codename, and `("ol","8.10")` → no
-  local rules. Oracle users get neither binaries nor sysreqs. Same shape as #209,
-  still open. Two lines fix it (`"ol"` alongside `"rhel"` in both tables).
+  local rules. Oracle users got neither binaries nor sysreqs. Same shape as #209,
+  and fixed the same way: `"ol"` alongside `"rhel"` in both tables — the sysreqs
+  half in #209, the binary half in #214.
 - **The two sysreqs sources disagree about coverage.** The API serves `rockylinux` 9
   and 10 but *not* 8; it serves no `fedora` at any release, and no `alpine` — all of
   which the vendored rules do cover. So the table records `api` and `local` as separate
@@ -148,7 +149,8 @@ and mounting the tree in gives **one shape that works for all 29 images**.
 
 **Nothing is built inside the images.** Users don't `cargo build` uvr — `install.sh`
 drops a release binary on their machine — so the artifact under test is the one that
-ships. Both Linux targets are built once in a `build` job, handed to every image, and
+ships. Both Linux targets are built once in a `build` job, through the same
+`ci/build-linux-gnu.sh` the release workflow uses (#212), then handed to every image;
 each container picks between them with the same rule `install.sh` applies:
 
 ```sh
@@ -244,7 +246,11 @@ else.
    and is independently the thing to paste into a bug report.
 2. **`ci/distro-suite.sh` + `distro-suite.yml`, PR lane only** (6 images).
 3. **Nightly lane + drift-to-issue** across all 29.
-4. **`catalog_live.rs`**, folded into `test-p3m-repos` renamed `test-catalogs`. Posit
+4. **`catalog_live.rs`**, folded into `test-p3m-repos` renamed `test-catalogs`.
+   Partly delivered: #213 reads this endpoint at runtime and ships
+   `p3m_status_live.rs`, which asserts the compiled-in table still agrees with it.
+   What remains here is the *reverse* coverage direction — what Posit supports that
+   uvr does not map. Posit
    publishes the whole supported-distro list as one documented, versioned endpoint —
    `GET /__api__/status`, described in the OpenAPI spec at `/__api__/swagger/doc.json`
    (spec version tracks the server build; `2026.06.0` at the time of writing). Each
@@ -267,10 +273,22 @@ else.
    `fedora` or `alpine` at any release). The flags can now be derived from the
    endpoint rather than maintained.
 
-Bugs this design has already surfaced, before any of it runs in CI: the Oracle Linux
-gap, the zypper/pacman installer gap, the `rockylinux` 8 API gap, and — from running
-the suite locally — that `curl` is a package conflict on RHEL images shipping
-`curl-minimal`, so tools must be requested by command rather than by package name.
+Bugs this design surfaced before any of it ran in CI, and where each landed:
+
+| Found | Fixed in |
+|---|---|
+| the published binary needs `GLIBC_2.34` and will not start on RHEL 8, Debian 11 or Ubuntu 20.04 | #212 |
+| P3M repo selection has no arch dimension, so arm64 hosts on x86_64-only distros compile everything | #213 |
+| Oracle Linux (`ID="ol"`) maps nowhere on the binary axis | #214 |
+| `rockylinux` 8 and `centos` 9/10 are not published under those names | #214 |
+| `pick_sysreqs_installer` knows only apk/dnf/apt-get, so `--install-system-deps` cannot work on openSUSE, SLES or Arch | open |
+| Alpine resolves no sysreqs at all — CRAN's `PACKAGES` carries no `SystemRequirements` | open (#207) |
+| R's `utils` calls `system(which ...)` in `.onLoad` and won't load without `which` | prerequisite here; `uvr doctor` could say so |
+| `curl` is a package *conflict* on RHEL images shipping `curl-minimal` | requested by command, not package |
+
+The first four are why this document's own matrix data had to be rewritten before
+merge: a matrix that describes gaps as open after they are closed is worse than no
+matrix, because it reads as authority.
 
 ## What this deliberately does not do
 
@@ -303,9 +321,10 @@ the suite locally — that `curl` is a package conflict on RHEL images shipping
   manylinux_2_28 aarch64  BINARY  bin/4.5-manylinux_2_28-arm64
   ```
 
-  uvr's slug → codename map has no arch dimension, so on arm64 Ubuntu 22.04, Debian
-  12, RHEL 8 or openSUSE it prefers a distro repo with no arm64 build and compiles
+  uvr's slug → codename map had no arch dimension, so on arm64 Ubuntu 22.04, Debian
+  12, RHEL 8 or openSUSE it preferred a distro repo with no arm64 build and compiled
   everything, when the portable repo would have handed it binaries. Not wrong — P3M
-  degrades to source rather than serving the wrong architecture, so nothing breaks the
-  way #175 did — but slow, and invisible. Worth its own issue; an arm64 lane in this
-  matrix is what would keep it honest.
+  degrades to source rather than serving the wrong architecture, so nothing broke the
+  way #175 did — but slow, and invisible. #213 fixes the selection by reading the
+  catalog's `arch` field; an arm64 lane in this matrix is what would keep it honest,
+  and remains unbuilt.

--- a/docs/design/2026-07-31-distro-conformance-ci-design.md
+++ b/docs/design/2026-07-31-distro-conformance-ci-design.md
@@ -311,8 +311,8 @@ Bugs this design surfaced before any of it ran in CI, and where each landed:
 | Alpine resolves no sysreqs at all — CRAN's `PACKAGES` carries no `SystemRequirements` | #208, closing #207 — re-verified green |
 | R's `utils` calls `system(which ...)` in `.onLoad` and won't load without `which` | prerequisite here; `uvr doctor` could say so |
 | `curl` is a package *conflict* on RHEL images shipping `curl-minimal` | requested by command, not package |
-| uvr tells a zypper host to run `apt-get install -y libxml2-devel` — the same unconditional final branch as the row above, but reaching the user as an instruction that cannot work | open, needs its own issue |
-| `uvr add` **fails outright** when P3M serves source where the index promised a binary: the Linux `PACKAGES` index lists every package regardless of build coverage, so uvr announces "3 binary" and then rejects the download | open, needs its own issue |
+| uvr tells a zypper host to run `apt-get install -y libxml2-devel` — the same unconditional final branch as the row above, but reaching the user as an instruction that cannot work; `uvr doctor` hardcodes it too | #226 |
+| `uvr add` **fails outright** when P3M serves source where the index promised a binary: the Linux `PACKAGES` index lists every package regardless of build coverage, so uvr announces "3 binary" and then rejects the download | #225 |
 
 The first four are why this document's own matrix data had to be rewritten before
 merge: a matrix that describes gaps as open after they are closed is worse than no


### PR DESCRIPTION
**Stack position: merge last.** Merge order is #213 → #215 → #216 → #211. All four are rebased on `bacdfe5` and #212/#214 have landed, so nothing borrows another branch's commits any more. Verified by merging all four in that order: the only collision in the stack is the `## Unreleased` changelog anchor between #215 and #216, where both sides append. `cargo test --all` 563 passed, clippy clean, fmt clean. #211 goes last because its matrix data and design doc describe the world *after* #213 lands — the findings table credits it by number. A doc that claims delivered what is not yet merged reads as authority the same way a stale gap does.

Follows #209 / #175. Design doc: `docs/design/2026-07-31-distro-conformance-ci-design.md`.

## Why

uvr maps `/etc/os-release` onto three *independent* third-party vocabularies, and they name the same host differently:

| Axis | Path | Vocabulary |
|---|---|---|
| R interpreter build | libc + arch | manylinux / musllinux |
| P3M binary packages | `detect_posit_distro_slug_from_os_release` → `ppm_linux_codename` | `rhel-8` → `centos8` |
| System dependencies | `detect_linux_distro` → API + vendored rules | `redhat`/`8` |

Axis 1 is distro-independent, which is why it has never broken this way. Axes 2 and 3 live in two separate match statements that no test compares. #175 was axis 2, #209 was axis 3, and neither was reachable from a test running on `ubuntu-latest` — the only thing that knows what a distro reports is that distro.

## What

29 distributions, matrix generated from `crates/uvr-core/tests/distro_matrix.json`. Each image gets the **binary that ships** — nothing is built inside the containers — and then runs `uvr --version`, `doctor`, `r install`, a binary package install + `library()` load, and a source build that needs system dependencies resolved.

Both Linux targets are built once — the gnu one through the same `ci/build-linux-gnu.sh` the release workflow uses (#212) — and handed to every image; each container picks between them with the same rule `install.sh` applies, so the selection is under test too. Building the artifact under test differently from the artifact that ships is the exact substitution this workflow exists to catch. Building in the container would hide the failures that matter most: a build made there links against the libc that is present by construction, so a glibc floor above what the distro ships can never show up.

`docker run` with the tree mounted rather than a `container:` job: `actions/checkout` needs a glibc the musl and minimal images don't have, so this is one shape that works for all 29. Package-manager dialects (apt/dnf/microdnf/zypper/apk/pacman/yum) live in one function in `ci/distro-suite.sh`, so adding a distro is a JSON entry, not a line of YAML.

## It fails today, on three supported distros

The published v0.4.4 `x86_64-unknown-linux-gnu` asset does not start on Ubuntu 20.04, Debian 11 or UBI 8:

```
/s/uvr: /lib64/libc.so.6: version `GLIBC_2.34' not found (required by /s/uvr)
```

All three are distros uvr otherwise supports — P3M publishes `focal`, `bullseye` and `centos8` binaries, and the sysreqs catalog covers all three. The **musl asset runs on all three**, so `install.sh` handing glibc hosts the gnu build is what strands them. Worth fixing separately (raise the gnu build's floor, or fall back to musl when the gnu binary won't exec); this PR is the thing that notices.

## The #209 assertion

The images carry libxml2's runtime library but not its headers, so

```sh
UVR_INSTALL_SYSREQS=1 uvr add xml2 --no-binary
```

compiles only if the os-release parse, the catalog naming, the package-manager probe and the installer dialect are all right for that distro.

Verified locally against `rockylinux:9`, same assertion, both sides of the fix:

```
pre-#210   exit=1   fatal error: libxml/tree.h: No such file or directory
post-#210  exit=0   ⚠ xml2 needs: libxml2-devel → dnf install -y libxml2-devel → sysreqs-smoke-ok
```

The published v0.4.4 binary is on the failing side of that line — it predates #210, which is now on main — so the stage reproduces #209 against a real released artifact.

Worth noting the failing run printed **no warning at all**, not even "System dependency check skipped". An assertion that greps for that message would have passed it clean. Only doing the install for real caught it.

## Fixtures are captured, never written

`os_release` values come from `ci/capture-os-release.sh`, and the workflow re-checks them against the image on every run. #209 was a reasoned-about fixture — RHEL reports `VERSION_ID=8.10`, not `8` — and a table written at a desk makes every offline test pass while production stays broken.

Capturing them turned up three things the code gets wrong today. They are recorded in the matrix rather than fixed here:

- **Oracle Linux mapped nowhere on either axis.** `oraclelinux:8` reports `ID="ol"` → slug `ol-8.10` → no P3M codename, and `("ol","8.10")` → no local rules. Fixed since: sysreqs in #209, binaries in #214, and this matrix now carries the RHEL slug, codename and sysreqs pair for it rather than nulls.
- **The two sysreqs sources disagree about coverage.** The API serves `rockylinux` 9 and 10 but not 8, and serves no `fedora` or `alpine` at any release, all of which the vendored rules cover. Tracked as separate `api` / `local` booleans.
- **`pick_sysreqs_installer` knows only apk/dnf/apt-get.** On openSUSE, SLES and Arch it falls through to `apt-get`, which isn't installed, so `--install-system-deps` can't work there. Those distros assert the diagnosis instead of the install.

Two smaller ones: `archlinux:latest` sets `VERSION_ID` to a rolling snapshot (a bare-metal Arch install sets none), so it is matched as `"*"` rather than pinned; and `curl` is a package *conflict* on RHEL images shipping `curl-minimal`, so tools are requested by command rather than by package name.

Dropping the compiler from the base image — closer to what a real user has — turned up two more. R's `utils` calls `system(which ...)` in `.onLoad` and fails to load without `which`, which the minimal RPM images don't ship; arguably `uvr doctor` should say so. And Alpine's `build-base` ships no `pkgconf`, which R's anticonf configure scripts need to find `libxml-2.0` — without it the source build fails for a second, unrelated reason and hides the first.

## Cost

| Trigger | Images | Wall clock |
|---|---|---|
| PR touching `sysreqs*.rs`, `p3m.rs`, `downloader.rs`, `os_release.rs`, the vendored rules or the matrix | 6 (`lane: "pr"` — one per package-manager dialect plus musl) | ~8 min including the shared build |
| nightly cron | 29 | ~15 min at `max-parallel: 12` |
| `workflow_dispatch` | any subset by key | — |

Free minutes on a public repo. `fail-fast: false`, since every distro is an independent question. Nightly failures open an issue rather than turning the tree red: upstream images drift on their own schedule (`rockylinux:9` was 9.3, is now 9.8) and a red main nobody caused is a red main everyone ignores.

## Alpine reproduces open issue #207

The musl path found two things the glibc images couldn't.

The binary stage cannot apply on musl at all — P3M publishes no musl repo and the portable manylinux fallback needs glibc, so `uvr add` correctly compiles from source, on an image that deliberately has no compiler yet. musl hosts now skip that stage; their coverage is the sysreqs path, which is what #30 was about.

With that out of the way, the sysreqs stage fails on Alpine, and not because of this suite: `libxml2-dev` is never installed and uvr prints **no warning at all**. That is #207 — CRAN's `PACKAGES` carries no `SystemRequirements`, and on Alpine the local rules are the only sysreqs source, so the fallback has nothing to match. (#209's report assumed #207 was already fixed. It isn't.)

**These jobs fail red, deliberately.** A matrix whose job is to tell you which distros are broken should say so in the only way CI says anything. The Alpine entries carry a note pointing at #207 so whoever sees the red job knows what they're looking at, and the failure blocks like any other until #207 lands.

Verified on `alpine:3.21` with a musl binary built from main: `install.sh`'s rule picks the musl asset, `uvr --version`, `doctor` and the R install all pass, and the sysreqs stage fails exactly as #207 describes.

## Relationship to the other three PRs

This matrix is what found the problems the other three fix, so its data had to be realigned before merge — a matrix that describes gaps as open after they are closed reads as authority while being wrong.

| Row | Then | Now |
|---|---|---|
| `oracle-8`, `oracle-9` | `gap`, null codename, `ol`/`8.10` | `rhel-8` → `centos8`, sysreqs `redhat`/`8` (#209 + #214) |
| `rocky-8`, `almalinux-8`, `centos-stream9/10` | `api: false` | unchanged — still the catalog fact — with a note that #214 asks under the RHEL name, and that the vendored rules deliberately keep the unaliased one |
| `rhel-8`, `ubuntu-2004`, `debian-11` | — | noted as expected to fail at `uvr r install`: portable R needs glibc 2.34. #212 is what lets the CLI start there at all |

Left deliberately failing: those three at `r install`, and the three Alpine entries at sysreqs (#207). Both are real, and both are the matrix doing its job.

## Not in this PR

The offline half of the design — `distro_conformance.rs` and `uvr doctor --json` — which catches everything offline-detectable in under a second with no containers. Happy to add it here or send it separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PkvRyFs8awBe4nHFjcvoa2

