### PR TITLE
release: pin the Linux glibc floor at 2.28 instead of inheriting the runner's

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,10 +22,16 @@ jobs:
             os: macos-latest
           - target: x86_64-apple-darwin
             os: macos-latest
+          # Built through ci/build-linux-gnu.sh, which pins the glibc floor
+          # instead of inheriting the runner's. The runner version no longer
+          # matters, which is the point — ubuntu-22.04 was chosen to keep the
+          # floor down and still shipped a binary needing GLIBC_2.34.
           - target: x86_64-unknown-linux-gnu
-            os: ubuntu-22.04
+            os: ubuntu-latest
+            zigbuild: true
           - target: aarch64-unknown-linux-gnu
-            os: ubuntu-22.04
+            os: ubuntu-latest
+            zigbuild: true
           - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
           - target: aarch64-unknown-linux-musl
@@ -41,13 +47,6 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
-
-      - name: Install cross-compilation tools (Linux ARM64)
-        if: matrix.target == 'aarch64-unknown-linux-gnu'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu
-          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
 
       - name: Install MUSL toolchain
         if: matrix.target == 'x86_64-unknown-linux-musl'
@@ -68,7 +67,13 @@ jobs:
           restore-keys: release-${{ matrix.target }}-
 
       - name: Build release binary
-        run: ${{ matrix.use_cross && 'cross' || 'cargo' }} build --release --target ${{ matrix.target }} -p uvr
+        run: |
+          if [ "${{ matrix.zigbuild }}" = "true" ]; then
+            sh ci/build-linux-gnu.sh "${{ matrix.target }}"
+          else
+            ${{ matrix.use_cross && 'cross' || 'cargo' }} build --release --target ${{ matrix.target }} -p uvr
+          fi
+        shell: bash
 
       # Smoke test the freshly-built binary on the runners where we can —
       # i.e. the target architecture matches the host. Catches regressions

--- a/ci/build-linux-gnu.sh
+++ b/ci/build-linux-gnu.sh
@@ -1,0 +1,110 @@
+#!/bin/sh
+# Build a glibc Linux release binary with an explicit glibc floor.
+#
+#   ci/build-linux-gnu.sh x86_64-unknown-linux-gnu
+#   ci/build-linux-gnu.sh aarch64-unknown-linux-gnu
+#
+# Why not just `cargo build`: a binary built on the runner inherits *that*
+# machine's glibc as its floor. Building on ubuntu-22.04 produced a binary
+# requiring GLIBC_2.34, which does not start on RHEL 8, Debian 11 or Ubuntu
+# 20.04 — all distros uvr otherwise supports, and all of which uvr can still
+# be useful on, since it finds and manages a system R when the portable builds
+# won't run there.
+#
+# The old fix for this was to build on an older runner, but GitHub retired
+# ubuntu-20.04 and there is nothing older to move to. zig ships every glibc
+# version's stubs, so `cargo zigbuild --target <triple>.<glibc>` pins the floor
+# regardless of the host — and cross-compiles aarch64 in the bargain, which
+# replaces the gcc-aarch64-linux-gnu sysroot that had the same problem.
+set -eu
+
+TARGET="${1:?usage: ci/build-linux-gnu.sh <target-triple>}"
+
+# Matches PPM_MANYLINUX_GLIBC_MIN in r_version/downloader.rs — the glibc below
+# which uvr can offer no binary R packages at all. There is no point running
+# on anything older, and no reason to exclude anything newer.
+GLIBC_FLOOR=2.28
+
+ZIG_VERSION=0.13.0
+CACHE="${ZIG_CACHE_DIR:-${HOME}/.cache/uvr-ci}"
+
+# Pinned from https://ziglang.org/download/index.json. This toolchain links the
+# binaries users install, so it is checked before it is run: a compiler fetched
+# over the network and executed unverified is a straight path from a CDN
+# compromise into a shipped artifact. Bump both together.
+zig_sha256() {
+    case "$(uname -m)" in
+        x86_64)  echo "d45312e61ebcc48032b77bc4cf7fd6915c11fa16e4aad116b66c9468211230ea" ;;
+        aarch64) echo "041ac42323837eb5624068acd8b00cd5777dac4cf91179e8dad7a7e90dd0c556" ;;
+        *) echo "" ;;
+    esac
+}
+
+if ! command -v zig >/dev/null 2>&1; then
+    zig_dir="$CACHE/zig-linux-$(uname -m)-$ZIG_VERSION"
+    if [ ! -x "$zig_dir/zig" ]; then
+        want="$(zig_sha256)"
+        [ -n "$want" ] || { echo "no pinned zig checksum for $(uname -m)" >&2; exit 1; }
+        echo ">>> fetching zig $ZIG_VERSION"
+        mkdir -p "$CACHE"
+        tarball="$CACHE/zig-$ZIG_VERSION-$(uname -m).tar.xz"
+        curl --proto '=https' --tlsv1.2 -sSfL -o "$tarball" \
+            "https://ziglang.org/download/$ZIG_VERSION/zig-linux-$(uname -m)-$ZIG_VERSION.tar.xz"
+        # Verify before unpacking, not after: tar runs code paths on the
+        # archive either way, and an unpacked tree is already a foothold.
+        got="$(sha256sum "$tarball" | cut -d' ' -f1)"
+        if [ "$got" != "$want" ]; then
+            rm -f "$tarball"
+            echo "!!! zig $ZIG_VERSION checksum mismatch" >&2
+            echo "    expected $want" >&2
+            echo "    got      $got" >&2
+            exit 1
+        fi
+        tar -xJf "$tarball" -C "$CACHE"
+        rm -f "$tarball"
+    fi
+    PATH="$zig_dir:$PATH"
+    export PATH
+fi
+
+command -v cargo-zigbuild >/dev/null 2>&1 || cargo install cargo-zigbuild --locked
+rustup target add "$TARGET"
+
+# Every C dependency here (lzma, bzip2, zstd, ring) vendors its source and only
+# prefers a system library when pkg-config finds one. That makes the artifact
+# depend on which machine built it: a builder with libbz2-dev installed emits a
+# binary needing libbz2.so.1.0, a Debian SONAME that RHEL does not ship. Take
+# the system out of the decision.
+LZMA_API_STATIC=1
+PKG_CONFIG_LIBDIR=/nonexistent
+PKG_CONFIG_PATH=/nonexistent
+export LZMA_API_STATIC PKG_CONFIG_LIBDIR PKG_CONFIG_PATH
+
+echo ">>> building $TARGET against glibc $GLIBC_FLOOR"
+cargo zigbuild --release --target "$TARGET.$GLIBC_FLOOR" --bin uvr
+
+out="target/$TARGET/release/uvr"
+[ -f "$out" ] || { echo "expected $out" >&2; exit 1; }
+
+# The floor is the whole point of this script, so assert it rather than trust
+# it: one dropped flag and the binary silently goes back to needing whatever
+# the runner had.
+max="$(objdump -T "$out" | grep -o 'GLIBC_[0-9.]*' | sed 's/GLIBC_//' | sort -V | tail -1)"
+if [ "$(printf '%s\n%s\n' "$GLIBC_FLOOR" "$max" | sort -V | tail -1)" != "$GLIBC_FLOOR" ]; then
+    echo "!!! $out requires GLIBC_$max, above the $GLIBC_FLOOR floor" >&2
+    exit 1
+fi
+
+echo ">>> $out requires at most GLIBC_$max"
+
+# Same reasoning one level up: a needed library the target distro names
+# differently is as fatal as a glibc symbol it lacks, and just as invisible on
+# the machine that built it. Only the C runtime is allowed.
+needed="$(objdump -p "$out" | awk '/NEEDED/ {print $2}')"
+for lib in $needed; do
+    case "$lib" in
+        libc.so.6|libm.so.6|libdl.so.2|libpthread.so.0|librt.so.1|ld-linux*) ;;
+        *) echo "!!! $out needs $lib, which is not part of the C runtime" >&2; exit 1 ;;
+    esac
+done
+echo ">>> needs only: $(echo "$needed" | tr '\n' ' ')"


### PR DESCRIPTION
**Stack position: merge third. Independent of #213/#214 — it touches only the release workflow — but #211 is rebased on this branch and calls `ci/build-linux-gnu.sh`, so it must land before #211.**

Fixes the glibc failures #211's distro matrix found.

## Problem

The published v0.4.4 `x86_64-unknown-linux-gnu` binary does not start on RHEL 8, Debian 11 or Ubuntu 20.04:

```
$ uvr --version
/usr/local/bin/uvr: /lib64/libc.so.6: version `GLIBC_2.34' not found (required by uvr)
```

All three are distros uvr otherwise supports — P3M publishes `focal`, `bullseye` and `centos8` binaries, and the sysreqs catalog covers all three. `install.sh` hands glibc hosts the gnu build, so those users get a binary that cannot run.

A binary inherits the glibc of whatever built it. The matrix already pinned the gnu targets to `ubuntu-22.04` to keep that floor down, and 22.04 still emits `GLIBC_2.34`. The obvious fix — move to an older runner — is gone: GitHub retired `ubuntu-20.04` and there is nothing below 22.04 left.

## Fix

`cargo zigbuild --target <triple>.2.28`. zig ships stubs for every glibc version, so the floor is pinned regardless of the host, and it cross-compiles aarch64 in the same step — which retires the `gcc-aarch64-linux-gnu` sysroot that had the identical problem on arm.

**2.28** matches `PPM_MANYLINUX_GLIBC_MIN` in `r_version/downloader.rs`, the glibc below which uvr can serve no binary R packages at all. No point running lower, no reason to exclude higher.

The build lives in `ci/build-linux-gnu.sh` rather than inline YAML so #211's matrix can build the artifact it tests the same way the release builds it — #211 now calls it, which is why it stacks on this PR.

## Two assertions, not two assumptions

Both regress silently, and neither is visible on the machine that built it:

- the maximum `GLIBC_` symbol version does not exceed the floor
- nothing outside the C runtime appears in `NEEDED`

The second caught a real hazard while writing this. Every C dependency here (lzma, bzip2, zstd, ring) vendors its source but prefers a system library when pkg-config finds one — so a builder with `libbz2-dev` installed emits a binary needing `libbz2.so.1.0`, a Debian SONAME RHEL does not ship. The artifact would then depend on which image built it. The build now takes the system out of that decision.

## Verification

The resulting binary runs on Ubuntu 20.04, Debian 11, UBI 8, Rocky 8, Ubuntu 24.04, Debian 13 and openSUSE Leap 15.5 — the first three being the ones that failed before.

```
>>> target/x86_64-unknown-linux-gnu/release/uvr requires at most GLIBC_2.28
>>> needs only: libm.so.6 libpthread.so.0 libc.so.6 libdl.so.2 ld-linux-x86-64.so.2
```

The aarch64 build is verified by symbol inspection only (max `GLIBC_2.28`, same NEEDED set); I have no arm64 emulation here to execute it.

## What this does not fix

`uvr r install` still cannot work on those distros. The portable R builds need glibc 2.34 and uvr says so explicitly:

```
Unsupported platform: glibc 2.28 is too old for portable R builds (need >= 2.34).
Distros below this floor — Ubuntu 20.04, RHEL 8, Debian 11 — are not supported by
uvr's R installer. Use your system package manager's R, or build R from source.
```

That is upstream's floor, not something a build change can move. What changes is that a RHEL 8 user now *gets* that explanation — and can still use uvr against a system R, which `find_all`/`find_r_binary` already support — instead of a dynamic-linker error with no path forward.

So #211's matrix will still fail on RHEL 8, Debian 11 and Ubuntu 20.04 at the `r install` stage after this lands — its entries for those three carry a note saying exactly that. The failure is honest and worth keeping visible; deciding what those distros should be promised is a separate call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PkvRyFs8awBe4nHFjcvoa2
