### PR TITLE
fix(sysreqs): close the last three RHEL-family alias gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,22 @@ Pure tracking section — fixes and small features land here between tags.
   without printing a sysreqs warning either. The check now runs after the
   tarballs are downloaded and reads `SystemRequirements` from each one's
   DESCRIPTION, which is where the field is actually published.
+
+- Oracle Linux gets binary packages, not just system dependencies (#209
+  follow-up). `ID="ol"` was aliased onto RHEL for sysreqs but not for the P3M
+  slug, so OL hosts resolved their system libraries correctly and then
+  compiled every package from source.
+
+- Rocky/Alma 8 and CentOS Stream 9/10 get authoritative sysreqs answers
+  instead of the local-rules fallback. Posit's catalogs serve `rockylinux`
+  from 9 on and `centos` only through 8, so those hosts fell back to the
+  vendored rules and printed a degraded-check warning for distros Posit does
+  cover, under their RHEL name. Catalogs are now asked under a name they
+  publish. The
+  local rules keep the unaliased name on purpose — they are not
+  interchangeable there: `rockylinux` 8 carries `leptonica-devel` where
+  `redhat` 8 carries nothing, and `centos` 8 wants `libarchive-devel` where
+  `redhat` 8 says `libarchive`.
 - System dependencies are resolved on RHEL and its rebuilds (#209). uvr asked
   both sysreqs catalogs under the raw `/etc/os-release` identity, which neither
   speaks: Posit's API answers `Unsupported system` for `rhel`/`8.10` but

--- a/crates/uvr-core/src/r_version/downloader.rs
+++ b/crates/uvr-core/src/r_version/downloader.rs
@@ -292,7 +292,12 @@ pub(crate) fn detect_posit_distro_slug_from_os_release(content: Option<&str>) ->
         }
         "debian" => format!("debian-{version_id}"),
         "centos" => format!("centos-{version_id}"),
-        "rhel" | "rocky" | "almalinux" => {
+        // Oracle Linux reports ID="ol" and is a straight RHEL rebuild, so it
+        // takes RHEL's binaries. Without this it fell through to the
+        // catch-all as `ol-8.10`, which maps to no PPM codename — Oracle
+        // users compiled everything (#209 follow-up). Kept in step with the
+        // sysreqs side of the same alias in `sysreqs::normalize_distro`.
+        "rhel" | "rocky" | "almalinux" | "ol" => {
             let major = version_id.split('.').next().unwrap_or(&version_id);
             format!("rhel-{major}")
         }

--- a/crates/uvr-core/src/sysreqs.rs
+++ b/crates/uvr-core/src/sysreqs.rs
@@ -85,6 +85,37 @@ pub(crate) fn normalize_distro(id: &str, version_id: &str) -> (String, String) {
     (distribution.to_string(), release.to_string())
 }
 
+/// Ask a Posit catalog under a name it actually publishes.
+///
+/// Both of Posit's catalogs — the sysreqs API and the platform list at
+/// `/__api__/status` that P3M binary selection reads — are keyed by the same
+/// `(distribution, release)` vocabulary, and both have the same holes in it,
+/// so both need this. The two sysreqs sources do not cover the same ground. Verified against
+/// `/__api__/status`, which lists every platform Posit serves: the API has
+/// `rockylinux` 9 and 10 but no 8, and `centos` 7 and 8 but no Stream 9 or
+/// 10. The vendored rules cover all four, so those hosts were already getting
+/// correct answers — they were just getting them from the fallback, with a
+/// "check degraded" warning, for distros Posit knows perfectly well under
+/// their RHEL name.
+///
+/// Applied only when querying a catalog. The vendored local rules
+/// deliberately keep the unaliased pair, because the two are *not*
+/// interchangeable there:
+/// `rockylinux` 8 resolves `leptonica-devel` where `redhat` 8 resolves
+/// nothing, and `centos` 8 says `libarchive-devel` where `redhat` 8 says
+/// `libarchive`. Aliasing the local lookup too would trade a spurious warning
+/// for wrong package names.
+pub(crate) fn catalog_alias<'a>(distribution: &'a str, release: &'a str) -> (&'a str, &'a str) {
+    match (distribution, release) {
+        // Rocky/Alma 8. Posit publishes rockylinux from 9 on.
+        ("rockylinux", "8") => ("redhat", "8"),
+        // CentOS Stream. Posit's `centos` stops at 8; Stream tracks the
+        // RHEL major of the same number.
+        ("centos", r) if r.parse::<u32>().is_ok_and(|n| n >= 9) => ("redhat", r),
+        _ => (distribution, release),
+    }
+}
+
 /// Response from the Posit Package Manager sysreqs API.
 #[derive(Debug, Deserialize)]
 struct PpmSysreqsResponse {
@@ -144,6 +175,7 @@ pub async fn resolve_system_deps(
     distro: &str,
 ) -> Result<SysReqLookup> {
     let (distribution, release) = distro.split_once('-').unwrap_or((distro, ""));
+    let (distribution, release) = catalog_alias(distribution, release);
 
     let url = "https://packagemanager.posit.co/__api__/repos/1/sysreqs";
 
@@ -486,6 +518,76 @@ mod tests {
         assert!(
             gdal.iter().any(|p| p == "gdal-devel"),
             "expected gdal-devel for rhel-8.10, got {gdal:?}"
+        );
+    }
+
+    #[test]
+    fn catalogs_are_asked_under_a_name_they_publish() {
+        // Posit serves rockylinux from 9 on, and centos only through 8
+        // (verified against /__api__/status). Asking under the RHEL name is
+        // what turns a degraded-check warning back into a real answer.
+        assert_eq!(catalog_alias("rockylinux", "8"), ("redhat", "8"));
+        assert_eq!(catalog_alias("centos", "9"), ("redhat", "9"));
+        assert_eq!(catalog_alias("centos", "10"), ("redhat", "10"));
+
+        // Everything Posit does publish is left alone.
+        assert_eq!(catalog_alias("rockylinux", "9"), ("rockylinux", "9"));
+        assert_eq!(catalog_alias("rockylinux", "10"), ("rockylinux", "10"));
+        assert_eq!(catalog_alias("centos", "7"), ("centos", "7"));
+        assert_eq!(catalog_alias("centos", "8"), ("centos", "8"));
+        assert_eq!(catalog_alias("redhat", "8"), ("redhat", "8"));
+        assert_eq!(catalog_alias("ubuntu", "22.04"), ("ubuntu", "22.04"));
+        // Not a release number: must not be mistaken for a Stream major.
+        assert_eq!(catalog_alias("centos", "stream"), ("centos", "stream"));
+    }
+
+    #[test]
+    fn the_local_rules_are_not_aliased() {
+        // The alias exists for the API only. These pairs resolve *differently*
+        // in the vendored rules, so aliasing the local lookup as well would
+        // trade a spurious warning for wrong package names.
+        assert!(
+            sysreqs_rules::resolve_local("leptonica", "rockylinux", "8")
+                .iter()
+                .any(|p| p == "leptonica-devel"),
+            "rockylinux 8 carries leptonica-devel"
+        );
+        assert!(
+            sysreqs_rules::resolve_local("leptonica", "redhat", "8").is_empty(),
+            "redhat 8 does not — aliasing the local lookup would lose it"
+        );
+        // Both halves of the libarchive divergence, so the test actually
+        // guards the claim: aliasing the local lookup would swap a headers
+        // package for a runtime one, and a source build would fail at
+        // configure with nothing pointing at the cause.
+        assert!(
+            sysreqs_rules::resolve_local("libarchive", "centos", "8")
+                .iter()
+                .any(|p| p == "libarchive-devel"),
+            "centos 8 wants the -devel package"
+        );
+        assert_eq!(
+            sysreqs_rules::resolve_local("libarchive", "redhat", "8"),
+            vec!["libarchive".to_string()],
+            "redhat 8 names the runtime package, not the headers"
+        );
+    }
+
+    #[test]
+    fn oracle_linux_also_gets_rhel_binaries() {
+        // The sysreqs half of this alias landed with #209; the binary half did
+        // not, so OL hosts resolved their system deps correctly and then
+        // compiled every package because `ol-8.10` maps to no PPM codename.
+        // Both axes have to agree or the alias is only half applied.
+        assert_eq!(
+            crate::r_version::downloader::detect_posit_distro_slug_from_os_release(Some(
+                "ID=ol\nVERSION_ID=8.10\n"
+            )),
+            "rhel-8"
+        );
+        assert_eq!(
+            crate::registry::p3m::ppm_linux_codename("rhel-8"),
+            Some("centos8")
         );
     }
 


### PR DESCRIPTION
**Stack position: merge first.** #213 depends on this (it calls `catalog_alias`) and will not compile without it. Nothing depends on the reverse.

Follow-up to #209, closing the last three RHEL-family gaps the `/__api__/status` sweep on #211 turned up. All for the same reason: the name uvr uses is not the name a catalog publishes.

## Oracle Linux got no binaries

#209 aliased `ID="ol"` onto RHEL for sysreqs but not for the P3M slug, so OL hosts resolved their system libraries correctly and then compiled every package — `ol-8.10` maps to no PPM codename. Half an alias is its own failure mode, and worse than none, because the working half makes it look handled.

Both axes now agree, and a test asserts they do rather than leaving the next person to notice.

## Rocky/Alma 8 and CentOS Stream 9/10 fell back for no reason

`/__api__/status` lists every platform Posit serves. The sysreqs API has `rockylinux` 9 and 10 but no 8, and `centos` 7 and 8 but no Stream 9 or 10:

```
?distribution=rockylinux&release=8  -> {"code":14,"error":"Unsupported system"}
?distribution=redhat&release=8      -> {"requirements":[{"name":"xml2", ...}]}
?distribution=centos&release=9      -> {"code":14,"error":"Unsupported system"}
?distribution=redhat&release=9      -> {"requirements":[{"name":"xml2", ...}]}
?distribution=centos&release=10     -> {"code":14,"error":"Unsupported system"}
?distribution=redhat&release=10     -> {"requirements":[{"name":"xml2", ...}]}
```

Those hosts were already getting correct answers — from the vendored rules, with a "check degraded" warning, for distros Posit knows perfectly well under their RHEL name.

## Why the alias lives at the query site, not in `normalize_distro`

Because the two vocabularies are **not** interchangeable in the local rules. Measured:

```
resolve_local("leptonica",  "rockylinux", "8") -> ["leptonica-devel"]
resolve_local("leptonica",  "redhat",     "8") -> []
resolve_local("libarchive", "centos",     "8") -> ["libarchive-devel"]
resolve_local("libarchive", "redhat",     "8") -> ["libarchive"]
```

Aliasing the local lookup as well would trade a spurious warning for wrong package names — `libarchive` instead of `libarchive-devel` is a source build that fails at `configure` with no hint why. So `catalog_alias` is applied where a catalog is queried, and `check_pkg_local` keeps the unaliased pair. A test pins all four of those resolutions so a future "simplification" that merges them fails loudly.

That measurement is also why this PR does **not** collapse the RHEL family onto `redhat` wholesale, which was the tidier-looking option: across 41 common `SystemRequirements` strings, `rockylinux` 9/10 and `redhat` 9/10 agree on everything but ordering, but `rockylinux` 8 differs from `redhat` 8 in 7 of 41 — in both directions.

The helper is named `catalog_alias`, not `api_alias`, and is `pub(crate)`: the platform list P3M binary selection reads has the same holes in the same vocabulary, so #213 applies it too. Keeping one copy is the point — two would drift.

## Tests

- `catalog_alias` maps the three unpublished pairs and leaves every published one alone, including `centos`/`stream`, which must not be mistaken for a release number.
- the local rules are asserted *not* aliased, via the four resolutions above.
- Oracle Linux resolves to `rhel-8` → `centos8` on the binary axis, alongside the existing sysreqs assertion.

`cargo test --all` green, clippy clean, fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PkvRyFs8awBe4nHFjcvoa2
