### PR TITLE
fix(sysreqs): don't report a successful local check as skipped

### DIFF
--- a/crates/uvr-core/src/sysreqs.rs
+++ b/crates/uvr-core/src/sysreqs.rs
@@ -586,7 +586,9 @@ mod tests {
         let mut out = SysReqsCheck::default();
         let pkg = PackageSysReqQuery {
             name: "xml2".to_string(),
-            system_requirements: Some("libxml2: libxml2-dev (deb), libxml2-devel (rpm)".to_string()),
+            system_requirements: Some(
+                "libxml2: libxml2-dev (deb), libxml2-devel (rpm)".to_string(),
+            ),
             bioc: false,
         };
         check_pkg_local(&mut out, &pkg, "alpine-3.23.5");

--- a/crates/uvr-core/src/sysreqs.rs
+++ b/crates/uvr-core/src/sysreqs.rs
@@ -240,12 +240,19 @@ pub struct SysReqsCheck {
     /// Missing system packages keyed by R package name.
     pub missing: HashMap<String, Vec<SysReq>>,
     /// Set when the Posit API reported the distro as unsupported.
-    /// When true, `missing` is not authoritative — the check was skipped.
+    /// When true, the API contributed nothing — but the vendored local
+    /// rules still ran, so `missing` may well be authoritative. Read this
+    /// together with `local_resolved` before claiming the check was skipped.
     pub unsupported_distro: bool,
     /// Set when at least one API lookup failed outright (network/HTTP/parse,
     /// #148). Affected packages were checked against the vendored local
-    /// rules instead, so `missing` is best-effort rather than authoritative.
+    /// rules instead.
     pub lookup_failed: bool,
+    /// Number of packages the vendored local rules resolved to at least one
+    /// system package. Distinguishes "the fallback ran and found nothing
+    /// missing" from "the fallback had nothing to say" — conflating those is
+    /// what made a successful Alpine check report itself as skipped.
+    pub local_resolved: usize,
 }
 
 /// R package to check sysreqs for.
@@ -350,6 +357,9 @@ fn check_pkg_local(out: &mut SysReqsCheck, pkg: &PackageSysReqQuery, distro: &st
     if resolved.is_empty() {
         return;
     }
+    // Past this point the local rules produced a real answer for this
+    // package, whether or not anything turns out to be missing.
+    out.local_resolved += 1;
     let missing = filter_missing(&resolved);
     if !missing.is_empty() {
         out.missing
@@ -564,5 +574,52 @@ mod tests {
             pkgs.iter().any(|p| p == "libxml2-dev"),
             "expected libxml2-dev in fallback output, got {pkgs:?}"
         );
+    }
+
+    #[test]
+    fn local_resolution_is_recorded_even_when_nothing_is_missing() {
+        // The Alpine bug: the vendored rules DO resolve `libxml2` on
+        // alpine-3.23.5, so a run where every resolved package is already
+        // installed is a *successful* check, not a skipped one. The counter
+        // is incremented before `filter_missing` runs, so this assertion is
+        // independent of what is installed on the test host.
+        let mut out = SysReqsCheck::default();
+        let pkg = PackageSysReqQuery {
+            name: "xml2".to_string(),
+            system_requirements: Some("libxml2: libxml2-dev (deb), libxml2-devel (rpm)".to_string()),
+            bioc: false,
+        };
+        check_pkg_local(&mut out, &pkg, "alpine-3.23.5");
+        assert_eq!(
+            out.local_resolved, 1,
+            "libxml2 resolves to libxml2-dev on alpine; that is a real answer"
+        );
+    }
+
+    #[test]
+    fn no_sysreqs_field_does_not_count_as_a_local_resolution() {
+        let mut out = SysReqsCheck::default();
+        let pkg = PackageSysReqQuery {
+            name: "jsonlite".to_string(),
+            system_requirements: None,
+            bioc: false,
+        };
+        check_pkg_local(&mut out, &pkg, "alpine-3.23.5");
+        assert_eq!(out.local_resolved, 0);
+    }
+
+    #[test]
+    fn unmatched_sysreqs_text_does_not_count_as_a_local_resolution() {
+        // A non-empty SystemRequirements string that matches no vendored rule
+        // is the genuine "we could not check this" case and must stay
+        // distinguishable from the two above.
+        let mut out = SysReqsCheck::default();
+        let pkg = PackageSysReqQuery {
+            name: "madeup".to_string(),
+            system_requirements: Some("a-library-no-rule-mentions-xyzzy".to_string()),
+            bioc: false,
+        };
+        check_pkg_local(&mut out, &pkg, "alpine-3.23.5");
+        assert_eq!(out.local_resolved, 0);
     }
 }

--- a/crates/uvr/src/commands/sync.rs
+++ b/crates/uvr/src/commands/sync.rs
@@ -937,17 +937,20 @@ async fn install_from_lockfile_with_r(
                     // fact nothing needed checking. Gate on the presence of
                     // sysreqs so the warning fires only when there's actually
                     // a check we couldn't perform.
-                    let any_has_sysreqs = queries.iter().any(|q| {
-                        q.system_requirements
-                            .as_deref()
-                            .is_some_and(|s| !s.trim().is_empty())
-                    });
+                    //
+                    // Counted, not `any()`: the gate below asks whether the
+                    // local rules covered *every* declaring package, so it
+                    // needs the denominator, not just "at least one".
+                    let pkgs_with_sysreqs = queries
+                        .iter()
+                        .filter(|q| {
+                            q.system_requirements
+                                .as_deref()
+                                .is_some_and(|s| !s.trim().is_empty())
+                        })
+                        .count();
 
-                    if check.lookup_failed
-                        && check.missing.is_empty()
-                        && check.local_resolved == 0
-                        && any_has_sysreqs
-                    {
+                    if check.lookup_failed && local_check_incomplete(&check, pkgs_with_sysreqs) {
                         // The sysreqs API couldn't be reached/parsed for at least
                         // one package and the local-rules fallback found nothing
                         // missing (#148). Say the check was degraded rather than
@@ -962,15 +965,13 @@ async fn install_from_lockfile_with_r(
                         );
                         eprintln!();
                     } else if check.unsupported_distro
-                        && check.missing.is_empty()
-                        && check.local_resolved == 0
-                        && any_has_sysreqs
+                        && local_check_incomplete(&check, pkgs_with_sysreqs)
                     {
                         // The API declined this distro AND the vendored rules
-                        // matched none of the declared SystemRequirements. Only
-                        // then was the check genuinely skipped: when the local
-                        // rules did resolve, an empty `missing` means every
-                        // requirement is already installed.
+                        // did not cover every declaring package. Only then was
+                        // part of the check genuinely skipped: for the packages
+                        // the local rules did resolve, an empty `missing` means
+                        // every requirement is already installed.
                         eprintln!();
                         ui::warn_block(
                             &format!("System dependency check skipped on {distro}"),
@@ -1625,6 +1626,32 @@ fn pick_sysreqs_installer(packages: &[&str]) -> Option<(String, Vec<String>)> {
     }
 }
 
+/// Whether the vendored local rules left part of the check unanswered.
+///
+/// `pkgs_with_sysreqs` is how many packages in this sync declare a
+/// non-empty `SystemRequirements`; `check.local_resolved` is how many of
+/// them the local rules matched to at least one system package.
+///
+/// This is deliberately a *per-package* comparison rather than
+/// `local_resolved == 0`. The any-package form silences the warning for
+/// a whole sync as soon as a single package resolves: a 40-package
+/// Alpine sync where only `xml2` matches a vendored rule would report
+/// nothing, implying uvr had checked all 40. `curl`/`openssl`/`xml2`
+/// resolve on nearly every distro, so in practice the warning became
+/// unreachable. Warn whenever at least one declaring package went
+/// unchecked.
+///
+/// `missing` must still be empty: when something is actually missing,
+/// the caller reports that instead, which is strictly more useful than a
+/// "the check may be incomplete" note.
+#[cfg(target_os = "linux")]
+fn local_check_incomplete(
+    check: &uvr_core::sysreqs::SysReqsCheck,
+    pkgs_with_sysreqs: usize,
+) -> bool {
+    check.missing.is_empty() && pkgs_with_sysreqs > 0 && check.local_resolved < pkgs_with_sysreqs
+}
+
 /// Prompt before invoking the system package manager. Same TTY-only
 /// pattern as `confirm_library_wipe` — non-interactive sessions
 /// (CI, scripts) proceed without prompting since the user opted in via
@@ -1786,6 +1813,42 @@ mod tests {
         if let Err(e) = result {
             std::panic::resume_unwind(e);
         }
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn a_partially_resolved_local_check_still_warns() {
+        use uvr_core::sysreqs::SysReqsCheck;
+
+        // The case an `== 0` gate silently swallowed: 40 packages declare
+        // `SystemRequirements`, the vendored rules match exactly one of them
+        // (`xml2` on Alpine), and the other 39 were never checked. Staying
+        // quiet here implies uvr checked all 40.
+        let one_of_forty = SysReqsCheck {
+            local_resolved: 1,
+            ..Default::default()
+        };
+        assert!(local_check_incomplete(&one_of_forty, 40));
+
+        // Every declaring package resolved: nothing was skipped, so an empty
+        // `missing` is a genuine pass (the Alpine false positive in #30).
+        let all_resolved = SysReqsCheck {
+            local_resolved: 40,
+            ..Default::default()
+        };
+        assert!(!local_check_incomplete(&all_resolved, 40));
+
+        // No package declares anything: there was no check to perform.
+        assert!(!local_check_incomplete(&SysReqsCheck::default(), 0));
+
+        // Something is actually missing — the caller reports the packages
+        // instead, which supersedes any "check may be incomplete" note.
+        let with_missing = SysReqsCheck {
+            local_resolved: 1,
+            missing: std::collections::HashMap::from([("sf".to_string(), Vec::new())]),
+            ..Default::default()
+        };
+        assert!(!local_check_incomplete(&with_missing, 40));
     }
 
     #[cfg(target_os = "linux")]

--- a/crates/uvr/src/commands/sync.rs
+++ b/crates/uvr/src/commands/sync.rs
@@ -943,7 +943,11 @@ async fn install_from_lockfile_with_r(
                             .is_some_and(|s| !s.trim().is_empty())
                     });
 
-                    if check.lookup_failed && check.missing.is_empty() && any_has_sysreqs {
+                    if check.lookup_failed
+                        && check.missing.is_empty()
+                        && check.local_resolved == 0
+                        && any_has_sysreqs
+                    {
                         // The sysreqs API couldn't be reached/parsed for at least
                         // one package and the local-rules fallback found nothing
                         // missing (#148). Say the check was degraded rather than
@@ -959,18 +963,19 @@ async fn install_from_lockfile_with_r(
                         eprintln!();
                     } else if check.unsupported_distro
                         && check.missing.is_empty()
+                        && check.local_resolved == 0
                         && any_has_sysreqs
                     {
-                        // PPM doesn't cover this distro AND the local fallback
-                        // found nothing (either no rule matched any of the
-                        // declared SystemRequirements, or the local rules are
-                        // out of date). Tell the user we skipped the check
-                        // rather than silently claiming everything is fine.
+                        // The API declined this distro AND the vendored rules
+                        // matched none of the declared SystemRequirements. Only
+                        // then was the check genuinely skipped: when the local
+                        // rules did resolve, an empty `missing` means every
+                        // requirement is already installed.
                         eprintln!();
                         ui::warn_block(
                             &format!("System dependency check skipped on {distro}"),
                             vec![
-                                "Posit's sysreqs catalog doesn't cover this distribution, and the local fallback had no applicable rules.".to_string(),
+                                "Posit's sysreqs API doesn't serve this distribution, and no vendored rule matched the declared SystemRequirements.".to_string(),
                                 "Packages with system-library requirements may fail to compile from source.".to_string(),
                             ],
                         );


### PR DESCRIPTION
## The problem

Every Alpine build prints a warning that is false:

```
 ! WARN  System dependency check skipped on alpine-3.23.5
  Posit's sysreqs catalog doesn't cover this distribution, and the local fallback had no applicable rules.
```

Both halves are wrong.

**The catalog does cover Alpine.** In the vendored snapshot, 106 of 131 rule files carry alpine constraints, and 99 of the 111 alpine constraints have no `versions` key at all. What doesn't cover Alpine is Posit's *HTTP API*, which returns `{"code":14,"error":"Unsupported system"}`. The message blamed the wrong component.

**And the check had actually succeeded.** When the API declines a distro, `check_system_deps` routes every package through the vendored rules, which resolve Alpine correctly (`curl` → `curl-dev`, `openssl-dev`; `xml2` → `libxml2-dev`, including the `3.23.5` → `3.23` truncation). Those go through `filter_missing`, and on a pre-provisioned image everything is already installed, so `missing` comes back empty. `SysReqsCheck` had no field distinguishing "the fallback ran and found nothing missing" from "the fallback could not check", so the branch reported a successful check as a skipped one.

### Why it started appearing after #208

Before #208, `SystemRequirements` was `None` for every CRAN package, so `any_has_sysreqs` was false and this branch never fired — as #208's own commit message notes. By populating the field from the tarball, #208 flipped that gate true while leaving the `missing.is_empty()` conflation intact. The fix surfaced a latent bug.

## The change

`SysReqsCheck` gains `local_resolved`, counting packages the vendored rules resolved to at least one system package. It is incremented in `check_pkg_local` *before* `filter_missing` shells out, so it is independent of what happens to be installed.

Both warning branches — `lookup_failed` and `unsupported_distro` — then gate on `local_check_incomplete()`, which compares `local_resolved` against the number of packages that actually declare `SystemRequirements`. A per-package comparison rather than `== 0` matters: the any-package form would silence the warning for a whole sync as soon as one package resolved, and since `curl`/`openssl`/`xml2` resolve nearly everywhere, that would have made the warning unreachable.

The skipped-check message now names the API rather than the catalog.

## Verification

In `build-env-alpine:3.23` (`VERSION_ID=3.23.5`), with `harfbuzz-dev`/`fribidi-dev` installed so every `textshaping` requirement resolves and is present:

- before: `! WARN  System dependency check skipped on alpine-3.23.5`
- after: silent

Positive control, same package with those two absent — must still fire, and does:

```
 ! WARN  Missing system dependencies for 1 package(s)
  textshaping needs: fribidi-dev, harfbuzz-dev
```

Tests: 492 → 496.
