### PR TITLE
feat(p3m): pick the binary repo from Posit's live catalog, per architecture

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -343,6 +343,11 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - name: Check every mapped repo still serves
         run: cargo test -p uvr-core --test p3m_repos_live -- --ignored --nocapture
+      # The catalog is what answers at runtime; the table is only the offline
+      # answer. A stale table is invisible until someone is offline, so the
+      # comparison has to run somewhere that is online on a schedule.
+      - name: Check the table still agrees with Posit's platform catalog
+        run: cargo test -p uvr-core --test p3m_status_live -- --ignored --nocapture
 
   audit:
     name: Security audit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,6 @@ Pure tracking section — fixes and small features land here between tags.
   tarballs are downloaded and reads `SystemRequirements` from each one's
   DESCRIPTION, which is where the field is actually published.
 
-
-
 - Binary package repos are chosen from Posit's live platform catalog, and the
   choice now accounts for the host architecture. uvr matched a hardcoded
   slug → repo table with no notion of arch, but only `rhel9`, `rhel10`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,19 @@ Pure tracking section — fixes and small features land here between tags.
   tarballs are downloaded and reads `SystemRequirements` from each one's
   DESCRIPTION, which is where the field is actually published.
 
+
+
+- Binary package repos are chosen from Posit's live platform catalog, and the
+  choice now accounts for the host architecture. uvr matched a hardcoded
+  slug → repo table with no notion of arch, but only `rhel9`, `rhel10`,
+  `noble`, `resolute` and `manylinux_2_28` carry arm64 builds — and P3M
+  degrades to *source* when a repo has no build for the caller's architecture.
+  An arm64 host on Ubuntu 22.04, Debian 12, RHEL 8 or openSUSE was therefore
+  compiling every package while the portable `manylinux_2_28` repo, which does
+  build for arm64, sat unused. uvr now reads `GET /__api__/status` (cached
+  daily) and picks a repo that actually serves this distro on this
+  architecture. The compiled-in table still answers when the endpoint is
+  unreachable, and `--distribution` still wins over both.
 - Oracle Linux gets binary packages, not just system dependencies (#209
   follow-up). `ID="ol"` was aliased onto RHEL for sysreqs but not for the P3M
   slug, so OL hosts resolved their system libraries correctly and then

--- a/crates/uvr-core/src/r_version/downloader.rs
+++ b/crates/uvr-core/src/r_version/downloader.rs
@@ -229,6 +229,14 @@ pub fn set_posit_distro_override(slug: String) {
     let _ = DISTRO_OVERRIDE.set(slug);
 }
 
+/// True when the user pinned the distro with `--distribution`. The live
+/// platform catalog keys off `/etc/os-release`, which is precisely what an
+/// override says not to trust, so the catalog path stands down when this is
+/// set (#54).
+pub fn distro_override_is_set() -> bool {
+    DISTRO_OVERRIDE.get().is_some()
+}
+
 /// Detect the Posit CDN distro slug from `/etc/os-release`, or use the
 /// override set by [`set_posit_distro_override`] if any.
 ///

--- a/crates/uvr-core/src/registry/mod.rs
+++ b/crates/uvr-core/src/registry/mod.rs
@@ -4,6 +4,7 @@ pub mod forgejo;
 pub mod github;
 pub mod gitlab;
 pub mod p3m;
+pub mod p3m_status;
 
 use semver::Version;
 

--- a/crates/uvr-core/src/registry/p3m.rs
+++ b/crates/uvr-core/src/registry/p3m.rs
@@ -8,6 +8,7 @@ use tracing::{debug, warn};
 
 use crate::error::Result;
 use crate::r_version::downloader::Platform;
+use crate::registry::p3m_status;
 use crate::resolver::normalize_version;
 
 /// Pre-built binary package index from Posit Package Manager (P3M).
@@ -45,7 +46,11 @@ impl P3MBinaryIndex {
         bioc_release: Option<&str>,
         posit_distro_slug: Option<&str>,
     ) -> Self {
-        let Some(info) = platform_info(platform, posit_distro_slug, r_minor) else {
+        // Ask Posit which repo actually has builds for this distro *and* this
+        // architecture before falling back to the compiled-in table (#211).
+        let live_repo = live_linux_repo(client, platform).await;
+        let Some(info) = platform_info(platform, posit_distro_slug, r_minor, live_repo.as_ref())
+        else {
             // Unsupported platform combination: macOS x86 / Windows always
             // OK; Linux only when we recognise the distro. Falls through
             // to source — same behavior as before #55.
@@ -295,10 +300,18 @@ struct PlatformInfo {
 /// `posit_distro_slug` should be the same slug uvr uses for the R install
 /// URL (`ubuntu-2204`, `debian-12`, `rhel-9`, …); we translate it to PPM's
 /// codename system (`jammy`, `bookworm`, `rhel9`) here.
+/// `live_repo` carries the platform catalog's answer for this host, when it
+/// could be reached: `Some(Some(codename))` to install from that repo,
+/// `Some(None)` for "Posit publishes nothing usable here", and `None` for
+/// "the catalog was unavailable, use the compiled-in table". The middle case
+/// is a real answer and must not be second-guessed by the table — it is how
+/// an arm64 host on an x86_64-only distro gets routed to the portable repo
+/// rather than to a repo that would silently serve it source.
 fn platform_info(
     platform: Platform,
     posit_distro_slug: Option<&str>,
     r_minor: &str,
+    live_repo: Option<&Option<String>>,
 ) -> Option<PlatformInfo> {
     match platform {
         // #72 / #53 / #102: the correct arm64 channel depends on the R
@@ -342,8 +355,10 @@ fn platform_info(
             // PPM Linux only — Bioc binary support comes via Bioconductor's
             // own server, which doesn't serve Linux binaries today; Bioc on
             // Linux falls back to source as before.
-            let slug = posit_distro_slug?;
-            let codename = ppm_linux_repo(slug)?;
+            let codename: String = match live_repo {
+                Some(live) => live.clone()?,
+                None => ppm_linux_repo(posit_distro_slug?)?.to_string(),
+            };
             let arch = if matches!(platform, Platform::LinuxX86_64) {
                 "x86_64"
             } else {
@@ -362,7 +377,7 @@ fn platform_info(
                 cache_key: format!("linux-{codename}-{arch}"),
                 pkg_ext: "tar.gz",
                 is_linux: true,
-                linux_codename: Some(codename.to_string()),
+                linux_codename: Some(codename),
                 user_agent: Some(user_agent),
             })
         }
@@ -422,6 +437,79 @@ pub fn ppm_linux_codename(posit_slug: &str) -> Option<&'static str> {
 /// function of the slug; that mapping stays pure for tests.
 pub fn ppm_linux_repo(posit_slug: &str) -> Option<&'static str> {
     ppm_linux_codename(posit_slug).or_else(crate::r_version::downloader::ppm_manylinux_repo)
+}
+
+/// Ask Posit's platform catalog which repo this host should install from.
+///
+/// Returns `None` when the catalog could not answer — unreachable, or it has
+/// never heard of this `(distribution, release)` pair — and the caller should
+/// use the compiled-in table, which knows aliases the catalog does not
+/// publish (Rocky 8 is not a catalog entry, but its binaries are `centos8`).
+///
+/// `Some(None)` is the catalog declining: it builds for this distro, just not
+/// for this architecture, and there is no portable repo to fall back to
+/// either. That answer is authoritative and the table must not override it.
+///
+/// The lookup keys on the same `(distribution, release)` pair the sysreqs
+/// catalog uses, which is what `normalize_distro` already produces — the two
+/// Posit catalogs speak one vocabulary, so uvr needs only one translation
+/// from `/etc/os-release` rather than the two it used to keep in sync.
+async fn live_linux_repo(client: &reqwest::Client, platform: Platform) -> Option<Option<String>> {
+    let arch = match platform {
+        Platform::LinuxX86_64 => "x86_64",
+        Platform::LinuxArm64 => "arm64",
+        // macOS and Windows binaries don't come from the __linux__ repos.
+        _ => return None,
+    };
+
+    // `--distribution X` is the user telling uvr its autodetection is wrong
+    // here (#54). The catalog lookup starts from that same autodetection, so
+    // honouring the override means not running it.
+    if crate::r_version::downloader::distro_override_is_set() {
+        return None;
+    }
+
+    let os = crate::os_release::detect()?;
+    if os.id.is_empty() || os.version_id.is_empty() {
+        return None;
+    }
+    let (distribution, release) = crate::sysreqs::normalize_distro(&os.id, &os.version_id);
+    // Both Posit catalogs have the same holes in that vocabulary — neither
+    // publishes `rockylinux` 8 or `centos` 9/10 — so the same alias applies
+    // here as when asking for sysreqs. Without it Rocky/Alma 8 and CentOS
+    // Stream fall through to the static table and lose the architecture
+    // awareness this function exists for.
+    let (distribution, release) = crate::sysreqs::catalog_alias(&distribution, &release);
+
+    let distros = p3m_status::fetch(client).await?;
+
+    if let Some(codename) = p3m_status::codename_for(&distros, distribution, release, arch) {
+        debug!("P3M catalog: {distribution}/{release} on {arch} serves from {codename}");
+        return Some(Some(codename.to_string()));
+    }
+
+    // Distinguish "the catalog has never heard of this pair" from "it has, but
+    // not for this architecture". Only the second is an authoritative no; the
+    // first leaves room for the static table's aliases.
+    if !p3m_status::is_known(&distros, distribution, release) {
+        debug!("P3M catalog has no entry for {distribution}/{release}; using the static table");
+        return None;
+    }
+
+    // The distro repo has no build for this architecture — the arm64 case.
+    // The portable repo is built for both, so prefer it over a repo that
+    // would quietly serve source, provided the host clears its glibc floor.
+    if crate::r_version::downloader::ppm_manylinux_repo().is_some() {
+        if let Some(codename) = p3m_status::portable_codename(&distros, arch) {
+            debug!(
+                "P3M catalog: {distribution}/{release} has no {arch} build; \
+                 using the portable {codename} repo"
+            );
+            return Some(Some(codename.to_string()));
+        }
+    }
+    debug!("P3M catalog: nothing serves {distribution}/{release} on {arch}");
+    Some(None)
 }
 
 fn cache_path(r_minor: &str, key: &str) -> PathBuf {
@@ -541,12 +629,12 @@ Version: 1.1.4
     fn platform_info_macos_arm64() {
         // #102: R <= 4.5 arm64 binaries live on the Big Sur channel,
         // R >= 4.6 on the Sonoma channel.
-        let info = platform_info(Platform::MacOsArm64, None, "4.5").unwrap();
+        let info = platform_info(Platform::MacOsArm64, None, "4.5", None).unwrap();
         assert_eq!(info.url_segment, "macosx/big-sur-arm64");
         assert_eq!(info.pkg_ext, "tgz");
         assert!(!info.is_linux);
 
-        let info = platform_info(Platform::MacOsArm64, None, "4.6").unwrap();
+        let info = platform_info(Platform::MacOsArm64, None, "4.6", None).unwrap();
         assert_eq!(info.url_segment, "macosx/sonoma-arm64");
     }
 
@@ -563,16 +651,50 @@ Version: 1.1.4
 
     #[test]
     fn platform_info_windows() {
-        let info = platform_info(Platform::WindowsX86_64, None, "4.5").unwrap();
+        let info = platform_info(Platform::WindowsX86_64, None, "4.5", None).unwrap();
         assert_eq!(info.url_segment, "windows");
         assert_eq!(info.pkg_ext, "zip");
         assert!(!info.is_linux);
     }
 
     #[test]
+    fn live_catalog_answer_wins_over_the_static_table() {
+        // ubuntu-2204 maps to `jammy` in the table, but jammy has no arm64
+        // build. When the catalog says "use the portable repo", that is the
+        // repo uvr must use — the table's answer would have quietly fetched
+        // source on arm64 (#211).
+        let info = platform_info(
+            Platform::LinuxArm64,
+            Some("ubuntu-2204"),
+            "4.5",
+            Some(&Some("manylinux_2_28".to_string())),
+        )
+        .expect("the catalog named a repo");
+        assert_eq!(info.linux_codename.as_deref(), Some("manylinux_2_28"));
+    }
+
+    #[test]
+    fn live_catalog_declining_means_source() {
+        // `Some(None)`: Posit builds for this distro but not for this arch,
+        // and the portable repo can't help either (musl, or glibc below the
+        // floor). That is an authoritative no, so the static table must not
+        // get a second vote.
+        assert!(
+            platform_info(
+                Platform::LinuxArm64,
+                Some("ubuntu-2204"),
+                "4.5",
+                Some(&None)
+            )
+            .is_none(),
+            "a declining catalog must not fall back to the table"
+        );
+    }
+
+    #[test]
     fn platform_info_linux_supported_distro() {
         // #55: Linux gets a binary index when the distro maps to a PPM codename.
-        let info = platform_info(Platform::LinuxX86_64, Some("ubuntu-2204"), "4.5")
+        let info = platform_info(Platform::LinuxX86_64, Some("ubuntu-2204"), "4.5", None)
             .expect("ubuntu-2204 covered");
         assert!(info.is_linux);
         assert_eq!(info.linux_codename.as_deref(), Some("jammy"));
@@ -591,7 +713,7 @@ Version: 1.1.4
         // binaries and the caller compiles from source. Assert the property
         // rather than one host's answer, so this passes on every runner.
         for slug in ["slackware-15", "nixos-2411"] {
-            let info = platform_info(Platform::LinuxX86_64, Some(slug), "4.5");
+            let info = platform_info(Platform::LinuxX86_64, Some(slug), "4.5", None);
             match crate::r_version::downloader::ppm_manylinux_repo() {
                 Some(repo) => {
                     let info = info.expect("manylinux host should still get a repo");
@@ -601,7 +723,7 @@ Version: 1.1.4
             }
         }
         // Without a slug there is nothing to translate, on any host.
-        assert!(platform_info(Platform::LinuxX86_64, None, "4.5").is_none());
+        assert!(platform_info(Platform::LinuxX86_64, None, "4.5", None).is_none());
     }
 
     #[test]
@@ -709,14 +831,14 @@ Version: 1.1.4
         // Reviewer flagged the prior hardcoded "4.5.3" UA as a future
         // staleness risk if PPM tightens its UA matching. r_minor flows
         // through and shows up in the UA — verify both arch variants.
-        let info_x86 =
-            platform_info(Platform::LinuxX86_64, Some("ubuntu-2204"), "4.6").expect("supported");
+        let info_x86 = platform_info(Platform::LinuxX86_64, Some("ubuntu-2204"), "4.6", None)
+            .expect("supported");
         let ua = info_x86.user_agent.expect("Linux gets a UA");
         assert!(ua.starts_with("R (4.6.0 x86_64-pc-linux-gnu"), "got {ua}");
         assert!(ua.contains("linux-gnu"));
 
         let info_arm =
-            platform_info(Platform::LinuxArm64, Some("debian-12"), "4.5").expect("supported");
+            platform_info(Platform::LinuxArm64, Some("debian-12"), "4.5", None).expect("supported");
         let ua = info_arm.user_agent.expect("Linux gets a UA");
         assert!(ua.starts_with("R (4.5.0 aarch64-pc-linux-gnu"), "got {ua}");
     }

--- a/crates/uvr-core/src/registry/p3m_status.rs
+++ b/crates/uvr-core/src/registry/p3m_status.rs
@@ -144,21 +144,44 @@ pub fn is_known(distros: &[Distro], distribution: &str, release: &str) -> bool {
     })
 }
 
+/// Whether a parse produced a catalog worth trusting.
+///
+/// Every field is `#[serde(default)]`, so an upstream *rename* parses cleanly
+/// and silently yields the default. That is the dangerous direction: if `arch`
+/// (or `os`, or `binaries`) stopped arriving under the name we expect,
+/// [`Distro::serves`] would be false for every entry while [`is_known`] still
+/// reported pairs as known — and `live_linux_repo` reads known-but-not-serving
+/// as an authoritative "Posit publishes nothing here", sending every distro to
+/// source builds. A whole-envelope failure degrades correctly to the static
+/// table; this is the partial failure that does not.
+///
+/// A catalog in which *nothing* serves binaries anywhere is a parse that lost
+/// a field, not a Posit that stopped building. Treat it as unreachable so the
+/// table answers, exactly as if the endpoint were down.
+fn usable(distros: &[Distro]) -> bool {
+    distros
+        .iter()
+        .any(|d| d.os == "linux" && d.binaries && !d.arch.is_empty() && !d.binary_url.is_empty())
+}
+
 /// Fetch the platform catalog, cached for the day alongside the package
 /// indexes.
 ///
-/// Returns `None` on any failure — unreachable, non-success, unparseable.
-/// Callers fall back to the static table rather than losing binaries because
-/// a status endpoint was down.
+/// Returns `None` on any failure — unreachable, non-success, unparseable, or
+/// parsed-but-unusable (see [`usable`]). Callers fall back to the static table
+/// rather than losing binaries because a status endpoint was down.
 pub async fn fetch(client: &reqwest::Client) -> Option<Vec<Distro>> {
     let cache = cache_path();
 
     if let Ok(cached) = std::fs::read_to_string(&cache) {
-        if let Ok(status) = serde_json::from_str::<Status>(&cached) {
-            return Some(status.distros);
+        match serde_json::from_str::<Status>(&cached) {
+            Ok(status) if usable(&status.distros) => return Some(status.distros),
+            // A corrupt or unusable cache file should cost one refetch, not
+            // the whole feature.
+            _ => {
+                let _ = std::fs::remove_file(&cache);
+            }
         }
-        // A corrupt cache file should cost one refetch, not the whole feature.
-        let _ = std::fs::remove_file(&cache);
     }
 
     debug!("Fetching P3M platform catalog from {STATUS_URL}");
@@ -183,7 +206,8 @@ pub async fn fetch(client: &reqwest::Client) -> Option<Vec<Distro>> {
             return None;
         }
     };
-    if status.distros.is_empty() {
+    if !usable(&status.distros) {
+        debug!("P3M status endpoint returned no usable entries; using the static table");
         return None;
     }
 
@@ -303,5 +327,39 @@ mod tests {
     fn posit_spells_aarch64_as_arm64() {
         assert_eq!(posit_arch("aarch64"), "arm64");
         assert_eq!(posit_arch("x86_64"), "x86_64");
+    }
+
+    #[test]
+    fn a_partial_field_rename_reads_as_unreachable_not_as_a_refusal() {
+        // Every field is #[serde(default)], so renaming one upstream parses
+        // cleanly and defaults it. The failure that matters is the one that
+        // does *not* look like a failure: `arch` arriving under another name
+        // makes `serves()` false everywhere, while `is_known()` still reports
+        // the pair as known — which `live_linux_repo` treats as "Posit
+        // publishes nothing for this host" and answers with source builds.
+        // `usable()` is what tells the two apart.
+        let renamed = SAMPLE.replace("\"arch\"", "\"architectures\"");
+        let distros = serde_json::from_str::<Status>(&renamed).unwrap().distros;
+        assert!(!distros.is_empty(), "it still parses — that is the problem");
+        assert!(is_known(&distros, "ubuntu", "22.04"), "still 'known'");
+        assert_eq!(
+            codename_for(&distros, "ubuntu", "22.04", "x86_64"),
+            None,
+            "and nothing serves, which alone would look like an authoritative no"
+        );
+        assert!(
+            !usable(&distros),
+            "so the catalog must be declared unusable"
+        );
+
+        // Same shape for the other two fields a lookup depends on.
+        for field in ["\"os\"", "\"binaries\"", "\"binaryURL\""] {
+            let mangled = SAMPLE.replace(field, "\"renamed_upstream\"");
+            let distros = serde_json::from_str::<Status>(&mangled).unwrap().distros;
+            assert!(!usable(&distros), "{field} rename must read as unusable");
+        }
+
+        // The real thing is of course fine.
+        assert!(usable(&sample()));
     }
 }

--- a/crates/uvr-core/src/registry/p3m_status.rs
+++ b/crates/uvr-core/src/registry/p3m_status.rs
@@ -1,0 +1,307 @@
+//! Live P3M platform catalog — `GET /__api__/status`.
+//!
+//! Posit publishes the exact set of distributions it builds for, and for which
+//! architectures, as one documented endpoint (described in the OpenAPI spec at
+//! `/__api__/swagger/doc.json`, whose version tracks the server build). Each
+//! entry names a distribution and release in the same vocabulary the sysreqs
+//! catalog uses, the repo codename its binaries live under, and the
+//! architectures that repo actually carries:
+//!
+//! ```text
+//! name     distribution  release  binaryURL    sysReqs  binaries  arch
+//! rhel8    redhat        8        centos8      true     true      x86_64
+//! rhel9    rockylinux    9        rhel9        true     true      x86_64, arm64
+//! sles156  sle           15.6     opensuse156  true     true      x86_64
+//! jammy    ubuntu        22.04    jammy        true     true      x86_64
+//! ```
+//!
+//! Two things follow from having this at runtime rather than in a table.
+//!
+//! **The arch dimension exists.** Only `rhel9`, `rhel10`, `noble`, `resolute`
+//! and `manylinux_2_28` carry arm64 builds. P3M routes by the R User-Agent and
+//! degrades to *source* when a repo has no build for the caller's
+//! architecture — so an arm64 host pointed at `jammy` silently compiles
+//! everything, while `manylinux_2_28` would have handed it arm64 binaries.
+//! Nothing breaks, but nothing is fast either, and a hardcoded slug → codename
+//! table cannot see the difference.
+//!
+//! **The table stops drifting.** Posit adds repos as distros ship and hides
+//! them at EOL; both directions used to be silent.
+//!
+//! The static table in [`super::p3m::ppm_linux_codename`] remains the offline
+//! answer. It is consulted only when this endpoint cannot be reached — never
+//! to second-guess a live answer, because "Posit publishes no arm64 build for
+//! this distro" is a *correct* negative that the table cannot express.
+
+use serde::Deserialize;
+use tracing::debug;
+
+/// Host architecture in Posit's vocabulary. Their `arch` field says `arm64`
+/// where Rust says `aarch64`.
+pub fn posit_arch(rust_arch: &str) -> &str {
+    match rust_arch {
+        "aarch64" => "arm64",
+        other => other,
+    }
+}
+
+/// One platform entry from `/__api__/status`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct Distro {
+    /// Posit's own key, e.g. `rhel8`, `jammy`. Not always the repo name.
+    #[serde(default)]
+    pub name: String,
+    #[serde(default)]
+    pub os: String,
+    /// Distribution in the sysreqs vocabulary: `redhat`, `rockylinux`, `sle`.
+    #[serde(default)]
+    pub distribution: String,
+    /// Release as the catalog keys it: `8`, `15.6`, `22.04`.
+    #[serde(default)]
+    pub release: String,
+    /// Repo codename to install binaries from — the `__linux__/<codename>`
+    /// segment. Several entries share one: `rhel8` and `centos8` both serve
+    /// from `centos8`.
+    #[serde(default, rename = "binaryURL")]
+    pub binary_url: String,
+    #[serde(default)]
+    pub binaries: bool,
+    #[serde(default, rename = "sysReqs")]
+    pub sys_reqs: bool,
+    /// Architectures this repo has builds for, in Posit's spelling.
+    #[serde(default)]
+    pub arch: Vec<String>,
+}
+
+/// The portable repo's codename. It appears in the catalog as a distro like
+/// any other — `distribution: "centos", release: "8"` — which makes
+/// `(distribution, release)` ambiguous for real CentOS 8 hosts, and would let
+/// a distro lookup return the portable repo without going through the glibc
+/// floor check that guards it. Distro lookups exclude it by name.
+const PORTABLE: &str = "manylinux_2_28";
+
+impl Distro {
+    fn serves(&self, arch: &str) -> bool {
+        self.os == "linux" && self.binaries && self.arch.iter().any(|a| a == arch)
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct Status {
+    #[serde(default)]
+    distros: Vec<Distro>,
+}
+
+const STATUS_URL: &str = "https://packagemanager.posit.co/__api__/status";
+
+/// The repo codename to use for `(distribution, release)` on `arch`, or
+/// `None` when Posit publishes nothing usable there.
+///
+/// `None` is a real answer, not a lookup failure: it covers both "Posit does
+/// not build for this distro" and "it does, but not for this architecture".
+/// Both mean the caller should look at the portable repo instead.
+pub fn codename_for<'a>(
+    distros: &'a [Distro],
+    distribution: &str,
+    release: &str,
+    arch: &str,
+) -> Option<&'a str> {
+    distros
+        .iter()
+        .filter(|d| d.binary_url != PORTABLE)
+        .find(|d| d.distribution == distribution && d.release == release && d.serves(arch))
+        .map(|d| d.binary_url.as_str())
+}
+
+/// The portable repo, if it has builds for `arch`. Posit publishes
+/// `manylinux_2_28` for x86_64 and arm64; the glibc floor is the caller's
+/// problem (see `ppm_manylinux_repo`).
+pub fn portable_codename<'a>(distros: &'a [Distro], arch: &str) -> Option<&'a str> {
+    distros
+        .iter()
+        .find(|d| d.binary_url == PORTABLE && d.serves(arch))
+        .map(|d| d.binary_url.as_str())
+}
+
+/// Whether the catalog carries this `(distribution, release)` at all.
+///
+/// Distinguishes "Posit has never heard of this pair" — where the caller's
+/// own table may still know an alias — from "Posit knows it and publishes no
+/// binaries uvr can use here", which is an authoritative no.
+///
+/// Deliberately does *not* require `binaries`. Debian 10 is catalogued for
+/// sysreqs with `binaries: false`; treating that as unknown would hand the
+/// question back to the static table, which is exactly the second-guessing of
+/// a catalog negative this module exists to prevent. The portable repo is
+/// excluded for the same reason `codename_for` excludes it: it is published
+/// under `centos`/`8` and would make that pair look known on its own.
+pub fn is_known(distros: &[Distro], distribution: &str, release: &str) -> bool {
+    distros.iter().any(|d| {
+        d.binary_url != PORTABLE
+            && d.os == "linux"
+            && d.distribution == distribution
+            && d.release == release
+    })
+}
+
+/// Fetch the platform catalog, cached for the day alongside the package
+/// indexes.
+///
+/// Returns `None` on any failure — unreachable, non-success, unparseable.
+/// Callers fall back to the static table rather than losing binaries because
+/// a status endpoint was down.
+pub async fn fetch(client: &reqwest::Client) -> Option<Vec<Distro>> {
+    let cache = cache_path();
+
+    if let Ok(cached) = std::fs::read_to_string(&cache) {
+        if let Ok(status) = serde_json::from_str::<Status>(&cached) {
+            return Some(status.distros);
+        }
+        // A corrupt cache file should cost one refetch, not the whole feature.
+        let _ = std::fs::remove_file(&cache);
+    }
+
+    debug!("Fetching P3M platform catalog from {STATUS_URL}");
+    let body = match client.get(STATUS_URL).send().await {
+        Ok(resp) => match resp.error_for_status() {
+            Ok(resp) => resp.text().await.ok()?,
+            Err(e) => {
+                debug!("P3M status endpoint returned {e}; using the static table");
+                return None;
+            }
+        },
+        Err(e) => {
+            debug!("P3M status endpoint unreachable ({e}); using the static table");
+            return None;
+        }
+    };
+
+    let status: Status = match serde_json::from_str(&body) {
+        Ok(s) => s,
+        Err(e) => {
+            debug!("P3M status endpoint returned unparseable JSON ({e})");
+            return None;
+        }
+    };
+    if status.distros.is_empty() {
+        return None;
+    }
+
+    // Cache only after a successful parse, matching the package-index cache.
+    if let Some(parent) = cache.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let _ = std::fs::write(&cache, &body);
+
+    Some(status.distros)
+}
+
+fn cache_path() -> std::path::PathBuf {
+    let date = chrono::Local::now().format("%Y-%m-%d").to_string();
+    crate::env_vars::cache_dir_or_temp().join(format!("p3m-status-{date}.json"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Verbatim shape of six entries from the live endpoint (2026-07-31),
+    /// chosen for the cases the lookups have to get right: an x86_64-only
+    /// distro repo, one with arm64, a `binaries: false` entry, and the
+    /// portable repo sharing `centos`/`8` with a real distro entry.
+    const SAMPLE: &str = r#"{"distros":[
+        {"name":"rhel8","os":"linux","distribution":"redhat","release":"8",
+         "binaryURL":"centos8","sysReqs":true,"binaries":true,"hidden":false,
+         "arch":["x86_64"]},
+        {"name":"rhel9","os":"linux","distribution":"rockylinux","release":"9",
+         "binaryURL":"rhel9","sysReqs":true,"binaries":true,"hidden":false,
+         "arch":["x86_64","arm64"]},
+        {"name":"jammy","os":"linux","distribution":"ubuntu","release":"22.04",
+         "binaryURL":"jammy","sysReqs":true,"binaries":true,"hidden":false,
+         "arch":["x86_64"]},
+        {"name":"buster","os":"linux","distribution":"debian","release":"10",
+         "binaryURL":"buster","sysReqs":true,"binaries":false,"hidden":true,
+         "arch":["x86_64"]},
+        {"name":"manylinux_2_28","os":"linux","distribution":"centos","release":"8",
+         "binaryURL":"manylinux_2_28","sysReqs":false,"binaries":true,
+         "hidden":false,"arch":["x86_64","arm64"]},
+        {"name":"centos8","os":"linux","distribution":"centos","release":"8",
+         "binaryURL":"centos8","sysReqs":true,"binaries":true,"hidden":true,
+         "arch":["x86_64"]}
+    ]}"#;
+
+    fn sample() -> Vec<Distro> {
+        serde_json::from_str::<Status>(SAMPLE).unwrap().distros
+    }
+
+    #[test]
+    fn resolves_a_distro_repo_for_its_architecture() {
+        let d = sample();
+        assert_eq!(codename_for(&d, "redhat", "8", "x86_64"), Some("centos8"));
+        assert_eq!(codename_for(&d, "rockylinux", "9", "x86_64"), Some("rhel9"));
+        assert_eq!(codename_for(&d, "ubuntu", "22.04", "x86_64"), Some("jammy"));
+    }
+
+    #[test]
+    fn declines_a_repo_that_has_no_build_for_this_architecture() {
+        // The arm64 gap this module exists for: jammy is x86_64-only, so an
+        // arm64 host must be told "no" here and sent to the portable repo,
+        // which does have arm64 builds. The old slug table answered "jammy"
+        // on both architectures and left arm64 users compiling everything.
+        let d = sample();
+        assert_eq!(codename_for(&d, "ubuntu", "22.04", "arm64"), None);
+        assert_eq!(codename_for(&d, "rockylinux", "9", "arm64"), Some("rhel9"));
+        assert_eq!(portable_codename(&d, "arm64"), Some("manylinux_2_28"));
+    }
+
+    #[test]
+    fn declines_a_distro_that_has_no_binaries_at_all() {
+        // Debian 10 is in the catalog for sysreqs but `binaries: false`.
+        let d = sample();
+        assert_eq!(codename_for(&d, "debian", "10", "x86_64"), None);
+    }
+
+    #[test]
+    fn the_portable_repo_never_answers_a_distro_lookup() {
+        // manylinux_2_28 is published as distribution `centos` release `8` —
+        // the same key real CentOS 8 has. The sample lists it *before* the
+        // centos8 entry on purpose: a plain scan would return whichever comes
+        // first, so this passing on the live catalog today is luck, not
+        // design. On arm64 it is not even luck: centos8 has no arm64 build,
+        // so the portable entry is the only match and would be returned
+        // without ever going through the glibc floor check that guards it.
+        let d = sample();
+        assert_eq!(codename_for(&d, "centos", "8", "x86_64"), Some("centos8"));
+        assert_eq!(codename_for(&d, "centos", "8", "arm64"), None);
+        // Reachable only through the front door, where the floor is checked.
+        assert_eq!(portable_codename(&d, "arm64"), Some("manylinux_2_28"));
+    }
+
+    #[test]
+    fn is_known_ignores_the_portable_repo() {
+        let d = sample();
+        assert!(is_known(&d, "centos", "8"), "the real centos8 entry");
+        assert!(is_known(&d, "ubuntu", "22.04"));
+        assert!(is_known(&d, "rockylinux", "9"));
+        // Catalogued for sysreqs with binaries: false. Known — the catalog
+        // has an opinion about it — so the static table does not get to
+        // resurrect a repo Posit is declining.
+        assert!(is_known(&d, "debian", "10"));
+        assert_eq!(codename_for(&d, "debian", "10", "x86_64"), None);
+        // Never catalogued at all: the table may still know an alias.
+        assert!(!is_known(&d, "ol", "8.10"));
+    }
+
+    #[test]
+    fn unknown_distros_resolve_to_nothing() {
+        let d = sample();
+        assert_eq!(codename_for(&d, "ol", "8.10", "x86_64"), None);
+        assert_eq!(codename_for(&d, "arch", "", "x86_64"), None);
+    }
+
+    #[test]
+    fn posit_spells_aarch64_as_arm64() {
+        assert_eq!(posit_arch("aarch64"), "arm64");
+        assert_eq!(posit_arch("x86_64"), "x86_64");
+    }
+}

--- a/crates/uvr-core/tests/p3m_status_live.rs
+++ b/crates/uvr-core/tests/p3m_status_live.rs
@@ -1,0 +1,129 @@
+//! Network-gated: the compiled-in platform table must still agree with Posit.
+//!
+//! `registry::p3m_status` reads the catalog at runtime, so drift no longer
+//! breaks users — but the static table is what answers when the endpoint is
+//! unreachable, and a stale offline answer is exactly the failure mode that is
+//! invisible until someone is offline. This is the job that notices.
+//!
+//! Skipped by default so CI stays offline-stable. Run with:
+//!     cargo test -p uvr-core --test p3m_status_live -- --ignored --nocapture
+
+use uvr_core::registry::p3m::ppm_linux_codename;
+use uvr_core::registry::p3m_status;
+
+/// Slugs `detect_posit_distro_slug_from_os_release` can produce, paired with
+/// the `(distribution, release)` the sysreqs catalog keys them by — which is
+/// also how `/__api__/status` keys them.
+const MAPPED: &[(&str, &str, &str)] = &[
+    ("ubuntu-2004", "ubuntu", "20.04"),
+    ("ubuntu-2204", "ubuntu", "22.04"),
+    ("ubuntu-2404", "ubuntu", "24.04"),
+    ("ubuntu-2604", "ubuntu", "26.04"),
+    ("debian-11", "debian", "11"),
+    ("debian-12", "debian", "12"),
+    ("debian-13", "debian", "13"),
+    ("rhel-7", "redhat", "7"),
+    ("rhel-8", "redhat", "8"),
+    ("rhel-9", "rockylinux", "9"),
+    ("rhel-10", "rockylinux", "10"),
+    ("opensuse-154", "opensuse", "15.4"),
+    ("opensuse-155", "opensuse", "15.5"),
+    ("opensuse-156", "opensuse", "15.6"),
+];
+
+async fn catalog() -> Vec<p3m_status::Distro> {
+    let client = reqwest::Client::builder()
+        .user_agent("uvr-test")
+        .build()
+        .unwrap();
+    p3m_status::fetch(&client)
+        .await
+        .expect("the platform catalog must be reachable for this test")
+}
+
+#[tokio::test]
+#[ignore = "requires network access to packagemanager.posit.co"]
+async fn the_static_table_matches_the_live_catalog() {
+    let distros = catalog().await;
+    let mut wrong = Vec::new();
+    for (slug, distribution, release) in MAPPED {
+        let live = p3m_status::codename_for(&distros, distribution, release, "x86_64");
+        let table = ppm_linux_codename(slug);
+        if live != table {
+            wrong.push(format!(
+                "{slug} ({distribution}/{release}): table says {table:?}, catalog says {live:?}"
+            ));
+        }
+    }
+    assert!(
+        wrong.is_empty(),
+        "the compiled-in table disagrees with Posit's catalog — it is what \
+         answers when the endpoint is unreachable, so fix it:\n  {}",
+        wrong.join("\n  ")
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires network access to packagemanager.posit.co"]
+async fn the_portable_repo_still_covers_both_architectures() {
+    // The whole arm64 story rests on this: distros without a native arm64
+    // build are routed here instead. If Posit ever drops arm64 from the
+    // portable repo, those users go back to compiling and should hear it from
+    // CI rather than from a slow install.
+    let distros = catalog().await;
+    for arch in ["x86_64", "arm64"] {
+        assert_eq!(
+            p3m_status::portable_codename(&distros, arch),
+            Some("manylinux_2_28"),
+            "no portable repo for {arch}"
+        );
+    }
+}
+
+#[tokio::test]
+#[ignore = "requires network access to packagemanager.posit.co"]
+async fn the_aliased_pairs_resolve_in_the_platform_catalog_too() {
+    // The pairs `catalog_alias` rewrites are absent from *both* Posit
+    // catalogs, not just the sysreqs one. If Posit ever starts publishing
+    // rockylinux 8 or centos 9/10 the alias becomes unnecessary here, and if
+    // it stops publishing the RHEL names the alias becomes wrong — either way
+    // this is where it shows up.
+    let distros = catalog().await;
+    for (from, to, release) in [
+        ("rockylinux", "redhat", "8"),
+        ("centos", "redhat", "9"),
+        ("centos", "redhat", "10"),
+    ] {
+        assert!(
+            p3m_status::codename_for(&distros, from, release, "x86_64").is_none(),
+            "{from}/{release} is published after all — the alias is now unnecessary"
+        );
+        assert!(
+            p3m_status::codename_for(&distros, to, release, "x86_64").is_some(),
+            "{to}/{release} is not published — the alias now points nowhere"
+        );
+    }
+}
+
+#[tokio::test]
+#[ignore = "requires network access to packagemanager.posit.co"]
+async fn some_distro_repo_carries_arm64() {
+    // Guards the arch plumbing itself. If every entry lost its arm64 build,
+    // `codename_for(.., "arm64")` would answer None everywhere and the arch
+    // filter would look like it worked while quietly routing everyone to the
+    // portable repo.
+    let distros = catalog().await;
+    let native: Vec<&str> = ["rockylinux/9", "rockylinux/10", "ubuntu/24.04"]
+        .iter()
+        .filter(|k| {
+            let (d, r) = k.split_once('/').unwrap();
+            p3m_status::codename_for(&distros, d, r, "arm64").is_some()
+        })
+        .copied()
+        .collect();
+    assert!(
+        !native.is_empty(),
+        "no distro repo reports an arm64 build; the arch field or its spelling changed"
+    );
+    eprintln!("distro repos with arm64 builds: {native:?}");
+}


### PR DESCRIPTION
**Stack position: merge first.** Merge order is #213 → #215 → #216 → #211. All four are rebased on `bacdfe5` and #212/#214 have landed, so nothing borrows another branch's commits any more. Verified by merging all four in that order: the only collision in the stack is the `## Unreleased` changelog anchor between #215 and #216, where both sides append. `cargo test --all` 563 passed, clippy clean, fmt clean. Nothing depends on it to compile; #215 was held behind it because they overlap in `downloader.rs`, and both of its review items are now closed.

## Problem

`ppm_linux_codename` maps a distro slug to a repo codename and has no notion of architecture — because nothing in uvr knew there was one to have. Posit's `/__api__/status` publishes it: only `rhel9`, `rhel10`, `noble`, `resolute` and `manylinux_2_28` carry arm64 builds.

P3M routes by the R User-Agent and degrades to **source** when a repo has no build for the caller's architecture, so this failed quietly:

```
jammy          aarch64  ->  source                                  (no arm64 build)
noble          aarch64  ->  BINARY  bin/4.5-noble-arm64
rhel9          aarch64  ->  BINARY  bin/4.5-rhel9-arm64
manylinux_2_28 aarch64  ->  BINARY  bin/4.5-manylinux_2_28-arm64
```

An arm64 host on Ubuntu 22.04, Debian 12, RHEL 8 or openSUSE was pointed at a repo with no arm64 build and compiled every package, while the portable repo — which does build for arm64 — sat unused. Nothing broke the way #175 did, since P3M serves source rather than the wrong architecture. It was just slow, and invisible.

## Fix

Read the catalog at runtime: one `GET /__api__/status`, cached daily beside the package indexes, and pick a repo that serves this distro on this architecture.

The lookup keys on the `(distribution, release)` pair `normalize_distro` already produces for sysreqs, and applies the same `catalog_alias` (#214). **Both Posit catalogs speak one vocabulary and have the same holes in it**, so uvr needs one translation from `/etc/os-release` rather than two tables to keep in sync — the endpoint lists `sles156` as distribution `sle`, release `15.6`, `binaryURL: opensuse156`, exactly the split #210 encoded by hand. Without the alias, Rocky/Alma 8 and CentOS Stream fall through to the static table and lose precisely the architecture awareness this PR adds.

Three cases, kept distinct on purpose:

| catalog says | uvr does |
|---|---|
| names a repo | use it |
| knows the pair, no build for this arch | authoritative no → portable repo, else source. The table gets **no second vote** — it cannot express "not on arm64" |
| never heard of the pair, or unreachable | compiled-in table, which knows aliases the catalog doesn't publish |

That middle row is the whole point, and it's why the fallback isn't simply "try the table next".

## The portable repo is excluded from distro lookups by name

Posit publishes `manylinux_2_28` as `distribution: "centos", release: "8"` — the same key real CentOS 8 has. A plain scan returns whichever the array lists first, so getting the right one today is luck rather than design; and on arm64, where `centos8` has no build, the portable entry is the only match and would be returned **without going through the glibc floor check that guards it**. The test pins this with the portable entry listed first in the fixture, so ordering cannot mask it.

`--distribution` still wins over the catalog: it's the user saying uvr's autodetection is wrong on this host, and the catalog lookup starts from that same autodetection (#54). Added `distro_override_is_set()` so the catalog path stands down.

## Tests

Unit tests cover the arch filter (`jammy`/arm64 → `None`, `rhel9`/arm64 → `rhel9`), `binaries: false` entries (Debian 10 is catalogued for sysreqs only), the portable-repo ambiguity above, and that a declining catalog is not overridden by the table.

`p3m_status_live.rs` (`#[ignore]`d, network) asserts the compiled-in table still agrees with the live catalog — it's what answers offline, and a stale offline answer is invisible until someone is offline. All 14 mapped slugs agree today. It also pins the aliased pairs from #214 against the platform catalog in both directions: if Posit starts publishing `rockylinux` 8 the alias becomes unnecessary, and if it stops publishing the RHEL names the alias points nowhere — either way CI says so.

`cargo test --all` green (350 unit + 9 integration binaries), clippy clean, fmt clean.

## Not in this PR

`uvr doctor` still reports from the static table; it's sync and this path is async. Worth following up, since doctor is where a user would look to see which repo they're getting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PkvRyFs8awBe4nHFjcvoa2

