### PR TITLE
perf(sysreqs): one Posit API request per sync instead of one per package

### DIFF
--- a/crates/uvr-core/src/sysreqs.rs
+++ b/crates/uvr-core/src/sysreqs.rs
@@ -3,7 +3,6 @@ use std::collections::HashMap;
 use serde::Deserialize;
 use tracing::{debug, warn};
 
-use crate::error::Result;
 use crate::sysreqs_rules;
 
 /// A resolved system dependency with its apt/rpm package name.
@@ -135,25 +134,6 @@ fn parse_sysreqs_index(
     Ok(index)
 }
 
-/// Outcome of a sysreqs API lookup.
-///
-/// `UnsupportedDistro` lets callers tell "no system deps needed" apart from
-/// "we couldn't check because Posit's catalog doesn't cover this distro"
-/// (e.g. Alpine — see issue #30). Silently treating the latter as the former
-/// makes uvr act like it verified sysreqs when it actually skipped them,
-/// which bites users whose packages then fail to compile from source.
-#[derive(Debug, Clone)]
-pub enum SysReqLookup {
-    Supported(Vec<SysReq>),
-    UnsupportedDistro,
-    /// The API couldn't be consulted at all (network failure, non-success
-    /// HTTP status, unparseable body). Distinct from `Supported(vec![])` —
-    /// "no sysdeps needed" — so callers can fall back to the vendored local
-    /// rules instead of silently acting as if the check passed (#148). An
-    /// offline CI runner used to get neither API nor local results.
-    LookupFailed,
-}
-
 /// Detects the Posit PPM "Unsupported system" error body.
 ///
 /// Response shape: `{"code":14,"error":"Unsupported system"}`. Match on the
@@ -161,76 +141,6 @@ pub enum SysReqLookup {
 /// non-success responses but don't want to couple to a specific HTTP code.
 fn is_unsupported_system_body(body: &str) -> bool {
     body.contains("Unsupported system")
-}
-
-/// Query the Posit Package Manager sysreqs API for system dependencies.
-///
-/// API: `GET https://packagemanager.posit.co/__api__/repos/1/sysreqs?all=false&pkgname=<name>&distribution=<os>&release=<version>`
-///
-/// This replaces the archived r-hub sysreqs API with Posit's actively
-/// maintained r-system-requirements catalog.
-pub async fn resolve_system_deps(
-    client: &reqwest::Client,
-    package_name: &str,
-    distro: &str,
-) -> Result<SysReqLookup> {
-    let (distribution, release) = distro.split_once('-').unwrap_or((distro, ""));
-
-    let url = "https://packagemanager.posit.co/__api__/repos/1/sysreqs";
-
-    debug!(
-        "Querying Posit sysreqs API for {package_name} (distro={distribution}, release={release})"
-    );
-
-    let resp = client
-        .get(url)
-        .query(&[
-            ("all", "false"),
-            ("pkgname", package_name),
-            ("distribution", distribution),
-            ("release", release),
-        ])
-        .send()
-        .await;
-
-    let resp = match resp {
-        Ok(r) => r,
-        Err(e) => {
-            warn!("Posit sysreqs API request failed: {e}");
-            return Ok(SysReqLookup::LookupFailed);
-        }
-    };
-
-    let status = resp.status();
-    let body = resp.text().await.unwrap_or_default();
-
-    if !status.is_success() {
-        if is_unsupported_system_body(&body) {
-            debug!("Posit sysreqs API reports {distribution} is unsupported");
-            return Ok(SysReqLookup::UnsupportedDistro);
-        }
-        warn!("Posit sysreqs API returned {status} for {package_name}");
-        return Ok(SysReqLookup::LookupFailed);
-    }
-
-    let response: PpmSysreqsResponse = match serde_json::from_str(&body) {
-        Ok(r) => r,
-        Err(e) => {
-            warn!("Failed to parse Posit sysreqs API response: {e}");
-            return Ok(SysReqLookup::LookupFailed);
-        }
-    };
-
-    let mut result = Vec::new();
-    for req in response.requirements {
-        for pkg in req.requirements.packages {
-            if !pkg.is_empty() {
-                result.push(SysReq { package: pkg });
-            }
-        }
-    }
-
-    Ok(SysReqLookup::Supported(result))
 }
 
 /// Outcome of the one-per-sync batched sysreqs fetch.
@@ -362,67 +272,71 @@ pub struct PackageSysReqQuery {
 /// Resolve and check system dependencies for a set of packages.
 ///
 /// Flow:
-/// 1. Query Posit's sysreqs API per package.
-/// 2. If PPM reports `UnsupportedDistro` (e.g. Alpine), stop querying and
-///    fall back to the vendored `r-system-requirements` rules. The fallback
-///    matches each package's `SystemRequirements` string against the local
-///    rule table. This is the path that addresses issue #30 end-to-end.
-/// 3. Filter the resolved deps through the installed package manager
+/// 1. Fetch the whole distro's sysreqs index in a single batched request
+///    (see `fetch_sysreqs_index`).
+/// 2. If PPM reports `UnsupportedDistro` (e.g. Alpine) or the fetch failed
+///    outright, fall back to the vendored `r-system-requirements` rules for
+///    every package. The fallback matches each package's
+///    `SystemRequirements` string against the local rule table. This is the
+///    path that addresses issue #30 end-to-end.
+/// 3. Bioc packages always go straight to the local rules, regardless of
+///    the index outcome — the Posit API is CRAN-only and 500s for Bioc
+///    names (#202).
+/// 4. Filter the resolved deps through the installed package manager
 ///    (`dpkg`/`rpm`/`apk`) to surface only the ones that are actually
 ///    missing.
 ///
-/// Returns both the missing-deps map and a flag indicating whether PPM
-/// rejected the distribution (set true even when the local fallback fills
-/// in results, so callers can mention the provenance if they want).
+/// Returns both the missing-deps map and flags indicating whether PPM
+/// rejected the distribution or the fetch failed (set true even when the
+/// local fallback fills in results, so callers can mention the provenance if
+/// they want).
 pub async fn check_system_deps(
     client: &reqwest::Client,
     packages: &[PackageSysReqQuery],
     distro: &str,
 ) -> SysReqsCheck {
     let mut out = SysReqsCheck::default();
-    let mut local_fallback = false;
-    let mut tail_start: usize = 0;
 
-    for (idx, pkg) in packages.iter().enumerate() {
-        // The Posit API is CRAN-only; Bioc names 500 every time. Check them
-        // against the vendored local rules directly — no request, no WARN,
-        // and no degraded-check flag, since nothing actually degraded (#202).
-        if pkg.bioc {
+    // Skip the fetch entirely when every package in the sync is Bioc-sourced:
+    // the index would never be consulted (see the loop below), so fetching
+    // it would just be a wasted round trip that could also spuriously flag
+    // `lookup_failed` on a network hiccup, even though nothing in this sync
+    // actually depended on reaching the API (#202).
+    let needs_index = packages.iter().any(|pkg| !pkg.bioc);
+
+    // One request for the whole sync, not one per package.
+    let index = if needs_index {
+        match fetch_sysreqs_index(client, distro).await {
+            SysReqIndex::Supported(idx) => Some(idx),
+            SysReqIndex::UnsupportedDistro => {
+                out.unsupported_distro = true;
+                None
+            }
+            SysReqIndex::LookupFailed => {
+                out.lookup_failed = true;
+                None
+            }
+        }
+    } else {
+        None
+    };
+
+    for pkg in packages {
+        // The Posit API is CRAN-only; Bioc names are absent from its index,
+        // so check them against the vendored local rules directly (#202).
+        let Some(index) = index.as_ref().filter(|_| !pkg.bioc) else {
             check_pkg_local(&mut out, pkg, distro);
             continue;
-        }
-        match resolve_system_deps(client, &pkg.name, distro).await {
-            Ok(SysReqLookup::Supported(resolved)) => {
-                let missing = filter_missing(&resolved);
-                if !missing.is_empty() {
-                    out.missing
-                        .insert(pkg.name.clone(), missing.into_iter().cloned().collect());
-                }
-            }
-            Ok(SysReqLookup::UnsupportedDistro) => {
-                out.unsupported_distro = true;
-                local_fallback = true;
-                tail_start = idx;
-                break;
-            }
-            Ok(SysReqLookup::LookupFailed) => {
-                // API unreachable/broken for this package (#148): check it
-                // against the vendored local rules instead of pretending the
-                // check passed, but keep querying the API for the rest — a
-                // transient per-request failure shouldn't downgrade the
-                // whole run to local rules.
-                out.lookup_failed = true;
-                check_pkg_local(&mut out, pkg, distro);
-            }
-            Err(e) => {
-                warn!("Failed to resolve system deps for {}: {e}", pkg.name);
-            }
-        }
-    }
-
-    if local_fallback {
-        for pkg in &packages[tail_start..] {
-            check_pkg_local(&mut out, pkg, distro);
+        };
+        let Some(resolved) = index.get(&pkg.name) else {
+            // Absent from the index means the package declares no system
+            // requirements, which is the common case.
+            continue;
+        };
+        let missing = filter_missing(resolved);
+        if !missing.is_empty() {
+            out.missing
+                .insert(pkg.name.clone(), missing.into_iter().cloned().collect());
         }
     }
 

--- a/crates/uvr-core/src/sysreqs.rs
+++ b/crates/uvr-core/src/sysreqs.rs
@@ -698,6 +698,14 @@ mod tests {
         // Absence from the index means "declares no system requirements",
         // per `parse_sysreqs_index`'s own contract — not an error, and not
         // a reason to fall back to local rules for that package.
+        //
+        // `system_requirements` is deliberately set to a string that WOULD
+        // resolve locally (the same trigger already verified elsewhere in
+        // this file to resolve on ubuntu-22.04) so this test can actually
+        // tell "skipped" apart from "silently fell back to local rules" —
+        // with `None` here, both behaviours produce identical output
+        // (`check_pkg_local` no-ops on `None` regardless), making the
+        // assertions vacuous.
         let mut index = HashMap::new();
         index.insert(
             "curl".to_string(),
@@ -708,7 +716,7 @@ mod tests {
         let mut out = SysReqsCheck::default();
         let packages = vec![PackageSysReqQuery {
             name: "jsonlite".to_string(),
-            system_requirements: None,
+            system_requirements: Some("libxml2 (>= 2.6.3)".to_string()),
             bioc: false,
         }];
         apply_index(&mut out, &packages, Some(&index), "ubuntu-22.04");

--- a/crates/uvr-core/src/sysreqs.rs
+++ b/crates/uvr-core/src/sysreqs.rs
@@ -110,15 +110,17 @@ struct PpmRequirementDetail {
 ///
 /// Packages absent from the map declare no system requirements — the API
 /// only lists those that do.
-fn parse_sysreqs_index(body: &str) -> HashMap<String, Vec<SysReq>> {
+///
+/// Fallible on purpose: an infallible version that swallowed the parse error
+/// into an empty map would make a malformed 200 response look identical to
+/// "no package on this distro needs anything", silently and on every distro.
+/// The per-package path this replaces mapped a parse failure to
+/// `LookupFailed`; keep that.
+fn parse_sysreqs_index(
+    body: &str,
+) -> std::result::Result<HashMap<String, Vec<SysReq>>, serde_json::Error> {
     let mut index: HashMap<String, Vec<SysReq>> = HashMap::new();
-    let response: PpmSysreqsResponse = match serde_json::from_str(body) {
-        Ok(r) => r,
-        Err(e) => {
-            warn!("Failed to parse Posit sysreqs index: {e}");
-            return index;
-        }
-    };
+    let response: PpmSysreqsResponse = serde_json::from_str(body)?;
     for req in response.requirements {
         if req.name.is_empty() {
             continue;
@@ -130,7 +132,7 @@ fn parse_sysreqs_index(body: &str) -> HashMap<String, Vec<SysReq>> {
             }
         }
     }
-    index
+    Ok(index)
 }
 
 /// Outcome of a sysreqs API lookup.
@@ -279,7 +281,13 @@ async fn fetch_sysreqs_index(client: &reqwest::Client, distro: &str) -> SysReqIn
         return SysReqIndex::LookupFailed;
     }
 
-    SysReqIndex::Supported(parse_sysreqs_index(&body))
+    match parse_sysreqs_index(&body) {
+        Ok(index) => SysReqIndex::Supported(index),
+        Err(e) => {
+            warn!("Failed to parse Posit sysreqs index: {e}");
+            SysReqIndex::LookupFailed
+        }
+    }
 }
 
 /// Check which packages are missing on the system.
@@ -714,7 +722,7 @@ mod tests {
             {"name":"ABC.RAP","requirements":{"packages":["make"]}},
             {"name":"curl","requirements":{"packages":["libcurl4-openssl-dev","libssl-dev"]}}
         ]}"#;
-        let index = parse_sysreqs_index(body);
+        let index = parse_sysreqs_index(body).unwrap();
         assert_eq!(index.len(), 2);
         let curl: Vec<&str> = index["curl"].iter().map(|r| r.package.as_str()).collect();
         assert_eq!(curl, vec!["libcurl4-openssl-dev", "libssl-dev"]);
@@ -726,7 +734,7 @@ mod tests {
         // "needs nothing", not an error.
         let body =
             r#"{"requirements":[{"name":"curl","requirements":{"packages":["libssl-dev"]}}]}"#;
-        let index = parse_sysreqs_index(body);
+        let index = parse_sysreqs_index(body).unwrap();
         assert!(!index.contains_key("jsonlite"));
     }
 
@@ -734,8 +742,18 @@ mod tests {
     fn empty_package_names_are_skipped() {
         let body =
             r#"{"requirements":[{"name":"x","requirements":{"packages":["","libssl-dev"]}}]}"#;
-        let index = parse_sysreqs_index(body);
+        let index = parse_sysreqs_index(body).unwrap();
         let x: Vec<&str> = index["x"].iter().map(|r| r.package.as_str()).collect();
         assert_eq!(x, vec!["libssl-dev"]);
+    }
+
+    #[test]
+    fn malformed_index_body_is_an_error_not_an_empty_map() {
+        // A malformed or truncated 200 response must not be silently treated
+        // as "no package on this distro needs anything" — that would be
+        // indistinguishable from a genuinely empty, well-formed index. This
+        // is what routes `fetch_sysreqs_index` to `LookupFailed` instead of
+        // `Supported(HashMap::new())` on a broken body.
+        assert!(parse_sysreqs_index("{not json").is_err());
     }
 }

--- a/crates/uvr-core/src/sysreqs.rs
+++ b/crates/uvr-core/src/sysreqs.rs
@@ -242,9 +242,9 @@ pub struct SysReqsCheck {
     /// rules still ran, so `missing` may well be authoritative. Read this
     /// together with `local_resolved` before claiming the check was skipped.
     pub unsupported_distro: bool,
-    /// Set when at least one API lookup failed outright (network/HTTP/parse,
-    /// #148). Affected packages were checked against the vendored local
-    /// rules instead.
+    /// Set when the single batched index fetch failed outright
+    /// (network/HTTP/parse, #148). Every package was checked against the
+    /// vendored local rules instead.
     pub lookup_failed: bool,
     /// Number of packages the vendored local rules resolved to at least one
     /// system package. Distinguishes "the fallback ran and found nothing
@@ -263,9 +263,10 @@ pub struct PackageSysReqQuery {
     /// the vendored `r-system-requirements` rules locally.
     pub system_requirements: Option<String>,
     /// True for Bioconductor-sourced packages. The Posit sysreqs API only
-    /// covers CRAN and returns HTTP 500 for Bioc names, so querying it is a
-    /// guaranteed per-package WARN with zero information (#202) — Bioc
-    /// packages go straight to the vendored local rules instead.
+    /// covers CRAN and returns HTTP 500 for Bioc names, so looking one up in
+    /// the fetched index would be a guaranteed non-match with zero
+    /// information (#202) — Bioc packages go straight to the vendored local
+    /// rules instead.
     pub bioc: bool,
 }
 
@@ -321,11 +322,29 @@ pub async fn check_system_deps(
         None
     };
 
+    apply_index(&mut out, packages, index.as_ref(), distro);
+
+    out
+}
+
+/// Decide, per package, whether to use the fetched index or the vendored
+/// local rules, and record the outcome.
+///
+/// Synchronous and free of I/O beyond `filter_missing`'s package-manager
+/// queries, so it can be exercised directly with a hand-built `index`
+/// instead of requiring network access — that is the whole reason this is
+/// split out of `check_system_deps`.
+fn apply_index(
+    out: &mut SysReqsCheck,
+    packages: &[PackageSysReqQuery],
+    index: Option<&HashMap<String, Vec<SysReq>>>,
+    distro: &str,
+) {
     for pkg in packages {
         // The Posit API is CRAN-only; Bioc names are absent from its index,
         // so check them against the vendored local rules directly (#202).
-        let Some(index) = index.as_ref().filter(|_| !pkg.bioc) else {
-            check_pkg_local(&mut out, pkg, distro);
+        let Some(index) = index.filter(|_| !pkg.bioc) else {
+            check_pkg_local(out, pkg, distro);
             continue;
         };
         let Some(resolved) = index.get(&pkg.name) else {
@@ -339,14 +358,12 @@ pub async fn check_system_deps(
                 .insert(pkg.name.clone(), missing.into_iter().cloned().collect());
         }
     }
-
-    out
 }
 
 /// Check one package's `SystemRequirements` against the vendored
 /// `r-system-requirements` rules and record any missing system packages.
-/// Shared by the unsupported-distro tail fallback and the per-package
-/// API-failure fallback (#148).
+/// Shared by the unsupported-distro / lookup-failed fallback in
+/// `apply_index` and the direct Bioc bypass in the same function.
 fn check_pkg_local(out: &mut SysReqsCheck, pkg: &PackageSysReqQuery, distro: &str) {
     let (distribution, version) = distro.split_once('-').unwrap_or((distro, ""));
     let Some(sys_req_text) = pkg.system_requirements.as_deref() else {
@@ -625,6 +642,118 @@ mod tests {
         };
         check_pkg_local(&mut out, &pkg, "alpine-3.23.5");
         assert_eq!(out.local_resolved, 0);
+    }
+
+    #[test]
+    fn no_index_falls_back_to_local_rules_for_every_package() {
+        // The unsupported-distro / lookup-failed case: `apply_index` gets
+        // `index = None` and must run every package through the vendored
+        // local rules rather than skipping them. Assert on `local_resolved`,
+        // not `missing` — the counter is incremented before `filter_missing`
+        // runs, so it holds regardless of what is installed on the test
+        // host (the Alpine bug this whole check exists to catch).
+        let mut out = SysReqsCheck::default();
+        let packages = vec![PackageSysReqQuery {
+            name: "xml2".to_string(),
+            system_requirements: Some(
+                "libxml2: libxml2-dev (deb), libxml2-devel (rpm)".to_string(),
+            ),
+            bioc: false,
+        }];
+        apply_index(&mut out, &packages, None, "alpine-3.23.5");
+        assert_eq!(
+            out.local_resolved, 1,
+            "with no index, xml2 must be resolved via the local rules"
+        );
+    }
+
+    #[test]
+    fn a_package_present_in_the_index_is_not_also_checked_locally() {
+        // The common, covered-distro case: when the index has an entry, it
+        // is authoritative and the local rules must NOT run — even though
+        // `system_requirements` here would resolve locally too, proving the
+        // index path was actually taken instead of the fallback.
+        let mut index = HashMap::new();
+        index.insert(
+            "curl".to_string(),
+            vec![SysReq {
+                package: "libcurl4-openssl-dev".to_string(),
+            }],
+        );
+        let mut out = SysReqsCheck::default();
+        let packages = vec![PackageSysReqQuery {
+            name: "curl".to_string(),
+            system_requirements: Some("libxml2 (>= 2.6.3)".to_string()),
+            bioc: false,
+        }];
+        apply_index(&mut out, &packages, Some(&index), "ubuntu-22.04");
+        assert_eq!(
+            out.local_resolved, 0,
+            "curl is in the index, so the local rules must be bypassed entirely"
+        );
+    }
+
+    #[test]
+    fn a_package_absent_from_the_index_is_skipped_not_faulted() {
+        // Absence from the index means "declares no system requirements",
+        // per `parse_sysreqs_index`'s own contract — not an error, and not
+        // a reason to fall back to local rules for that package.
+        let mut index = HashMap::new();
+        index.insert(
+            "curl".to_string(),
+            vec![SysReq {
+                package: "libcurl4-openssl-dev".to_string(),
+            }],
+        );
+        let mut out = SysReqsCheck::default();
+        let packages = vec![PackageSysReqQuery {
+            name: "jsonlite".to_string(),
+            system_requirements: None,
+            bioc: false,
+        }];
+        apply_index(&mut out, &packages, Some(&index), "ubuntu-22.04");
+        assert!(
+            out.missing.is_empty(),
+            "a package absent from the index must not produce a missing entry"
+        );
+        assert_eq!(
+            out.local_resolved, 0,
+            "a package absent from the index must not fall back to local rules"
+        );
+    }
+
+    #[test]
+    fn mixed_bioc_and_cran_packages_split_between_index_and_local_rules() {
+        // The subtle case the `.filter(|_| !pkg.bioc)` line encodes: in a
+        // single sync with a fetched index, the Bioc package must still go
+        // to the local rules while the CRAN package alongside it uses the
+        // index, even though both apply_index calls share the same `Some`
+        // index.
+        let mut index = HashMap::new();
+        index.insert(
+            "curl".to_string(),
+            vec![SysReq {
+                package: "libcurl4-openssl-dev".to_string(),
+            }],
+        );
+        let mut out = SysReqsCheck::default();
+        let packages = vec![
+            PackageSysReqQuery {
+                name: "Rhtslib".to_string(),
+                system_requirements: Some("libxml2 (>= 2.6.3)".to_string()),
+                bioc: true,
+            },
+            PackageSysReqQuery {
+                name: "curl".to_string(),
+                system_requirements: Some("libxml2 (>= 2.6.3)".to_string()),
+                bioc: false,
+            },
+        ];
+        apply_index(&mut out, &packages, Some(&index), "ubuntu-22.04");
+        assert_eq!(
+            out.local_resolved, 1,
+            "only the Bioc package (Rhtslib) should have gone through the local rules"
+        );
     }
 
     #[test]

--- a/crates/uvr-core/src/sysreqs.rs
+++ b/crates/uvr-core/src/sysreqs.rs
@@ -586,7 +586,9 @@ mod tests {
         let mut out = SysReqsCheck::default();
         let pkg = PackageSysReqQuery {
             name: "xml2".to_string(),
-            system_requirements: Some("libxml2: libxml2-dev (deb), libxml2-devel (rpm)".to_string()),
+            system_requirements: Some(
+                "libxml2: libxml2-dev (deb), libxml2-devel (rpm)".to_string(),
+            ),
             bioc: false,
         };
         check_pkg_local(&mut out, &pkg, "alpine-3.23.5");

--- a/crates/uvr-core/src/sysreqs.rs
+++ b/crates/uvr-core/src/sysreqs.rs
@@ -240,12 +240,19 @@ pub struct SysReqsCheck {
     /// Missing system packages keyed by R package name.
     pub missing: HashMap<String, Vec<SysReq>>,
     /// Set when the Posit API reported the distro as unsupported.
-    /// When true, `missing` is not authoritative — the check was skipped.
+    /// When true, the API contributed nothing — but the vendored local
+    /// rules still ran, so `missing` may well be authoritative. Read this
+    /// together with `local_resolved` before claiming the check was skipped.
     pub unsupported_distro: bool,
     /// Set when at least one API lookup failed outright (network/HTTP/parse,
     /// #148). Affected packages were checked against the vendored local
-    /// rules instead, so `missing` is best-effort rather than authoritative.
+    /// rules instead.
     pub lookup_failed: bool,
+    /// Number of packages the vendored local rules resolved to at least one
+    /// system package. Distinguishes "the fallback ran and found nothing
+    /// missing" from "the fallback had nothing to say" — conflating those is
+    /// what made a successful Alpine check report itself as skipped.
+    pub local_resolved: usize,
 }
 
 /// R package to check sysreqs for.
@@ -350,6 +357,9 @@ fn check_pkg_local(out: &mut SysReqsCheck, pkg: &PackageSysReqQuery, distro: &st
     if resolved.is_empty() {
         return;
     }
+    // Past this point the local rules produced a real answer for this
+    // package, whether or not anything turns out to be missing.
+    out.local_resolved += 1;
     let missing = filter_missing(&resolved);
     if !missing.is_empty() {
         out.missing
@@ -564,5 +574,52 @@ mod tests {
             pkgs.iter().any(|p| p == "libxml2-dev"),
             "expected libxml2-dev in fallback output, got {pkgs:?}"
         );
+    }
+
+    #[test]
+    fn local_resolution_is_recorded_even_when_nothing_is_missing() {
+        // The Alpine bug: the vendored rules DO resolve `libxml2` on
+        // alpine-3.23.5, so a run where every resolved package is already
+        // installed is a *successful* check, not a skipped one. The counter
+        // is incremented before `filter_missing` runs, so this assertion is
+        // independent of what is installed on the test host.
+        let mut out = SysReqsCheck::default();
+        let pkg = PackageSysReqQuery {
+            name: "xml2".to_string(),
+            system_requirements: Some("libxml2: libxml2-dev (deb), libxml2-devel (rpm)".to_string()),
+            bioc: false,
+        };
+        check_pkg_local(&mut out, &pkg, "alpine-3.23.5");
+        assert_eq!(
+            out.local_resolved, 1,
+            "libxml2 resolves to libxml2-dev on alpine; that is a real answer"
+        );
+    }
+
+    #[test]
+    fn no_sysreqs_field_does_not_count_as_a_local_resolution() {
+        let mut out = SysReqsCheck::default();
+        let pkg = PackageSysReqQuery {
+            name: "jsonlite".to_string(),
+            system_requirements: None,
+            bioc: false,
+        };
+        check_pkg_local(&mut out, &pkg, "alpine-3.23.5");
+        assert_eq!(out.local_resolved, 0);
+    }
+
+    #[test]
+    fn unmatched_sysreqs_text_does_not_count_as_a_local_resolution() {
+        // A non-empty SystemRequirements string that matches no vendored rule
+        // is the genuine "we could not check this" case and must stay
+        // distinguishable from the two above.
+        let mut out = SysReqsCheck::default();
+        let pkg = PackageSysReqQuery {
+            name: "madeup".to_string(),
+            system_requirements: Some("a-library-no-rule-mentions-xyzzy".to_string()),
+            bioc: false,
+        };
+        check_pkg_local(&mut out, &pkg, "alpine-3.23.5");
+        assert_eq!(out.local_resolved, 0);
     }
 }

--- a/crates/uvr-core/src/sysreqs.rs
+++ b/crates/uvr-core/src/sysreqs.rs
@@ -95,6 +95,8 @@ struct PpmSysreqsResponse {
 #[derive(Debug, Deserialize)]
 struct PpmRequirement {
     #[serde(default)]
+    name: String,
+    #[serde(default)]
     requirements: PpmRequirementDetail,
 }
 
@@ -102,6 +104,33 @@ struct PpmRequirement {
 struct PpmRequirementDetail {
     #[serde(default)]
     packages: Vec<String>,
+}
+
+/// Index a batched (`all=true`) sysreqs response by R package name.
+///
+/// Packages absent from the map declare no system requirements — the API
+/// only lists those that do.
+fn parse_sysreqs_index(body: &str) -> HashMap<String, Vec<SysReq>> {
+    let mut index: HashMap<String, Vec<SysReq>> = HashMap::new();
+    let response: PpmSysreqsResponse = match serde_json::from_str(body) {
+        Ok(r) => r,
+        Err(e) => {
+            warn!("Failed to parse Posit sysreqs index: {e}");
+            return index;
+        }
+    };
+    for req in response.requirements {
+        if req.name.is_empty() {
+            continue;
+        }
+        let entry = index.entry(req.name).or_default();
+        for pkg in req.requirements.packages {
+            if !pkg.is_empty() {
+                entry.push(SysReq { package: pkg });
+            }
+        }
+    }
+    index
 }
 
 /// Outcome of a sysreqs API lookup.
@@ -200,6 +229,57 @@ pub async fn resolve_system_deps(
     }
 
     Ok(SysReqLookup::Supported(result))
+}
+
+/// Outcome of the one-per-sync batched sysreqs fetch.
+enum SysReqIndex {
+    Supported(HashMap<String, Vec<SysReq>>),
+    UnsupportedDistro,
+    LookupFailed,
+}
+
+/// Fetch every package's system requirements for `distro` in one request.
+///
+/// Replaces the per-package `all=false&pkgname=` loop: a 68-package sync
+/// made 68 requests, where `all=true` answers in one (~150 KB, ~1125
+/// entries for ubuntu 22.04).
+async fn fetch_sysreqs_index(client: &reqwest::Client, distro: &str) -> SysReqIndex {
+    let (distribution, release) = distro.split_once('-').unwrap_or((distro, ""));
+    let url = "https://packagemanager.posit.co/__api__/repos/1/sysreqs";
+
+    debug!("Fetching Posit sysreqs index (distro={distribution}, release={release})");
+
+    let resp = client
+        .get(url)
+        .query(&[
+            ("all", "true"),
+            ("distribution", distribution),
+            ("release", release),
+        ])
+        .send()
+        .await;
+
+    let resp = match resp {
+        Ok(r) => r,
+        Err(e) => {
+            warn!("Posit sysreqs API request failed: {e}");
+            return SysReqIndex::LookupFailed;
+        }
+    };
+
+    let status = resp.status();
+    let body = resp.text().await.unwrap_or_default();
+
+    if !status.is_success() {
+        if is_unsupported_system_body(&body) {
+            debug!("Posit sysreqs API reports {distribution} is unsupported");
+            return SysReqIndex::UnsupportedDistro;
+        }
+        warn!("Posit sysreqs API returned {status} for the {distribution} index");
+        return SysReqIndex::LookupFailed;
+    }
+
+    SysReqIndex::Supported(parse_sysreqs_index(&body))
 }
 
 /// Check which packages are missing on the system.
@@ -623,5 +703,39 @@ mod tests {
         };
         check_pkg_local(&mut out, &pkg, "alpine-3.23.5");
         assert_eq!(out.local_resolved, 0);
+    }
+
+    #[test]
+    fn batched_index_is_keyed_by_package_name() {
+        // Shape of `?all=true&distribution=ubuntu&release=22.04`, which
+        // returns every package that declares sysreqs for that distro
+        // (~1125 entries, ~150 KB) in a single response.
+        let body = r#"{"requirements":[
+            {"name":"ABC.RAP","requirements":{"packages":["make"]}},
+            {"name":"curl","requirements":{"packages":["libcurl4-openssl-dev","libssl-dev"]}}
+        ]}"#;
+        let index = parse_sysreqs_index(body);
+        assert_eq!(index.len(), 2);
+        let curl: Vec<&str> = index["curl"].iter().map(|r| r.package.as_str()).collect();
+        assert_eq!(curl, vec!["libcurl4-openssl-dev", "libssl-dev"]);
+    }
+
+    #[test]
+    fn packages_absent_from_the_index_have_no_sysreqs() {
+        // The API only lists packages that declare sysreqs, so absence is
+        // "needs nothing", not an error.
+        let body =
+            r#"{"requirements":[{"name":"curl","requirements":{"packages":["libssl-dev"]}}]}"#;
+        let index = parse_sysreqs_index(body);
+        assert!(!index.contains_key("jsonlite"));
+    }
+
+    #[test]
+    fn empty_package_names_are_skipped() {
+        let body =
+            r#"{"requirements":[{"name":"x","requirements":{"packages":["","libssl-dev"]}}]}"#;
+        let index = parse_sysreqs_index(body);
+        let x: Vec<&str> = index["x"].iter().map(|r| r.package.as_str()).collect();
+        assert_eq!(x, vec!["libssl-dev"]);
     }
 }

--- a/crates/uvr/src/commands/sync.rs
+++ b/crates/uvr/src/commands/sync.rs
@@ -937,17 +937,20 @@ async fn install_from_lockfile_with_r(
                     // fact nothing needed checking. Gate on the presence of
                     // sysreqs so the warning fires only when there's actually
                     // a check we couldn't perform.
-                    let any_has_sysreqs = queries.iter().any(|q| {
-                        q.system_requirements
-                            .as_deref()
-                            .is_some_and(|s| !s.trim().is_empty())
-                    });
+                    //
+                    // Counted, not `any()`: the gate below asks whether the
+                    // local rules covered *every* declaring package, so it
+                    // needs the denominator, not just "at least one".
+                    let pkgs_with_sysreqs = queries
+                        .iter()
+                        .filter(|q| {
+                            q.system_requirements
+                                .as_deref()
+                                .is_some_and(|s| !s.trim().is_empty())
+                        })
+                        .count();
 
-                    if check.lookup_failed
-                        && check.missing.is_empty()
-                        && check.local_resolved == 0
-                        && any_has_sysreqs
-                    {
+                    if check.lookup_failed && local_check_incomplete(&check, pkgs_with_sysreqs) {
                         // The sysreqs API couldn't be reached/parsed for at least
                         // one package and the local-rules fallback found nothing
                         // missing (#148). Say the check was degraded rather than
@@ -962,15 +965,13 @@ async fn install_from_lockfile_with_r(
                         );
                         eprintln!();
                     } else if check.unsupported_distro
-                        && check.missing.is_empty()
-                        && check.local_resolved == 0
-                        && any_has_sysreqs
+                        && local_check_incomplete(&check, pkgs_with_sysreqs)
                     {
                         // The API declined this distro AND the vendored rules
-                        // matched none of the declared SystemRequirements. Only
-                        // then was the check genuinely skipped: when the local
-                        // rules did resolve, an empty `missing` means every
-                        // requirement is already installed.
+                        // did not cover every declaring package. Only then was
+                        // part of the check genuinely skipped: for the packages
+                        // the local rules did resolve, an empty `missing` means
+                        // every requirement is already installed.
                         eprintln!();
                         ui::warn_block(
                             &format!("System dependency check skipped on {distro}"),
@@ -1625,6 +1626,32 @@ fn pick_sysreqs_installer(packages: &[&str]) -> Option<(String, Vec<String>)> {
     }
 }
 
+/// Whether the vendored local rules left part of the check unanswered.
+///
+/// `pkgs_with_sysreqs` is how many packages in this sync declare a
+/// non-empty `SystemRequirements`; `check.local_resolved` is how many of
+/// them the local rules matched to at least one system package.
+///
+/// This is deliberately a *per-package* comparison rather than
+/// `local_resolved == 0`. The any-package form silences the warning for
+/// a whole sync as soon as a single package resolves: a 40-package
+/// Alpine sync where only `xml2` matches a vendored rule would report
+/// nothing, implying uvr had checked all 40. `curl`/`openssl`/`xml2`
+/// resolve on nearly every distro, so in practice the warning became
+/// unreachable. Warn whenever at least one declaring package went
+/// unchecked.
+///
+/// `missing` must still be empty: when something is actually missing,
+/// the caller reports that instead, which is strictly more useful than a
+/// "the check may be incomplete" note.
+#[cfg(target_os = "linux")]
+fn local_check_incomplete(
+    check: &uvr_core::sysreqs::SysReqsCheck,
+    pkgs_with_sysreqs: usize,
+) -> bool {
+    check.missing.is_empty() && pkgs_with_sysreqs > 0 && check.local_resolved < pkgs_with_sysreqs
+}
+
 /// Prompt before invoking the system package manager. Same TTY-only
 /// pattern as `confirm_library_wipe` — non-interactive sessions
 /// (CI, scripts) proceed without prompting since the user opted in via
@@ -1786,6 +1813,42 @@ mod tests {
         if let Err(e) = result {
             std::panic::resume_unwind(e);
         }
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn a_partially_resolved_local_check_still_warns() {
+        use uvr_core::sysreqs::SysReqsCheck;
+
+        // The case an `== 0` gate silently swallowed: 40 packages declare
+        // `SystemRequirements`, the vendored rules match exactly one of them
+        // (`xml2` on Alpine), and the other 39 were never checked. Staying
+        // quiet here implies uvr checked all 40.
+        let one_of_forty = SysReqsCheck {
+            local_resolved: 1,
+            ..Default::default()
+        };
+        assert!(local_check_incomplete(&one_of_forty, 40));
+
+        // Every declaring package resolved: nothing was skipped, so an empty
+        // `missing` is a genuine pass (the Alpine false positive in #30).
+        let all_resolved = SysReqsCheck {
+            local_resolved: 40,
+            ..Default::default()
+        };
+        assert!(!local_check_incomplete(&all_resolved, 40));
+
+        // No package declares anything: there was no check to perform.
+        assert!(!local_check_incomplete(&SysReqsCheck::default(), 0));
+
+        // Something is actually missing — the caller reports the packages
+        // instead, which supersedes any "check may be incomplete" note.
+        let with_missing = SysReqsCheck {
+            local_resolved: 1,
+            missing: std::collections::HashMap::from([("sf".to_string(), Vec::new())]),
+            ..Default::default()
+        };
+        assert!(!local_check_incomplete(&with_missing, 40));
     }
 
     #[cfg(target_os = "linux")]

--- a/crates/uvr/src/commands/sync.rs
+++ b/crates/uvr/src/commands/sync.rs
@@ -943,7 +943,11 @@ async fn install_from_lockfile_with_r(
                             .is_some_and(|s| !s.trim().is_empty())
                     });
 
-                    if check.lookup_failed && check.missing.is_empty() && any_has_sysreqs {
+                    if check.lookup_failed
+                        && check.missing.is_empty()
+                        && check.local_resolved == 0
+                        && any_has_sysreqs
+                    {
                         // The sysreqs API couldn't be reached/parsed for at least
                         // one package and the local-rules fallback found nothing
                         // missing (#148). Say the check was degraded rather than
@@ -959,18 +963,19 @@ async fn install_from_lockfile_with_r(
                         eprintln!();
                     } else if check.unsupported_distro
                         && check.missing.is_empty()
+                        && check.local_resolved == 0
                         && any_has_sysreqs
                     {
-                        // PPM doesn't cover this distro AND the local fallback
-                        // found nothing (either no rule matched any of the
-                        // declared SystemRequirements, or the local rules are
-                        // out of date). Tell the user we skipped the check
-                        // rather than silently claiming everything is fine.
+                        // The API declined this distro AND the vendored rules
+                        // matched none of the declared SystemRequirements. Only
+                        // then was the check genuinely skipped: when the local
+                        // rules did resolve, an empty `missing` means every
+                        // requirement is already installed.
                         eprintln!();
                         ui::warn_block(
                             &format!("System dependency check skipped on {distro}"),
                             vec![
-                                "Posit's sysreqs catalog doesn't cover this distribution, and the local fallback had no applicable rules.".to_string(),
+                                "Posit's sysreqs API doesn't serve this distribution, and no vendored rule matched the declared SystemRequirements.".to_string(),
                                 "Packages with system-library requirements may fail to compile from source.".to_string(),
                             ],
                         );


### PR DESCRIPTION
Stacked on #219 — review that first; this branch contains its commits.

## The change

`check_system_deps` queried Posit's sysreqs API once per package, breaking out to the vendored rules on the first `Unsupported system` response. The API also serves a whole distribution in one call, so this fetches `?all=true&distribution=…&release=…` once per sync (~150 KB, ~1125 entries for ubuntu 22.04) and looks each package up in it.

Measured on `ubuntu:22.04` with a 32-package resolution: **32 requests → 1**.

## Equivalence

The resolved system-package sets are byte-identical before and after — `diff` over the deduplicated sorted sets is empty, and the aggregate `Install with: apt-get install -y …` line matches exactly.

**One visible output change, worth calling out.** The old per-package endpoint returns the *recursive dependency closure* tagged by `name`, and the old code ignored `req.name`, attributing every dependency to whichever package was queried — so `pkgname=gert` reported `credentials`, `curl` and `openssl`'s requirements as `gert`'s. The batched index attributes each to its own package. The aggregate set is unchanged because `check_system_deps` always receives the full transitive install set.

## Two things this deliberately preserves

**Malformed responses stay distinguishable from empty ones.** `parse_sysreqs_index` returns `Result`, and a JSON failure yields `LookupFailed`, not `Supported(empty)`. An infallible version would make a truncated 200 response look identical to "no package on this distro needs anything" — on every distro, silently — and would regress against the `resolve_system_deps` it replaces.

**All-Bioconductor syncs still make zero API requests.** The fetch is guarded on at least one non-Bioc package being present. Without that guard, batching would have quietly dropped the #202 guarantee and let a network hiccup flag `lookup_failed` on a sync that never needed the API.

## Known tradeoff

A single transient API failure now downgrades the whole sync to the vendored rules, where the old loop kept querying for the remaining packages. That is inherent to fetching once, and the local rules are a complete fallback.

## Structure

The per-package decision is extracted into a synchronous `apply_index`, so the branch selection is testable without network. Four tests cover unsupported-distro, index-hit, index-miss and mixed Bioc/CRAN, asserting on `local_resolved` rather than `missing` so they hold regardless of what is installed on the test host.

Tests: 496 → 504.
