### PR TITLE
feat(sysreqs): run the rules' pre_install/post_install commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ release page on GitHub. Issue numbers reference https://github.com/nbafrank/uvr/
 
 Pure tracking section — fixes and small features land here between tags.
 
+- **`--install-system-deps` now runs the setup commands the sysreqs rules
+  carry**, so it works on distros where the packages do not exist until a
+  repository is enabled.
+  63 of the 131 vendored rule files have a `pre_install` and 2 have a
+  `post_install`, and uvr dropped all of them: on Rocky 9 it tried to
+  install `gdal3.4-devel` from repos that were never enabled, and `rJava`
+  never got its `R CMD javareconf`.
+  `pre_install` now runs before the batched package install and
+  `post_install` after, both only when something is actually missing, so a
+  fully provisioned machine does not re-enable EPEL on every sync.
+  Nothing runs without `--install-system-deps` / `UVR_INSTALL_SYSREQS=1`.
+
+- **The consent block says where each root command comes from and what it
+  does.**
+  These are shell strings run as root, and two of them are worth reading
+  before approving: they arrive either from uvr's vendored
+  `r-system-requirements` snapshot or from Posit's API fetched during that
+  sync, and some of them fetch and execute remote code, install from a
+  URL, disable signature checking, or add a third-party repository.
+  Each command is now listed with both, on stderr alongside the prompt and
+  unconditionally, so redirecting stdout to a build log cannot separate
+  the consent from what it covers.
+  The block also states that an unannotated command is one uvr matched no
+  pattern in rather than one it vetted.
+
 ## v0.4.6 (2026-08-10)
 
 Standalone scripts land: a `.R` file can now declare its own dependencies

--- a/crates/uvr-core/build.rs
+++ b/crates/uvr-core/build.rs
@@ -18,10 +18,19 @@ struct Rule {
 }
 
 #[derive(Debug, Deserialize)]
+struct Command {
+    command: String,
+}
+
+#[derive(Debug, Deserialize)]
 struct Dependency {
     packages: Vec<String>,
     #[serde(default)]
     constraints: Vec<Constraint>,
+    #[serde(default)]
+    pre_install: Vec<Command>,
+    #[serde(default)]
+    post_install: Vec<Command>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -69,7 +78,7 @@ fn main() {
          // Do not edit by hand.\n\n",
     );
     out.push_str("pub struct ConstraintStatic {\n    pub os: Option<&'static str>,\n    pub distribution: Option<&'static str>,\n    pub versions: &'static [&'static str],\n}\n\n");
-    out.push_str("pub struct DependencyStatic {\n    pub packages: &'static [&'static str],\n    pub constraints: &'static [ConstraintStatic],\n}\n\n");
+    out.push_str("pub struct DependencyStatic {\n    pub packages: &'static [&'static str],\n    pub constraints: &'static [ConstraintStatic],\n    pub pre_install: &'static [&'static str],\n    pub post_install: &'static [&'static str],\n}\n\n");
     out.push_str("pub struct RuleStatic {\n    pub name: &'static str,\n    pub patterns: &'static [&'static str],\n    pub dependencies: &'static [DependencyStatic],\n}\n\n");
     writeln!(out, "pub static RULES: &[RuleStatic] = &[").unwrap();
     for (name, rule) in &rules {
@@ -107,6 +116,16 @@ fn main() {
                 writeln!(out, "] }},").unwrap();
             }
             writeln!(out, "                ],").unwrap();
+            write!(out, "                pre_install: &[").unwrap();
+            for c in &dep.pre_install {
+                write!(out, "{:?}, ", c.command).unwrap();
+            }
+            writeln!(out, "],").unwrap();
+            write!(out, "                post_install: &[").unwrap();
+            for c in &dep.post_install {
+                write!(out, "{:?}, ", c.command).unwrap();
+            }
+            writeln!(out, "],").unwrap();
             writeln!(out, "            }},").unwrap();
         }
         writeln!(out, "        ],").unwrap();

--- a/crates/uvr-core/src/installer/binary_install.rs
+++ b/crates/uvr-core/src/installer/binary_install.rs
@@ -1111,7 +1111,7 @@ mod tests {
         let pkgs = crate::sysreqs_rules::resolve_local(&sys_reqs, "alpine", "3.24.1");
         for expected in ["gdal-dev", "geos-dev", "proj-dev", "sqlite-dev"] {
             assert!(
-                pkgs.iter().any(|p| p == expected),
+                pkgs.packages.iter().any(|p| p == expected),
                 "expected {expected}, got {pkgs:?}"
             );
         }

--- a/crates/uvr-core/src/sysreqs.rs
+++ b/crates/uvr-core/src/sysreqs.rs
@@ -260,9 +260,29 @@ struct PpmRequirement {
 }
 
 #[derive(Debug, Default, Deserialize)]
+struct PpmCommand {
+    #[serde(default)]
+    command: String,
+}
+
+#[derive(Debug, Default, Deserialize)]
 struct PpmRequirementDetail {
     #[serde(default)]
     packages: Vec<String>,
+    #[serde(default)]
+    pre_install: Vec<PpmCommand>,
+    #[serde(default)]
+    post_install: Vec<PpmCommand>,
+}
+
+/// One package's entry in the batched sysreqs index: its distro packages
+/// plus any setup commands the API attaches to them (e.g. enabling EPEL
+/// before a `dnf install`, or `R CMD javareconf` after one).
+#[derive(Debug, Default)]
+struct SysReqIndexEntry {
+    packages: Vec<SysReq>,
+    pre_install: Vec<String>,
+    post_install: Vec<String>,
 }
 
 /// Index a batched (`all=true`) sysreqs response by R package name.
@@ -277,8 +297,8 @@ struct PpmRequirementDetail {
 /// `LookupFailed`; keep that.
 fn parse_sysreqs_index(
     body: &str,
-) -> std::result::Result<HashMap<String, Vec<SysReq>>, serde_json::Error> {
-    let mut index: HashMap<String, Vec<SysReq>> = HashMap::new();
+) -> std::result::Result<HashMap<String, SysReqIndexEntry>, serde_json::Error> {
+    let mut index: HashMap<String, SysReqIndexEntry> = HashMap::new();
     let response: PpmSysreqsResponse = serde_json::from_str(body)?;
     for req in response.requirements {
         if req.name.is_empty() {
@@ -287,7 +307,17 @@ fn parse_sysreqs_index(
         let entry = index.entry(req.name).or_default();
         for pkg in req.requirements.packages {
             if !pkg.is_empty() {
-                entry.push(SysReq { package: pkg });
+                entry.packages.push(SysReq { package: pkg });
+            }
+        }
+        for c in req.requirements.pre_install {
+            if !c.command.is_empty() && !entry.pre_install.contains(&c.command) {
+                entry.pre_install.push(c.command);
+            }
+        }
+        for c in req.requirements.post_install {
+            if !c.command.is_empty() && !entry.post_install.contains(&c.command) {
+                entry.post_install.push(c.command);
             }
         }
     }
@@ -305,7 +335,7 @@ fn is_unsupported_system_body(body: &str) -> bool {
 
 /// Outcome of the one-per-sync batched sysreqs fetch.
 enum SysReqIndex {
-    Supported(HashMap<String, Vec<SysReq>>),
+    Supported(HashMap<String, SysReqIndexEntry>),
     UnsupportedDistro,
     LookupFailed,
 }
@@ -516,7 +546,7 @@ pub async fn check_system_deps(
 fn apply_index(
     out: &mut SysReqsCheck,
     packages: &[PackageSysReqQuery],
-    index: Option<&HashMap<String, Vec<SysReq>>>,
+    index: Option<&HashMap<String, SysReqIndexEntry>>,
     distro: &str,
 ) {
     for pkg in packages {
@@ -526,13 +556,26 @@ fn apply_index(
             check_pkg_local(out, pkg, distro);
             continue;
         };
-        let Some(resolved) = index.get(&pkg.name) else {
+        let Some(entry) = index.get(&pkg.name) else {
             // Absent from the index means the package declares no system
             // requirements, which is the common case.
             continue;
         };
-        let missing = filter_missing(resolved);
+        let missing = filter_missing(&entry.packages);
         if !missing.is_empty() {
+            // Same rule as the local path: setup commands only matter when
+            // something is actually missing — otherwise every sync on a
+            // Rocky box would re-enable EPEL.
+            for cmd in &entry.pre_install {
+                if !out.pre_install.contains(cmd) {
+                    out.pre_install.push(cmd.clone());
+                }
+            }
+            for cmd in &entry.post_install {
+                if !out.post_install.contains(cmd) {
+                    out.post_install.push(cmd.clone());
+                }
+            }
             out.missing
                 .insert(pkg.name.clone(), missing.into_iter().cloned().collect());
         }
@@ -1024,9 +1067,12 @@ mod tests {
         let mut index = HashMap::new();
         index.insert(
             "curl".to_string(),
-            vec![SysReq {
-                package: "libcurl4-openssl-dev".to_string(),
-            }],
+            SysReqIndexEntry {
+                packages: vec![SysReq {
+                    package: "libcurl4-openssl-dev".to_string(),
+                }],
+                ..Default::default()
+            },
         );
         let mut out = SysReqsCheck::default();
         let packages = vec![PackageSysReqQuery {
@@ -1057,9 +1103,12 @@ mod tests {
         let mut index = HashMap::new();
         index.insert(
             "curl".to_string(),
-            vec![SysReq {
-                package: "libcurl4-openssl-dev".to_string(),
-            }],
+            SysReqIndexEntry {
+                packages: vec![SysReq {
+                    package: "libcurl4-openssl-dev".to_string(),
+                }],
+                ..Default::default()
+            },
         );
         let mut out = SysReqsCheck::default();
         let packages = vec![PackageSysReqQuery {
@@ -1088,9 +1137,12 @@ mod tests {
         let mut index = HashMap::new();
         index.insert(
             "curl".to_string(),
-            vec![SysReq {
-                package: "libcurl4-openssl-dev".to_string(),
-            }],
+            SysReqIndexEntry {
+                packages: vec![SysReq {
+                    package: "libcurl4-openssl-dev".to_string(),
+                }],
+                ..Default::default()
+            },
         );
         let mut out = SysReqsCheck::default();
         let packages = vec![
@@ -1124,9 +1176,12 @@ mod tests {
         let mut index = HashMap::new();
         index.insert(
             "curl".to_string(),
-            vec![SysReq {
-                package: "libcurl4-openssl-dev".to_string(),
-            }],
+            SysReqIndexEntry {
+                packages: vec![SysReq {
+                    package: "libcurl4-openssl-dev".to_string(),
+                }],
+                ..Default::default()
+            },
         );
         let mut out = SysReqsCheck::default();
         let packages = vec![
@@ -1186,7 +1241,11 @@ mod tests {
         ]}"#;
         let index = parse_sysreqs_index(body).unwrap();
         assert_eq!(index.len(), 2);
-        let curl: Vec<&str> = index["curl"].iter().map(|r| r.package.as_str()).collect();
+        let curl: Vec<&str> = index["curl"]
+            .packages
+            .iter()
+            .map(|r| r.package.as_str())
+            .collect();
         assert_eq!(curl, vec!["libcurl4-openssl-dev", "libssl-dev"]);
     }
 
@@ -1205,8 +1264,60 @@ mod tests {
         let body =
             r#"{"requirements":[{"name":"x","requirements":{"packages":["","libssl-dev"]}}]}"#;
         let index = parse_sysreqs_index(body).unwrap();
-        let x: Vec<&str> = index["x"].iter().map(|r| r.package.as_str()).collect();
+        let x: Vec<&str> = index["x"]
+            .packages
+            .iter()
+            .map(|r| r.package.as_str())
+            .collect();
         assert_eq!(x, vec!["libssl-dev"]);
+    }
+
+    #[test]
+    fn batched_index_carries_setup_commands() {
+        // Shape returned by the API for `sf` on rockylinux 9.
+        let body = r#"{"requirements":[
+            {"name":"sf","requirements":{
+                "packages":["gdal3.4-devel"],
+                "pre_install":[{"command":"dnf install -y epel-release"}]
+            }},
+            {"name":"rJava","requirements":{
+                "packages":["default-jdk"],
+                "post_install":[{"command":"R CMD javareconf"}]
+            }}
+        ]}"#;
+        let index = parse_sysreqs_index(body).unwrap();
+        assert_eq!(index["sf"].pre_install, vec!["dnf install -y epel-release"]);
+        assert_eq!(index["rJava"].post_install, vec!["R CMD javareconf"]);
+        assert!(index["sf"].post_install.is_empty());
+    }
+
+    #[test]
+    fn api_setup_commands_are_collected_only_when_something_is_missing() {
+        // Mirrors the local-path rule: an index entry with pre_install
+        // commands must not leak them into `out.pre_install` unless
+        // `filter_missing` actually reports something missing for that
+        // package — otherwise every sync on a covered distro would
+        // re-enable EPEL regardless of what's already installed.
+        let mut index = HashMap::new();
+        index.insert(
+            "sf".to_string(),
+            SysReqIndexEntry {
+                packages: vec![],
+                pre_install: vec!["dnf install -y epel-release".to_string()],
+                post_install: vec![],
+            },
+        );
+        let mut out = SysReqsCheck::default();
+        let packages = vec![PackageSysReqQuery {
+            name: "sf".to_string(),
+            system_requirements: None,
+            bioc: false,
+        }];
+        apply_index(&mut out, &packages, Some(&index), "rockylinux-9");
+        assert!(
+            out.pre_install.is_empty(),
+            "sf has no packages, so nothing can be missing, so no setup command should be collected"
+        );
     }
 
     #[test]

--- a/crates/uvr-core/src/sysreqs.rs
+++ b/crates/uvr-core/src/sysreqs.rs
@@ -426,6 +426,10 @@ pub struct SysReqsCheck {
     /// requirement: not missing, not degraded, not skipped. Silence there is
     /// precisely the false confidence this subsystem exists to prevent.
     pub local_unresolved: usize,
+    /// Deduplicated setup commands for the rules that produced `missing`.
+    pub pre_install: Vec<String>,
+    /// Deduplicated commands to run after the package install.
+    pub post_install: Vec<String>,
 }
 
 /// R package to check sysreqs for.
@@ -544,7 +548,9 @@ fn check_pkg_local(out: &mut SysReqsCheck, pkg: &PackageSysReqQuery, distro: &st
     let Some(sys_req_text) = pkg.system_requirements.as_deref() else {
         return;
     };
-    let resolved: Vec<SysReq> = sysreqs_rules::resolve_local(sys_req_text, distribution, version)
+    let local = sysreqs_rules::resolve_local(sys_req_text, distribution, version);
+    let resolved: Vec<SysReq> = local
+        .packages
         .into_iter()
         .map(|package| SysReq { package })
         .collect();
@@ -562,6 +568,18 @@ fn check_pkg_local(out: &mut SysReqsCheck, pkg: &PackageSysReqQuery, distro: &st
     out.local_resolved += 1;
     let missing = filter_missing(&resolved);
     if !missing.is_empty() {
+        // Setup commands only matter when something is actually missing —
+        // otherwise every sync on a Rocky box would re-enable EPEL.
+        for cmd in local.pre_install {
+            if !out.pre_install.contains(&cmd) {
+                out.pre_install.push(cmd);
+            }
+        }
+        for cmd in local.post_install {
+            if !out.post_install.contains(&cmd) {
+                out.post_install.push(cmd);
+            }
+        }
         out.missing
             .insert(pkg.name.clone(), missing.into_iter().cloned().collect());
     }
@@ -709,7 +727,7 @@ mod tests {
         let (distribution, release) = normalize_distro("ol", "8.10");
         let pkgs = sysreqs_rules::resolve_local("libxml2 (>= 2.6.3)", &distribution, &release);
         assert!(
-            pkgs.iter().any(|p| p == "libxml2-devel"),
+            pkgs.packages.iter().any(|p| p == "libxml2-devel"),
             "expected libxml2-devel for ol-8.10, got {pkgs:?}"
         );
     }
@@ -727,7 +745,7 @@ mod tests {
         );
         let pkgs = sysreqs_rules::resolve_local("libxml2 (>= 2.6.3)", "centos", "9");
         assert!(
-            pkgs.iter().any(|p| p == "libxml2-devel"),
+            pkgs.packages.iter().any(|p| p == "libxml2-devel"),
             "expected the version-less centos rules to still resolve, got {pkgs:?}"
         );
     }
@@ -764,12 +782,12 @@ mod tests {
         let (distribution, release) = normalize_distro("rhel", "8.10");
         let pkgs = sysreqs_rules::resolve_local("libxml2 (>= 2.6.3)", &distribution, &release);
         assert!(
-            pkgs.iter().any(|p| p == "libxml2-devel"),
+            pkgs.packages.iter().any(|p| p == "libxml2-devel"),
             "expected libxml2-devel for rhel-8.10, got {pkgs:?}"
         );
         let gdal = sysreqs_rules::resolve_local("GDAL (>= 2.2.3)", &distribution, &release);
         assert!(
-            gdal.iter().any(|p| p == "gdal-devel"),
+            gdal.packages.iter().any(|p| p == "gdal-devel"),
             "expected gdal-devel for rhel-8.10, got {gdal:?}"
         );
     }
@@ -801,12 +819,15 @@ mod tests {
         // trade a spurious warning for wrong package names.
         assert!(
             sysreqs_rules::resolve_local("leptonica", "rockylinux", "8")
+                .packages
                 .iter()
                 .any(|p| p == "leptonica-devel"),
             "rockylinux 8 carries leptonica-devel"
         );
         assert!(
-            sysreqs_rules::resolve_local("leptonica", "redhat", "8").is_empty(),
+            sysreqs_rules::resolve_local("leptonica", "redhat", "8")
+                .packages
+                .is_empty(),
             "redhat 8 does not — aliasing the local lookup would lose it"
         );
         // Both halves of the libarchive divergence, so the test actually
@@ -815,12 +836,13 @@ mod tests {
         // configure with nothing pointing at the cause.
         assert!(
             sysreqs_rules::resolve_local("libarchive", "centos", "8")
+                .packages
                 .iter()
                 .any(|p| p == "libarchive-devel"),
             "centos 8 wants the -devel package"
         );
         assert_eq!(
-            sysreqs_rules::resolve_local("libarchive", "redhat", "8"),
+            sysreqs_rules::resolve_local("libarchive", "redhat", "8").packages,
             vec!["libarchive".to_string()],
             "redhat 8 names the runtime package, not the headers"
         );
@@ -916,7 +938,7 @@ mod tests {
         // apk-compatible package name. This is the invariant issue #30 needs.
         let pkgs = sysreqs_rules::resolve_local("libxml2 (>= 2.9.0)", "alpine", "3.21");
         assert!(
-            pkgs.iter().any(|p| p == "libxml2-dev"),
+            pkgs.packages.iter().any(|p| p == "libxml2-dev"),
             "expected libxml2-dev in fallback output, got {pkgs:?}"
         );
     }

--- a/crates/uvr-core/src/sysreqs.rs
+++ b/crates/uvr-core/src/sysreqs.rs
@@ -566,6 +566,11 @@ fn apply_index(
             // Same rule as the local path: setup commands only matter when
             // something is actually missing — otherwise every sync on a
             // Rocky box would re-enable EPEL.
+            //
+            // Dedup keeps the first occurrence across packages, which assumes
+            // rule commands are order-independent across rules — see the
+            // ordering note on `sysreqs_rules::resolve_local` for the one
+            // known (EOL-Ubuntu-only) case where that assumption bites.
             for cmd in &entry.pre_install {
                 if !out.pre_install.contains(cmd) {
                     out.pre_install.push(cmd.clone());
@@ -1317,6 +1322,73 @@ mod tests {
         assert!(
             out.pre_install.is_empty(),
             "sf has no packages, so nothing can be missing, so no setup command should be collected"
+        );
+    }
+
+    #[test]
+    fn api_setup_commands_are_deduplicated_across_packages() {
+        // The real rockylinux-9 shape: every geospatial package's index entry
+        // repeats `dnf install -y epel-release`. `apply_index` merges the
+        // entries of all packages in one sync, so without its `contains`
+        // guard the user would be shown — and asked to consent to — the same
+        // root command once per package, and uvr would run it N times.
+        //
+        // Both packages must genuinely be missing something, since setup
+        // commands are only collected when `filter_missing` reports a gap.
+        if which::which("dpkg").is_err()
+            && which::which("rpm").is_err()
+            && which::which("apk").is_err()
+        {
+            // Without dpkg/rpm/apk (macOS/Windows dev boxes) `filter_missing`
+            // reports nothing missing, so the collection path under test
+            // never runs and the assertions below would be vacuous.
+            return;
+        }
+        let entry = |pkg: &str| SysReqIndexEntry {
+            packages: vec![SysReq {
+                package: pkg.to_string(),
+            }],
+            pre_install: vec!["dnf install -y epel-release".to_string()],
+            post_install: vec!["R CMD javareconf".to_string()],
+        };
+        let mut index = HashMap::new();
+        index.insert(
+            "sf".to_string(),
+            entry("uvr-test-absent-gdal-devel-4e1d9f2a"),
+        );
+        index.insert(
+            "terra".to_string(),
+            entry("uvr-test-absent-geos-devel-4e1d9f2a"),
+        );
+        let mut out = SysReqsCheck::default();
+        let packages = vec![
+            PackageSysReqQuery {
+                name: "sf".to_string(),
+                system_requirements: None,
+                bioc: false,
+            },
+            PackageSysReqQuery {
+                name: "terra".to_string(),
+                system_requirements: None,
+                bioc: false,
+            },
+        ];
+        apply_index(&mut out, &packages, Some(&index), "rockylinux-9");
+        assert_eq!(
+            out.missing.len(),
+            2,
+            "precondition: both packages must report a missing system package, \
+             otherwise no setup command is collected at all"
+        );
+        assert_eq!(
+            out.pre_install,
+            vec!["dnf install -y epel-release".to_string()],
+            "the shared pre_install command must appear exactly once"
+        );
+        assert_eq!(
+            out.post_install,
+            vec!["R CMD javareconf".to_string()],
+            "the shared post_install command must appear exactly once"
         );
     }
 

--- a/crates/uvr-core/src/sysreqs.rs
+++ b/crates/uvr-core/src/sysreqs.rs
@@ -285,6 +285,183 @@ struct SysReqIndexEntry {
     post_install: Vec<String>,
 }
 
+/// Where a setup command uvr is about to run as root came from.
+///
+/// The two provenances have genuinely different trust stories, and until
+/// now `SysReqsCheck` funnelled both into the same `Vec<String>` so the
+/// consent block could not tell a user which was which:
+///
+/// - `Vendored` is a compile-time constant out of the
+///   `vendor/r-system-requirements` snapshot in this repo. It changes only
+///   when someone bumps the snapshot in a reviewed commit.
+/// - `PositApi` was fetched over the network during *this* sync. On any
+///   API-covered distro — Ubuntu and the RHEL family, i.e. most users —
+///   that is where a meaningful share of what runs as root comes from.
+///
+/// `Both` is the common case in practice rather than a curiosity: the API
+/// and the snapshot are two views of the same upstream rule set, so a
+/// command usually appears identically in both. That makes the label a
+/// drift detector — a command tagged with only one source is one the other
+/// source does not carry, which is exactly the state worth noticing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CommandSource {
+    /// From the audited `vendor/r-system-requirements` snapshot.
+    Vendored,
+    /// From the Posit sysreqs API response fetched during this sync.
+    PositApi,
+    /// Carried identically by both.
+    Both,
+}
+
+impl CommandSource {
+    /// Fold a second sighting of the same command into this one.
+    fn merge(self, other: Self) -> Self {
+        if self == other {
+            self
+        } else {
+            Self::Both
+        }
+    }
+
+    /// Human-readable provenance for the consent block.
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::Vendored => "uvr's vendored rules",
+            Self::PositApi => "Posit's sysreqs API, fetched this sync",
+            Self::Both => "uvr's vendored rules and Posit's sysreqs API",
+        }
+    }
+}
+
+/// What a setup command does that a user approving root execution should
+/// see stated outright, rather than having to read the shell string for.
+///
+/// This is a *behaviour* axis, deliberately independent of
+/// [`CommandSource`]. The two answer different questions, and only this one
+/// is what the user is really consenting to: `curl … https://sh.rustup.rs |
+/// sh` and `dnf install -y --nogpgcheck https://mirrors.rpmfusion.org/…`
+/// are both vendored, and "vendored" means a human reviewed the *rule* —
+/// not that they vouched for what the rule does at runtime.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CommandEffect {
+    /// Downloads code from the network and executes it (`curl … | sh`).
+    RemoteScript,
+    /// Installs a package straight from a URL rather than from a
+    /// configured, signed repository.
+    RemotePackage,
+    /// Installs with package signature verification switched off.
+    NoGpgCheck,
+    /// Adds or enables a repository, changing what every later install on
+    /// this machine — not just this one — will trust.
+    AddsRepository,
+}
+
+impl CommandEffect {
+    /// Phrasing for the consent block, as a verb phrase about the command.
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::RemoteScript => "downloads and executes a script from the network",
+            Self::RemotePackage => "installs a package directly from a URL",
+            Self::NoGpgCheck => "disables package signature verification",
+            Self::AddsRepository => "adds a third-party repository to this system",
+        }
+    }
+}
+
+/// A setup command, with everything the consent block needs to describe it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SetupCommand {
+    /// The shell string, verbatim, exactly as it will be passed to `sh -c`.
+    pub command: String,
+    /// Which catalog(s) it came from.
+    pub source: CommandSource,
+}
+
+impl SetupCommand {
+    pub fn new(command: impl Into<String>, source: CommandSource) -> Self {
+        Self {
+            command: command.into(),
+            source,
+        }
+    }
+
+    /// Classify what this command does, for the consent block.
+    ///
+    /// Substring matching over the shell string, and knowingly so: these
+    /// are 34 hand-written commands from one upstream catalog, not
+    /// arbitrary input, and the alternative (parsing shell) buys precision
+    /// this does not need. It is biased toward over-reporting — a
+    /// false-positive note costs a user one line of reading, a
+    /// false-negative costs them the disclosure they were owed.
+    ///
+    /// The corollary is the reason `run_rule_commands` prints the raw
+    /// command too, and the reason the block says so: an *unannotated*
+    /// command is one uvr recognised no pattern in, which is not the same
+    /// as one that is safe. Do not let this list grow into something the
+    /// UI presents as exhaustive.
+    pub fn effects(&self) -> Vec<CommandEffect> {
+        let cmd = &self.command;
+        let mut effects = Vec::new();
+        let fetches_remote = cmd.contains("http://") || cmd.contains("https://");
+
+        // `curl`/`wget` whose output reaches a shell, whether by pipe
+        // (`curl … | sh`) or by substitution (`sh -c "$(curl …)"`).
+        if fetches_remote
+            && (cmd.contains("curl") || cmd.contains("wget"))
+            && (cmd.contains("| sh") || cmd.contains("|sh") || cmd.contains("| bash"))
+        {
+            effects.push(CommandEffect::RemoteScript);
+        }
+        // A URL as the argument of an install, rather than a package name
+        // resolved out of a configured repo. `add-apt-repository` and
+        // `zypper addrepo` also carry URLs but are repo additions, covered
+        // below; excluding them keeps each command's notes to what it does.
+        if fetches_remote
+            && !effects.contains(&CommandEffect::RemoteScript)
+            && (cmd.contains("install") || cmd.contains(" -o "))
+            && !cmd.contains("add-apt-repository")
+            && !cmd.contains("addrepo")
+        {
+            effects.push(CommandEffect::RemotePackage);
+        }
+        if cmd.contains("--nogpgcheck")
+            || cmd.contains("--allow-unauthenticated")
+            || cmd.contains("--allow-untrusted")
+        {
+            effects.push(CommandEffect::NoGpgCheck);
+        }
+        // Repository additions, including the ones that arrive as a
+        // `*-release` package (`epel-release`, `rpmfusion-*-release`) —
+        // installing one of those is how EPEL gets enabled, so calling it
+        // only a package install would understate it.
+        if cmd.contains("add-apt-repository")
+            || cmd.contains("addrepo")
+            || cmd.contains("config-manager")
+            || cmd.contains("subscription-manager")
+            || cmd.contains("-release")
+            || cmd.contains("--repository=")
+        {
+            effects.push(CommandEffect::AddsRepository);
+        }
+        effects
+    }
+}
+
+/// Append `command` to `list`, deduplicated, merging provenance when the
+/// same command arrives from both catalogs.
+///
+/// Dedup is by command string alone: two identical strings are one
+/// execution, so collapsing them and widening the source to `Both` is the
+/// accurate description. Keeping them separate would run EPEL enablement
+/// twice and claim two different provenances for one action.
+fn push_setup_command(list: &mut Vec<SetupCommand>, command: &str, source: CommandSource) {
+    if let Some(existing) = list.iter_mut().find(|c| c.command == command) {
+        existing.source = existing.source.merge(source);
+        return;
+    }
+    list.push(SetupCommand::new(command, source));
+}
+
 /// Index a batched (`all=true`) sysreqs response by R package name.
 ///
 /// Packages absent from the map declare no system requirements — the API
@@ -456,10 +633,13 @@ pub struct SysReqsCheck {
     /// requirement: not missing, not degraded, not skipped. Silence there is
     /// precisely the false confidence this subsystem exists to prevent.
     pub local_unresolved: usize,
-    /// Deduplicated setup commands for the rules that produced `missing`.
-    pub pre_install: Vec<String>,
-    /// Deduplicated commands to run after the package install.
-    pub post_install: Vec<String>,
+    /// Deduplicated setup commands for the rules that produced `missing`,
+    /// each tagged with the catalog it came from so the consent block can
+    /// disclose which half of the plan was fetched over the network.
+    pub pre_install: Vec<SetupCommand>,
+    /// Deduplicated commands to run after the package install, tagged the
+    /// same way.
+    pub post_install: Vec<SetupCommand>,
 }
 
 /// R package to check sysreqs for.
@@ -572,14 +752,10 @@ fn apply_index(
             // ordering note on `sysreqs_rules::resolve_local` for the one
             // known (EOL-Ubuntu-only) case where that assumption bites.
             for cmd in &entry.pre_install {
-                if !out.pre_install.contains(cmd) {
-                    out.pre_install.push(cmd.clone());
-                }
+                push_setup_command(&mut out.pre_install, cmd, CommandSource::PositApi);
             }
             for cmd in &entry.post_install {
-                if !out.post_install.contains(cmd) {
-                    out.post_install.push(cmd.clone());
-                }
+                push_setup_command(&mut out.post_install, cmd, CommandSource::PositApi);
             }
             out.missing
                 .insert(pkg.name.clone(), missing.into_iter().cloned().collect());
@@ -618,15 +794,11 @@ fn check_pkg_local(out: &mut SysReqsCheck, pkg: &PackageSysReqQuery, distro: &st
     if !missing.is_empty() {
         // Setup commands only matter when something is actually missing —
         // otherwise every sync on a Rocky box would re-enable EPEL.
-        for cmd in local.pre_install {
-            if !out.pre_install.contains(&cmd) {
-                out.pre_install.push(cmd);
-            }
+        for cmd in &local.pre_install {
+            push_setup_command(&mut out.pre_install, cmd, CommandSource::Vendored);
         }
-        for cmd in local.post_install {
-            if !out.post_install.contains(&cmd) {
-                out.post_install.push(cmd);
-            }
+        for cmd in &local.post_install {
+            push_setup_command(&mut out.post_install, cmd, CommandSource::Vendored);
         }
         out.missing
             .insert(pkg.name.clone(), missing.into_iter().cloned().collect());
@@ -1382,14 +1554,198 @@ mod tests {
         );
         assert_eq!(
             out.pre_install,
-            vec!["dnf install -y epel-release".to_string()],
+            vec![SetupCommand::new(
+                "dnf install -y epel-release",
+                CommandSource::PositApi
+            )],
             "the shared pre_install command must appear exactly once"
         );
         assert_eq!(
             out.post_install,
-            vec!["R CMD javareconf".to_string()],
+            vec![SetupCommand::new(
+                "R CMD javareconf",
+                CommandSource::PositApi
+            )],
             "the shared post_install command must appear exactly once"
         );
+    }
+
+    #[test]
+    fn a_command_carried_by_both_catalogs_is_labelled_as_such() {
+        // The provenance tag has to survive dedup, or the label is worse
+        // than none: the two catalogs are two views of the same upstream
+        // rules and usually agree, so keeping only whichever source was
+        // seen first would tell most users "vendored" about commands the
+        // API also sent — reassurance that is not true of the second half.
+        //
+        // Reached the way a real sync reaches it: `apply_index` sends a
+        // Bioc package to the vendored rules (#202) and a CRAN one to the
+        // index, so a mixed sync collects from both catalogs at once.
+        if which::which("dpkg").is_err()
+            && which::which("rpm").is_err()
+            && which::which("apk").is_err()
+        {
+            // No package manager: `filter_missing` reports nothing missing,
+            // so no setup command is collected and this would pass vacuously.
+            return;
+        }
+        let mut index = HashMap::new();
+        index.insert(
+            "sf".to_string(),
+            SysReqIndexEntry {
+                packages: vec![SysReq {
+                    package: "uvr-test-absent-gdal-devel-7c3b1e50".to_string(),
+                }],
+                // The command the rockylinux-9 GDAL rule also carries.
+                pre_install: vec!["dnf install -y dnf-plugins-core".to_string()],
+                post_install: vec![],
+            },
+        );
+        let mut out = SysReqsCheck::default();
+        let packages = vec![
+            PackageSysReqQuery {
+                name: "sf".to_string(),
+                system_requirements: None,
+                bioc: false,
+            },
+            PackageSysReqQuery {
+                name: "SomeBiocPkg".to_string(),
+                system_requirements: Some("GDAL (>= 2.0.1)".to_string()),
+                bioc: true,
+            },
+        ];
+        apply_index(&mut out, &packages, Some(&index), "rockylinux-9");
+        let shared = out
+            .pre_install
+            .iter()
+            .find(|c| c.command == "dnf install -y dnf-plugins-core")
+            .expect("both catalogs carry this command");
+        assert_eq!(
+            shared.source,
+            CommandSource::Both,
+            "a command both catalogs carry must not be attributed to only one"
+        );
+        assert_eq!(
+            out.pre_install
+                .iter()
+                .filter(|c| c.command == "dnf install -y dnf-plugins-core")
+                .count(),
+            1,
+            "merging provenance must not duplicate the command itself"
+        );
+        // The vendored rule's other command has no API counterpart here, so
+        // it stays single-sourced — that asymmetry is the drift signal the
+        // label exists to make visible.
+        assert_eq!(
+            out.pre_install
+                .iter()
+                .find(|c| c.command == "dnf config-manager --set-enabled crb")
+                .map(|c| c.source),
+            Some(CommandSource::Vendored)
+        );
+    }
+
+    #[test]
+    fn the_riskiest_vendored_commands_are_annotated() {
+        // @gdevenyi's point on #221: provenance alone points at the wrong
+        // axis. Every command below is *vendored* — a human reviewed the
+        // rule, which says nothing about what the rule does at runtime — so
+        // labelling them only "from uvr's vendored rules" would read as
+        // reassurance about the four things most worth seeing before
+        // approving root execution. All four are live in the snapshot on
+        // main today; this PR is what starts running them.
+        let vendored = |cmd: &str| SetupCommand::new(cmd, CommandSource::Vendored);
+
+        // rust.json: fetches a script over the network and pipes it to a
+        // root shell.
+        let effects = vendored(
+            "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --no-modify-path -y",
+        )
+        .effects();
+        assert!(
+            effects.contains(&CommandEffect::RemoteScript),
+            "{effects:?}"
+        );
+
+        // chrome.json: downloads a vendor package, then installs the file.
+        assert!(
+            vendored(
+                "[ $(which google-chrome) ] || curl -fsSL -o /tmp/google-chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb"
+            )
+            .effects()
+            .contains(&CommandEffect::RemotePackage)
+        );
+
+        // libavfilter.json: installs with signature checking off, from a URL.
+        let effects = vendored(
+            "dnf install -y --nogpgcheck https://mirrors.rpmfusion.org/free/el/rpmfusion-free-release-$(rpm -E %rhel).noarch.rpm",
+        )
+        .effects();
+        assert!(effects.contains(&CommandEffect::NoGpgCheck), "{effects:?}");
+        assert!(
+            effects.contains(&CommandEffect::RemotePackage),
+            "both notes apply and both are worth printing: {effects:?}"
+        );
+
+        // gdal.json and friends: changes what this machine trusts from here
+        // on, not just for this install.
+        assert!(vendored("add-apt-repository -y ppa:ubuntugis/ppa")
+            .effects()
+            .contains(&CommandEffect::AddsRepository));
+        // Enabling EPEL arrives as a `*-release` package install; calling
+        // that a plain package install would understate what it does.
+        assert!(vendored("dnf install -y epel-release")
+            .effects()
+            .contains(&CommandEffect::AddsRepository));
+        assert!(vendored("dnf config-manager --set-enabled crb")
+            .effects()
+            .contains(&CommandEffect::AddsRepository));
+    }
+
+    #[test]
+    fn an_ordinary_command_gets_no_note() {
+        // The notes must stay a signal. If `R CMD javareconf` or a plain
+        // index refresh picked one up, the annotated lines would stop
+        // standing out — and the block's closing line is what covers the
+        // other direction, that an unannotated command is one uvr matched
+        // no pattern in rather than one it vetted.
+        for cmd in [
+            "R CMD javareconf",
+            "apt-get update",
+            "apt-get install -y software-properties-common",
+            "yum install -y which",
+        ] {
+            assert!(
+                SetupCommand::new(cmd, CommandSource::Vendored)
+                    .effects()
+                    .is_empty(),
+                "{cmd} should not be annotated"
+            );
+        }
+    }
+
+    #[test]
+    fn every_vendored_setup_command_is_classifiable_without_panicking() {
+        // Blanket sweep over the whole snapshot: `effects` is substring
+        // matching over shell strings, and the point of running it across
+        // every rule the table carries is to catch the day a snapshot bump
+        // introduces a command shape that trips it. Also pins the
+        // over-reporting bias — any command touching a URL must say
+        // *something*, since a network fetch as root is never a detail to
+        // leave to the user to spot in the shell string.
+        for rule in sysreqs_rules::RULES {
+            for dep in rule.dependencies.iter() {
+                for cmd in dep.pre_install.iter().chain(dep.post_install.iter()) {
+                    let effects = SetupCommand::new(*cmd, CommandSource::Vendored).effects();
+                    if cmd.contains("http://") || cmd.contains("https://") {
+                        assert!(
+                            !effects.is_empty(),
+                            "a command that reaches the network as root must carry a note: {cmd}"
+                        );
+                    }
+                }
+            }
+        }
     }
 
     #[test]

--- a/crates/uvr-core/src/sysreqs_rules.rs
+++ b/crates/uvr-core/src/sysreqs_rules.rs
@@ -226,4 +226,47 @@ mod tests {
         let n_libxml = pkgs.iter().filter(|p| *p == "libxml2-dev").count();
         assert_eq!(n_libxml, 1);
     }
+
+    #[test]
+    fn gdal_carries_pre_install_on_rockylinux_but_not_alpine() {
+        // rules/gdal.json: the rockylinux 9/10 entry needs the CRB repo
+        // enabled first (dnf-plugins-core + config-manager --set-enabled
+        // crb); the alpine entry needs nothing.
+        // (The vendored gdal.json rockylinux 9/10 entry does not mention
+        // EPEL, unlike the sibling geos.json rule; asserting on "crb" here
+        // matches the actual vendored data.)
+        // Rule names in the generated table are file stems (build.rs uses
+        // `path.file_stem()`), so this is "gdal", not "gdal.json".
+        let gdal = RULES
+            .iter()
+            .find(|r| r.name == "gdal")
+            .expect("gdal rule is vendored");
+        let rocky_dep = gdal
+            .dependencies
+            .iter()
+            .find(|d| {
+                d.constraints.iter().any(|c| {
+                    c.distribution == Some("rockylinux") && c.versions.contains(&"9")
+                })
+            })
+            .expect("rockylinux 9 entry");
+        assert!(
+            rocky_dep.pre_install.iter().any(|c| c.contains("crb")),
+            "rockylinux gdal needs the CRB repo enabled first"
+        );
+
+        let alpine_dep = gdal_dep_for(gdal, "alpine");
+        assert!(alpine_dep.pre_install.is_empty());
+    }
+
+    fn gdal_dep_for<'a>(rule: &'a RuleStatic, distro: &str) -> &'a DependencyStatic {
+        rule.dependencies
+            .iter()
+            .find(|d| {
+                d.constraints
+                    .iter()
+                    .any(|c| c.distribution == Some(distro))
+            })
+            .expect("dependency entry for distro")
+    }
 }

--- a/crates/uvr-core/src/sysreqs_rules.rs
+++ b/crates/uvr-core/src/sysreqs_rules.rs
@@ -39,6 +39,17 @@ fn pattern_sets() -> &'static [RegexSet] {
     })
 }
 
+/// What the vendored rules say a package needs on this distribution.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct LocalResolution {
+    /// Distro-native package names, deduplicated in stable order.
+    pub packages: Vec<String>,
+    /// Commands to run before installing `packages` (e.g. enabling EPEL).
+    pub pre_install: Vec<String>,
+    /// Commands to run after installing `packages` (e.g. `R CMD javareconf`).
+    pub post_install: Vec<String>,
+}
+
 /// Resolve sysreqs against the local rules.
 ///
 /// - `sys_req_text`: the raw `SystemRequirements` field from DESCRIPTION
@@ -49,14 +60,16 @@ fn pattern_sets() -> &'static [RegexSet] {
 ///   string if unknown; rules with empty `versions` still match.
 ///
 /// Returns the matched distro-native system package names, de-duplicated in
-/// stable order. Empty if no rules match or the distro isn't covered.
-pub fn resolve_local(sys_req_text: &str, distribution: &str, version: &str) -> Vec<String> {
+/// stable order, along with the pre/post install commands the matched rules
+/// carry (also de-duplicated). Empty if no rules match or the distro isn't
+/// covered.
+pub fn resolve_local(sys_req_text: &str, distribution: &str, version: &str) -> LocalResolution {
+    let mut out = LocalResolution::default();
     if sys_req_text.is_empty() {
-        return Vec::new();
+        return out;
     }
 
     let sets = pattern_sets();
-    let mut out: Vec<String> = Vec::new();
 
     for (rule, set) in RULES.iter().zip(sets.iter()) {
         if !set.is_match(sys_req_text) {
@@ -72,8 +85,18 @@ pub fn resolve_local(sys_req_text: &str, distribution: &str, version: &str) -> V
                 .any(|c| constraint_matches(c, distribution, version))
             {
                 for pkg in dep.packages {
-                    if !out.iter().any(|x| x == pkg) {
-                        out.push((*pkg).to_string());
+                    if !out.packages.iter().any(|x| x == pkg) {
+                        out.packages.push((*pkg).to_string());
+                    }
+                }
+                for cmd in dep.pre_install {
+                    if !out.pre_install.iter().any(|x| x == cmd) {
+                        out.pre_install.push((*cmd).to_string());
+                    }
+                }
+                for cmd in dep.post_install {
+                    if !out.post_install.iter().any(|x| x == cmd) {
+                        out.post_install.push((*cmd).to_string());
                     }
                 }
                 break;
@@ -162,7 +185,7 @@ mod tests {
         // Reproduces the scenario from issue #30.
         let pkgs = resolve_local("libxml2 (>= 2.6.3)", "alpine", "3.21");
         assert!(
-            pkgs.iter().any(|p| p == "libxml2-dev"),
+            pkgs.packages.iter().any(|p| p == "libxml2-dev"),
             "expected libxml2-dev, got {pkgs:?}"
         );
     }
@@ -173,7 +196,7 @@ mod tests {
         // but rules key on "3.23". The fallback truncates the patch.
         let pkgs = resolve_local("libxml2 (>= 2.6.3)", "alpine", "3.23.4");
         assert!(
-            pkgs.iter().any(|p| p == "libxml2-dev"),
+            pkgs.packages.iter().any(|p| p == "libxml2-dev"),
             "expected libxml2-dev for alpine-3.23.4, got {pkgs:?}"
         );
     }
@@ -191,7 +214,7 @@ mod tests {
     fn xml2_on_ubuntu_matches_libxml2_dev() {
         let pkgs = resolve_local("libxml2 (>= 2.6.3)", "ubuntu", "22.04");
         assert!(
-            pkgs.iter().any(|p| p == "libxml2-dev"),
+            pkgs.packages.iter().any(|p| p == "libxml2-dev"),
             "expected libxml2-dev, got {pkgs:?}"
         );
     }
@@ -204,26 +227,29 @@ mod tests {
             "alpine",
             "3.21",
         );
-        assert!(!pkgs.is_empty(), "expected at least one package, got empty");
+        assert!(
+            !pkgs.packages.is_empty(),
+            "expected at least one package, got empty"
+        );
     }
 
     #[test]
     fn unknown_distro_returns_empty() {
         let pkgs = resolve_local("libxml2", "haiku", "");
-        assert!(pkgs.is_empty(), "expected empty, got {pkgs:?}");
+        assert!(pkgs.packages.is_empty(), "expected empty, got {pkgs:?}");
     }
 
     #[test]
     fn empty_sys_reqs_returns_empty() {
         let pkgs = resolve_local("", "alpine", "3.21");
-        assert!(pkgs.is_empty());
+        assert!(pkgs.packages.is_empty());
     }
 
     #[test]
     fn dedupes_packages_across_rule_matches() {
         // A string that may match multiple rules shouldn't duplicate packages.
         let pkgs = resolve_local("libxml2 libxml2 libxml2", "alpine", "3.21");
-        let n_libxml = pkgs.iter().filter(|p| *p == "libxml2-dev").count();
+        let n_libxml = pkgs.packages.iter().filter(|p| *p == "libxml2-dev").count();
         assert_eq!(n_libxml, 1);
     }
 
@@ -268,5 +294,53 @@ mod tests {
                     .any(|c| c.distribution == Some(distro))
             })
             .expect("dependency entry for distro")
+    }
+
+    #[test]
+    fn pre_install_is_deduplicated_across_matched_rules() {
+        // sf's SystemRequirements matches gdal, geos and proj. In the VENDORED
+        // snapshot all three carry `dnf install -y dnf-plugins-core` and
+        // `dnf config-manager --set-enabled crb`; only geos.json also carries
+        // `dnf install -y epel-release`.
+        let r = resolve_local(
+            "GDAL (>= 2.0.1), GEOS (>= 3.4.0), PROJ (>= 4.8.0), sqlite3",
+            "rockylinux",
+            "9",
+        );
+        // Assert on a command that ALL THREE matched rules carry, otherwise
+        // the test proves nothing: in the vendored snapshot `epel-release`
+        // appears only in geos.json, so counting it would pass trivially even
+        // with dedup removed. `--set-enabled crb` and `dnf-plugins-core` are
+        // in gdal.json, geos.json and proj.json alike.
+        let crb: Vec<&String> = r
+            .pre_install
+            .iter()
+            .filter(|c| c.contains("--set-enabled crb"))
+            .collect();
+        assert_eq!(crb.len(), 1, "crb enable must be deduplicated across rules");
+        let plugins: Vec<&String> = r
+            .pre_install
+            .iter()
+            .filter(|c| c.contains("dnf-plugins-core"))
+            .collect();
+        assert_eq!(plugins.len(), 1, "dnf-plugins-core must be deduplicated");
+        assert!(r.packages.iter().any(|p| p.starts_with("gdal")));
+    }
+
+    #[test]
+    fn alpine_resolution_carries_no_setup_commands() {
+        let r = resolve_local("GDAL (>= 2.0.1)", "alpine", "3.23.5");
+        assert_eq!(r.packages, vec!["gdal-dev", "gdal-tools"]);
+        assert!(r.pre_install.is_empty());
+        assert!(r.post_install.is_empty());
+    }
+
+    #[test]
+    fn java_carries_a_post_install_command() {
+        let r = resolve_local("Java JDK 8 or higher", "ubuntu", "22.04");
+        assert!(
+            r.post_install.iter().any(|c| c.contains("javareconf")),
+            "rJava needs `R CMD javareconf` after install"
+        );
     }
 }

--- a/crates/uvr-core/src/sysreqs_rules.rs
+++ b/crates/uvr-core/src/sysreqs_rules.rs
@@ -89,6 +89,18 @@ pub fn resolve_local(sys_req_text: &str, distribution: &str, version: &str) -> L
                         out.packages.push((*pkg).to_string());
                     }
                 }
+                // ORDERING ASSUMPTION: dedup keeps the first occurrence, so
+                // the merged list is in rule-table order and a command can
+                // end up before or after commands of another rule that the
+                // rule author never saw. That is only sound because rule
+                // commands are assumed order-independent *across* rules
+                // (each enables a repo or refreshes an index for its own
+                // packages). Known, accepted exception: on EOL Ubuntu 16.04,
+                // `sf` + `gert` merge to [software-properties-common,
+                // ppa:ubuntugis/ppa, apt-get update, ppa:cran/libgit2], which
+                // adds the libgit2 PPA *after* the last index refresh. No
+                // supported release is affected; revisit if a rule for a
+                // current distro ever grows an intra-sequence dependency.
                 for cmd in dep.pre_install {
                     if !out.pre_install.iter().any(|x| x == cmd) {
                         out.pre_install.push((*cmd).to_string());
@@ -271,9 +283,9 @@ mod tests {
             .dependencies
             .iter()
             .find(|d| {
-                d.constraints.iter().any(|c| {
-                    c.distribution == Some("rockylinux") && c.versions.contains(&"9")
-                })
+                d.constraints
+                    .iter()
+                    .any(|c| c.distribution == Some("rockylinux") && c.versions.contains(&"9"))
             })
             .expect("rockylinux 9 entry");
         assert!(
@@ -288,11 +300,7 @@ mod tests {
     fn gdal_dep_for<'a>(rule: &'a RuleStatic, distro: &str) -> &'a DependencyStatic {
         rule.dependencies
             .iter()
-            .find(|d| {
-                d.constraints
-                    .iter()
-                    .any(|c| c.distribution == Some(distro))
-            })
+            .find(|d| d.constraints.iter().any(|c| c.distribution == Some(distro)))
             .expect("dependency entry for distro")
     }
 

--- a/crates/uvr/src/commands/sync.rs
+++ b/crates/uvr/src/commands/sync.rs
@@ -1154,12 +1154,13 @@ async fn install_from_lockfile_with_r(
                                     // so they go through `sh -c`. A failed
                                     // setup step bails: the package install
                                     // below would fail anyway.
-                                    run_rule_commands(
-                                        &check.pre_install,
-                                        "setup",
-                                        r_binary.parent(),
-                                        true,
-                                    )?;
+                                    //
+                                    // No R bin dir, hence no `PATH` override
+                                    // at all: nothing in a `pre_install` rule
+                                    // needs R, and leaving `PATH` alone keeps
+                                    // sudo's `secure_path` in force for these
+                                    // root-run shell strings.
+                                    run_rule_commands(&check.pre_install, "setup", None, true)?;
                                     ui::info(format!("Running: {install_cmd_display}"));
                                     let mut cmd = std::process::Command::new(&install_program);
                                     cmd.args(&install_args);
@@ -1852,6 +1853,14 @@ fn local_check_incomplete(
 
 
 
+/// Base `PATH` for rule commands that run as root. Mirrors the default
+/// `secure_path` shipped in `/etc/sudoers` on Debian/Ubuntu, Fedora/RHEL
+/// and Alpine, so a rule command sees the same search path it would have
+/// seen under plain `sudo`. Only ever extended with the R bin directory
+/// uvr manages — never with the invoking user's `$PATH`.
+#[cfg(target_os = "linux")]
+const ROOT_SAFE_PATH: &str = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
+
 /// Run a rule's setup/post-install commands via `sh -c`: entries such as
 /// `rpm -q epel-release || yum install -y https://...` rely on shell
 /// operators, so a direct `Command::new` of the first token would break
@@ -1866,19 +1875,34 @@ fn local_check_incomplete(
 /// `sudo` is guaranteed to exist here whenever it's needed.
 ///
 /// `r_bin_dir` is the directory holding the R binary this sync is using
-/// (`r_binary`'s parent). A uvr-managed R install lives under uvr's own
-/// managed directory and is never added to `$PATH`, so a rule command
-/// such as `R CMD javareconf` (rJava) can't find `R` unless we put it
-/// there ourselves — it previously failed with exit 127 on every
-/// uvr-managed R. `sudo`'s default `env_reset` discards the environment
-/// it inherited and rebuilds one from its own policy (`secure_path`,
-/// `env_keep`), so setting `PATH` on the `sudo` child via `Command::env`
-/// would not reliably survive into the command sudo execs. Instead we
-/// run `sudo env PATH=<path> sh -c <cmd>`: `env` is the program sudo
-/// execs (resolved via `secure_path`, so it's found regardless of the
-/// sanitised `PATH`), and setting a variable via `env`'s own argv is not
-/// subject to `env_keep`/`env_delete` filtering the way an inherited
-/// variable would be — it reaches `sh` unconditionally.
+/// (`r_binary`'s parent). It is `Some` only for the `post_install`
+/// phase: that is the one phase whose commands need R on `PATH` (`R CMD
+/// javareconf` for rJava). A uvr-managed R install lives under uvr's own
+/// managed directory and is never added to `$PATH`, so that command
+/// failed with exit 127 on every uvr-managed R.
+///
+/// SECURITY — the `PATH` seen by a root shell is built from a fixed,
+/// known-safe base ([`ROOT_SAFE_PATH`]), never from the invoking user's
+/// `$PATH`. Inheriting `$PATH` into `sudo env PATH=…` would defeat
+/// `sudo`'s `secure_path`, which exists precisely to stop a root command
+/// resolving binaries out of an unprivileged user's search path: with
+/// conda or `~/.local/bin` active, `rpm -q epel-release || yum install
+/// -y …` would consult the *user's* `rpm`, and some vendored rules pipe
+/// a downloaded script through the user's `curl`, as root. `pre_install`
+/// therefore passes no `PATH` override at all, leaving `sudo`'s own
+/// `secure_path` in force; `post_install` prepends only the R bin
+/// directory, which uvr itself installed, to the safe base.
+///
+/// `sudo`'s default `env_reset` discards the environment it inherited
+/// and rebuilds one from its own policy (`secure_path`, `env_keep`), so
+/// setting `PATH` on the `sudo` child via `Command::env` would not
+/// reliably survive into the command sudo execs. Hence `sudo env
+/// PATH=<path> sh -c <cmd>` when a `PATH` is needed at all: `env` is the
+/// program sudo execs (resolved via `secure_path`, so it's found
+/// regardless of the sanitised `PATH`), and setting a variable via
+/// `env`'s own argv is not subject to `env_keep`/`env_delete` filtering
+/// the way an inherited variable would be — it reaches `sh`
+/// unconditionally.
 ///
 /// `bail_on_failure` is why `pre_install` and `post_install` are no
 /// longer symmetric: a `pre_install` failure (e.g. a repo that didn't
@@ -1898,13 +1922,8 @@ fn run_rule_commands(
     bail_on_failure: bool,
 ) -> Result<()> {
     let needs_sudo = !is_effective_root();
-    let path_env = r_bin_dir.map(|dir| {
-        format!(
-            "{}:{}",
-            dir.display(),
-            std::env::var("PATH").unwrap_or_default()
-        )
-    });
+    // Deliberately NOT `std::env::var("PATH")`: see the security note above.
+    let path_env = r_bin_dir.map(|dir| format!("{}:{ROOT_SAFE_PATH}", dir.display()));
     for cmd in cmds {
         ui::info(format!("Running: {cmd}"));
         let status = if needs_sudo {

--- a/crates/uvr/src/commands/sync.rs
+++ b/crates/uvr/src/commands/sync.rs
@@ -1873,8 +1873,6 @@ fn local_check_incomplete(
     check.missing.is_empty() && pkgs_with_sysreqs > 0 && check.local_resolved < pkgs_with_sysreqs
 }
 
-
-
 /// Base `PATH` for rule commands that run as root. Mirrors the default
 /// `secure_path` shipped in `/etc/sudoers` on Debian/Ubuntu, Fedora/RHEL
 /// and Alpine, so a rule command sees the same search path it would have

--- a/crates/uvr/src/commands/sync.rs
+++ b/crates/uvr/src/commands/sync.rs
@@ -1151,8 +1151,15 @@ async fn install_from_lockfile_with_r(
                                     // Setup next: several rules need a repo
                                     // enabled (EPEL, crb) before their packages
                                     // exist. Entries contain shell operators,
-                                    // so they go through `sh -c`.
-                                    run_rule_commands(&check.pre_install, "setup")?;
+                                    // so they go through `sh -c`. A failed
+                                    // setup step bails: the package install
+                                    // below would fail anyway.
+                                    run_rule_commands(
+                                        &check.pre_install,
+                                        "setup",
+                                        r_binary.parent(),
+                                        true,
+                                    )?;
                                     ui::info(format!("Running: {install_cmd_display}"));
                                     let mut cmd = std::process::Command::new(&install_program);
                                     cmd.args(&install_args);
@@ -1172,7 +1179,18 @@ async fn install_from_lockfile_with_r(
                                             status.code().unwrap_or(-1)
                                         );
                                     }
-                                    run_rule_commands(&check.post_install, "post-install")?;
+                                    // Post-install runs after the packages
+                                    // are already installed, so a failure
+                                    // here (e.g. `R CMD javareconf` still
+                                    // missing something) warns and continues
+                                    // instead of failing an otherwise-
+                                    // successful sync.
+                                    run_rule_commands(
+                                        &check.post_install,
+                                        "post-install",
+                                        r_binary.parent(),
+                                        false,
+                                    )?;
                                     ui::success("System dependencies installed.");
                                 } else {
                                     ui::hint(&install_hint);
@@ -1837,8 +1855,7 @@ fn local_check_incomplete(
 /// Run a rule's setup/post-install commands via `sh -c`: entries such as
 /// `rpm -q epel-release || yum install -y https://...` rely on shell
 /// operators, so a direct `Command::new` of the first token would break
-/// them. Bails on the first failing command with the exit code and the
-/// offending command so the user can re-run it manually.
+/// them.
 ///
 /// Escalates with the same `sudo` rule as `pick_sysreqs_installer`: these
 /// commands enable repos and install RPMs/DEBs, which need root just like
@@ -1847,24 +1864,73 @@ fn local_check_incomplete(
 /// already returned `None` (and short-circuited to the `(true, None)`
 /// arm instead) whenever `sudo` would be needed but isn't on PATH — so
 /// `sudo` is guaranteed to exist here whenever it's needed.
+///
+/// `r_bin_dir` is the directory holding the R binary this sync is using
+/// (`r_binary`'s parent). A uvr-managed R install lives under uvr's own
+/// managed directory and is never added to `$PATH`, so a rule command
+/// such as `R CMD javareconf` (rJava) can't find `R` unless we put it
+/// there ourselves — it previously failed with exit 127 on every
+/// uvr-managed R. `sudo`'s default `env_reset` discards the environment
+/// it inherited and rebuilds one from its own policy (`secure_path`,
+/// `env_keep`), so setting `PATH` on the `sudo` child via `Command::env`
+/// would not reliably survive into the command sudo execs. Instead we
+/// run `sudo env PATH=<path> sh -c <cmd>`: `env` is the program sudo
+/// execs (resolved via `secure_path`, so it's found regardless of the
+/// sanitised `PATH`), and setting a variable via `env`'s own argv is not
+/// subject to `env_keep`/`env_delete` filtering the way an inherited
+/// variable would be — it reaches `sh` unconditionally.
+///
+/// `bail_on_failure` is why `pre_install` and `post_install` are no
+/// longer symmetric: a `pre_install` failure (e.g. a repo that didn't
+/// enable) means the package install that follows will fail anyway, so
+/// failing fast with a clear message is correct. `post_install` runs
+/// after the packages are already installed, so a failure there (e.g.
+/// `javareconf` still missing a system lib) must not turn an otherwise-
+/// successful sync into a failed one — it warns, names the command to
+/// re-run, and continues. Do not merge these back into one "just bail"
+/// path; that regresses the exact case this feature exists for (rJava +
+/// `--install-system-deps`).
 #[cfg(target_os = "linux")]
-fn run_rule_commands(cmds: &[String], phase: &str) -> Result<()> {
+fn run_rule_commands(
+    cmds: &[String],
+    phase: &str,
+    r_bin_dir: Option<&std::path::Path>,
+    bail_on_failure: bool,
+) -> Result<()> {
     let needs_sudo = !is_effective_root();
+    let path_env = r_bin_dir.map(|dir| {
+        format!(
+            "{}:{}",
+            dir.display(),
+            std::env::var("PATH").unwrap_or_default()
+        )
+    });
     for cmd in cmds {
         ui::info(format!("Running: {cmd}"));
         let status = if needs_sudo {
-            std::process::Command::new("sudo")
-                .args(["sh", "-c", cmd])
-                .status()
+            let mut command = std::process::Command::new("sudo");
+            if let Some(path) = &path_env {
+                command.args(["env", &format!("PATH={path}")]);
+            }
+            command.args(["sh", "-c", cmd]).status()
         } else {
-            std::process::Command::new("sh").arg("-c").arg(cmd).status()
+            let mut command = std::process::Command::new("sh");
+            command.arg("-c").arg(cmd);
+            if let Some(path) = &path_env {
+                command.env("PATH", path);
+            }
+            command.status()
         }
         .with_context(|| format!("Failed to spawn: {cmd}"))?;
         if !status.success() {
-            anyhow::bail!(
-                "System dependency {phase} failed (exit {}): {cmd}",
-                status.code().unwrap_or(-1)
-            );
+            let code = status.code().unwrap_or(-1);
+            if bail_on_failure {
+                anyhow::bail!("System dependency {phase} failed (exit {code}): {cmd}");
+            }
+            ui::warn(format!(
+                "System dependency {phase} failed (exit {code}): {cmd}"
+            ));
+            ui::hint(format!("Run `{cmd}` manually to finish {phase}."));
         }
     }
     Ok(())

--- a/crates/uvr/src/commands/sync.rs
+++ b/crates/uvr/src/commands/sync.rs
@@ -1113,42 +1113,26 @@ async fn install_from_lockfile_with_r(
                                 // setup commands here too rather than handing
                                 // the user a line that fails when pasted.
                                 for cmd in &check.pre_install {
-                                    ui::hint(format!("First run: {cmd}"));
+                                    ui::hint(format!("First run: {}", cmd.command));
                                 }
                                 ui::hint(&install_hint);
                                 for cmd in &check.post_install {
-                                    ui::hint(format!("Then run: {cmd}"));
+                                    ui::hint(format!("Then run: {}", cmd.command));
                                 }
                                 ui::hint("Or run uvr as root in this container.");
                             }
                             (true, Some((install_program, install_args))) => {
-                                // Full disclosure before consent: the prompt
-                                // below only names the package-manager
-                                // command, but answering yes also authorises
-                                // every pre_install/post_install command a
-                                // rule carries (repo enablement, `R CMD
-                                // javareconf`, etc.). Show the whole plan
-                                // first — unconditionally, since
-                                // `confirm_sysreqs_install` proceeds without
-                                // prompting on a non-TTY — so nothing runs
-                                // without having been shown.
-                                //
-                                // On stderr, deliberately: the confirmation
-                                // prompt is written to stderr, so a stdout
-                                // disclosure would vanish under
-                                // `uvr sync --install-system-deps > build.log`
-                                // and leave the user consenting to a prompt
-                                // that names only the package-manager command.
-                                if !check.pre_install.is_empty() || !check.post_install.is_empty() {
-                                    ui::info_err("The following will run:");
-                                    for cmd in &check.pre_install {
-                                        ui::bullet_err(cmd);
-                                    }
-                                    ui::bullet_err(&install_cmd_display);
-                                    for cmd in &check.post_install {
-                                        ui::bullet_err(cmd);
-                                    }
-                                }
+                                // Before consent, not after: the prompt below
+                                // names only the package-manager command, but
+                                // answering yes also authorises every
+                                // pre_install/post_install command a rule
+                                // carries. See `print_sysreqs_disclosure` for
+                                // what it prints and why it prints it there.
+                                print_sysreqs_disclosure(
+                                    &check.pre_install,
+                                    &install_cmd_display,
+                                    &check.post_install,
+                                );
                                 if confirm_sysreqs_install(&install_cmd_display)? {
                                     // Refresh the package index first where the
                                     // manager needs it: fresh openSUSE/Arch
@@ -1224,11 +1208,11 @@ async fn install_from_lockfile_with_r(
                             }
                             (false, _) => {
                                 for cmd in &check.pre_install {
-                                    ui::hint(format!("First run: {cmd}"));
+                                    ui::hint(format!("First run: {}", cmd.command));
                                 }
                                 ui::hint(&install_hint);
                                 for cmd in &check.post_install {
-                                    ui::hint(format!("Then run: {cmd}"));
+                                    ui::hint(format!("Then run: {}", cmd.command));
                                 }
                                 ui::hint(
                                     "Or set --install-system-deps / UVR_INSTALL_SYSREQS=1 to let uvr run that for you.",
@@ -1936,7 +1920,7 @@ const ROOT_SAFE_PATH: &str = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:
 /// `--install-system-deps`).
 #[cfg(target_os = "linux")]
 fn run_rule_commands(
-    cmds: &[String],
+    cmds: &[uvr_core::sysreqs::SetupCommand],
     phase: &str,
     r_bin_dir: Option<&std::path::Path>,
     bail_on_failure: bool,
@@ -1944,7 +1928,7 @@ fn run_rule_commands(
     let needs_sudo = !is_effective_root();
     // Deliberately NOT `std::env::var("PATH")`: see the security note above.
     let path_env = r_bin_dir.map(|dir| format!("{}:{ROOT_SAFE_PATH}", dir.display()));
-    for cmd in cmds {
+    for cmd in cmds.iter().map(|c| &c.command) {
         // stderr: this is the audit line for a privileged command, and it
         // belongs with the disclosure and the prompt that preceded it.
         ui::info_err(format!("Running: {cmd}"));
@@ -1976,6 +1960,67 @@ fn run_rule_commands(
     }
     Ok(())
 }
+
+/// Print the full plan before `confirm_sysreqs_install` asks for consent.
+///
+/// Every command is listed with two annotations, because a user approving
+/// root execution is answering two different questions and the block used
+/// to answer neither:
+///
+/// - **source** — a vendored command is a compile-time constant from the
+///   reviewed `vendor/r-system-requirements` snapshot; a `Posit's sysreqs
+///   API` one arrived over the network during this sync. On Ubuntu and the
+///   RHEL family the API answers, so that is most users.
+/// - **note** — what the command actually does. Provenance alone would be
+///   actively misleading here: `curl … https://sh.rustup.rs | sh` and
+///   `dnf install -y --nogpgcheck https://mirrors.rpmfusion.org/…` are
+///   *vendored*, and "vendored" means a human reviewed the rule, not that
+///   they vouched for what it does at runtime.
+///
+/// The closing line says outright that an unannotated command is one uvr
+/// recognised no pattern in rather than one it has cleared, so the notes
+/// are not read as a whitelist. Everything goes to stderr, where
+/// `confirm_sysreqs_install` prompts, so redirecting stdout to a build log
+/// cannot separate the consent from what it covers.
+///
+/// Unconditional: `confirm_sysreqs_install` returns `true` without
+/// prompting on a non-TTY, so printing this only when a prompt will appear
+/// would leave CI runs with no record of what ran as root.
+#[cfg(target_os = "linux")]
+fn print_sysreqs_disclosure(
+    pre_install: &[uvr_core::sysreqs::SetupCommand],
+    install_cmd_display: &str,
+    post_install: &[uvr_core::sysreqs::SetupCommand],
+) {
+    if pre_install.is_empty() && post_install.is_empty() {
+        // Nothing but the package-manager command, which the prompt itself
+        // names in full — a disclosure block would only repeat it.
+        return;
+    }
+    ui::info_err("The following will run as root:");
+    let describe = |cmd: &uvr_core::sysreqs::SetupCommand| {
+        ui::bullet_err(&cmd.command);
+        ui::sub_err(format!("source: {}", cmd.source.label()));
+        let effects = cmd.effects();
+        if !effects.is_empty() {
+            let notes: Vec<&str> = effects.iter().map(|e| e.label()).collect();
+            ui::sub_err(format!("note: {}", notes.join("; ")));
+        }
+    };
+    for cmd in pre_install {
+        describe(cmd);
+    }
+    // uvr builds this one itself from the resolved package names, so it has
+    // no rule provenance to report and needs no note.
+    ui::bullet_err(install_cmd_display);
+    for cmd in post_install {
+        describe(cmd);
+    }
+    ui::note_err(
+        "Commands without a note are ones uvr matched no pattern in, not ones it has vetted.",
+    );
+}
+
 /// Prompt before invoking the system package manager. Same TTY-only
 /// pattern as `confirm_library_wipe` — non-interactive sessions
 /// (CI, scripts) proceed without prompting since the user opted in via

--- a/crates/uvr/src/commands/sync.rs
+++ b/crates/uvr/src/commands/sync.rs
@@ -1118,7 +1118,21 @@ async fn install_from_lockfile_with_r(
                                     // found" for packages that exist. Best-effort
                                     // — a failed refresh still lets the install
                                     // try (it may have usable cached lists).
+                                    //
+                                    // Before the rules' own setup, not after:
+                                    // `gdal.json` opens its Ubuntu pre_install
+                                    // with `apt-get install -y
+                                    // software-properties-common`, which needs
+                                    // lists a fresh container doesn't have. The
+                                    // rules re-refresh themselves where their own
+                                    // repo additions require it (that same rule
+                                    // ends with `apt-get update` after the PPA).
                                     run_sysreqs_refresh();
+                                    // Setup next: several rules need a repo
+                                    // enabled (EPEL, crb) before their packages
+                                    // exist. Entries contain shell operators,
+                                    // so they go through `sh -c`.
+                                    run_rule_commands(&check.pre_install, "setup")?;
                                     ui::info(format!("Running: {install_cmd_display}"));
                                     let mut cmd = std::process::Command::new(&install_program);
                                     cmd.args(&install_args);
@@ -1138,6 +1152,7 @@ async fn install_from_lockfile_with_r(
                                             status.code().unwrap_or(-1)
                                         );
                                     }
+                                    run_rule_commands(&check.post_install, "post-install")?;
                                     ui::success("System dependencies installed.");
                                 } else {
                                     ui::hint(&install_hint);
@@ -1147,7 +1162,13 @@ async fn install_from_lockfile_with_r(
                                 }
                             }
                             (false, _) => {
+                                for cmd in &check.pre_install {
+                                    ui::hint(format!("First run: {cmd}"));
+                                }
                                 ui::hint(&install_hint);
+                                for cmd in &check.post_install {
+                                    ui::hint(format!("Then run: {cmd}"));
+                                }
                                 ui::hint(
                                     "Or set --install-system-deps / UVR_INSTALL_SYSREQS=1 to let uvr run that for you.",
                                 );
@@ -1791,6 +1812,31 @@ fn local_check_incomplete(
     check.missing.is_empty() && pkgs_with_sysreqs > 0 && check.local_resolved < pkgs_with_sysreqs
 }
 
+
+
+/// Run a rule's setup/post-install commands via `sh -c`: entries such as
+/// `rpm -q epel-release || yum install -y https://...` rely on shell
+/// operators, so a direct `Command::new` of the first token would break
+/// them. Bails on the first failing command with the exit code and the
+/// offending command so the user can re-run it manually.
+#[cfg(target_os = "linux")]
+fn run_rule_commands(cmds: &[String], phase: &str) -> Result<()> {
+    for cmd in cmds {
+        ui::info(format!("Running: {cmd}"));
+        let status = std::process::Command::new("sh")
+            .arg("-c")
+            .arg(cmd)
+            .status()
+            .with_context(|| format!("Failed to spawn: {cmd}"))?;
+        if !status.success() {
+            anyhow::bail!(
+                "System dependency {phase} failed (exit {}): {cmd}",
+                status.code().unwrap_or(-1)
+            );
+        }
+    }
+    Ok(())
+}
 /// Prompt before invoking the system package manager. Same TTY-only
 /// pattern as `confirm_library_wipe` — non-interactive sessions
 /// (CI, scripts) proceed without prompting since the user opted in via

--- a/crates/uvr/src/commands/sync.rs
+++ b/crates/uvr/src/commands/sync.rs
@@ -1110,6 +1110,26 @@ async fn install_from_lockfile_with_r(
                                 ui::hint("Or run uvr as root in this container.");
                             }
                             (true, Some((install_program, install_args))) => {
+                                // Full disclosure before consent: the prompt
+                                // below only names the package-manager
+                                // command, but answering yes also authorises
+                                // every pre_install/post_install command a
+                                // rule carries (repo enablement, `R CMD
+                                // javareconf`, etc.). Show the whole plan
+                                // first — unconditionally, since
+                                // `confirm_sysreqs_install` proceeds without
+                                // prompting on a non-TTY — so nothing runs
+                                // without having been shown.
+                                if !check.pre_install.is_empty() || !check.post_install.is_empty() {
+                                    ui::info("The following will run:");
+                                    for cmd in &check.pre_install {
+                                        ui::bullet(cmd);
+                                    }
+                                    ui::bullet(&install_cmd_display);
+                                    for cmd in &check.post_install {
+                                        ui::bullet(cmd);
+                                    }
+                                }
                                 if confirm_sysreqs_install(&install_cmd_display)? {
                                     // Refresh the package index first where the
                                     // manager needs it: fresh openSUSE/Arch
@@ -1819,15 +1839,27 @@ fn local_check_incomplete(
 /// operators, so a direct `Command::new` of the first token would break
 /// them. Bails on the first failing command with the exit code and the
 /// offending command so the user can re-run it manually.
+///
+/// Escalates with the same `sudo` rule as `pick_sysreqs_installer`: these
+/// commands enable repos and install RPMs/DEBs, which need root just like
+/// the package install itself. The caller only reaches this function via
+/// the `(true, Some(..))` match arm, where `pick_sysreqs_installer` has
+/// already returned `None` (and short-circuited to the `(true, None)`
+/// arm instead) whenever `sudo` would be needed but isn't on PATH — so
+/// `sudo` is guaranteed to exist here whenever it's needed.
 #[cfg(target_os = "linux")]
 fn run_rule_commands(cmds: &[String], phase: &str) -> Result<()> {
+    let needs_sudo = !is_effective_root();
     for cmd in cmds {
         ui::info(format!("Running: {cmd}"));
-        let status = std::process::Command::new("sh")
-            .arg("-c")
-            .arg(cmd)
-            .status()
-            .with_context(|| format!("Failed to spawn: {cmd}"))?;
+        let status = if needs_sudo {
+            std::process::Command::new("sudo")
+                .args(["sh", "-c", cmd])
+                .status()
+        } else {
+            std::process::Command::new("sh").arg("-c").arg(cmd).status()
+        }
+        .with_context(|| format!("Failed to spawn: {cmd}"))?;
         if !status.success() {
             anyhow::bail!(
                 "System dependency {phase} failed (exit {}): {cmd}",

--- a/crates/uvr/src/commands/sync.rs
+++ b/crates/uvr/src/commands/sync.rs
@@ -1106,7 +1106,19 @@ async fn install_from_lockfile_with_r(
                                 ui::warn(
                                     "--install-system-deps requested, but `sudo` is not on PATH and uvr is not running as root.",
                                 );
+                                // Same shape as the `(false, _)` arm below:
+                                // the package-manager command alone is not a
+                                // working recipe when a rule needs a repo
+                                // enabled first (EPEL, crb), so print the
+                                // setup commands here too rather than handing
+                                // the user a line that fails when pasted.
+                                for cmd in &check.pre_install {
+                                    ui::hint(format!("First run: {cmd}"));
+                                }
                                 ui::hint(&install_hint);
+                                for cmd in &check.post_install {
+                                    ui::hint(format!("Then run: {cmd}"));
+                                }
                                 ui::hint("Or run uvr as root in this container.");
                             }
                             (true, Some((install_program, install_args))) => {
@@ -1120,14 +1132,21 @@ async fn install_from_lockfile_with_r(
                                 // `confirm_sysreqs_install` proceeds without
                                 // prompting on a non-TTY — so nothing runs
                                 // without having been shown.
+                                //
+                                // On stderr, deliberately: the confirmation
+                                // prompt is written to stderr, so a stdout
+                                // disclosure would vanish under
+                                // `uvr sync --install-system-deps > build.log`
+                                // and leave the user consenting to a prompt
+                                // that names only the package-manager command.
                                 if !check.pre_install.is_empty() || !check.post_install.is_empty() {
-                                    ui::info("The following will run:");
+                                    ui::info_err("The following will run:");
                                     for cmd in &check.pre_install {
-                                        ui::bullet(cmd);
+                                        ui::bullet_err(cmd);
                                     }
-                                    ui::bullet(&install_cmd_display);
+                                    ui::bullet_err(&install_cmd_display);
                                     for cmd in &check.post_install {
-                                        ui::bullet(cmd);
+                                        ui::bullet_err(cmd);
                                     }
                                 }
                                 if confirm_sysreqs_install(&install_cmd_display)? {
@@ -1161,7 +1180,10 @@ async fn install_from_lockfile_with_r(
                                     // sudo's `secure_path` in force for these
                                     // root-run shell strings.
                                     run_rule_commands(&check.pre_install, "setup", None, true)?;
-                                    ui::info(format!("Running: {install_cmd_display}"));
+                                    // stderr, like the disclosure above: this
+                                    // is the audit trail for what was just
+                                    // consented to, not command output.
+                                    ui::info_err(format!("Running: {install_cmd_display}"));
                                     let mut cmd = std::process::Command::new(&install_program);
                                     cmd.args(&install_args);
                                     if let Some(pm) = uvr_core::sysreqs::PackageManager::detect() {
@@ -1925,7 +1947,9 @@ fn run_rule_commands(
     // Deliberately NOT `std::env::var("PATH")`: see the security note above.
     let path_env = r_bin_dir.map(|dir| format!("{}:{ROOT_SAFE_PATH}", dir.display()));
     for cmd in cmds {
-        ui::info(format!("Running: {cmd}"));
+        // stderr: this is the audit line for a privileged command, and it
+        // belongs with the disclosure and the prompt that preceded it.
+        ui::info_err(format!("Running: {cmd}"));
         let status = if needs_sudo {
             let mut command = std::process::Command::new("sudo");
             if let Some(path) = &path_env {

--- a/crates/uvr/src/ui/mod.rs
+++ b/crates/uvr/src/ui/mod.rs
@@ -17,8 +17,8 @@ pub mod progress;
 
 #[allow(unused_imports)]
 pub use print::{
-    bullet, bullet_dim, check, error_block, fail, hint, info, row, row_added, row_removed,
-    row_upgrade, section, success, summary, warn, warn_block, welcome, welcome_group,
+    bullet, bullet_dim, bullet_err, check, error_block, fail, hint, info, info_err, row, row_added,
+    row_removed, row_upgrade, section, success, summary, warn, warn_block, welcome, welcome_group,
 };
 #[allow(unused_imports)]
 pub use progress::{make_aggregate_bar, make_spinner};

--- a/crates/uvr/src/ui/mod.rs
+++ b/crates/uvr/src/ui/mod.rs
@@ -17,8 +17,9 @@ pub mod progress;
 
 #[allow(unused_imports)]
 pub use print::{
-    bullet, bullet_dim, bullet_err, check, error_block, fail, hint, info, info_err, row, row_added,
-    row_removed, row_upgrade, section, success, summary, warn, warn_block, welcome, welcome_group,
+    bullet, bullet_dim, bullet_err, check, error_block, fail, hint, info, info_err, note_err, row,
+    row_added, row_removed, row_upgrade, section, sub_err, success, summary, warn, warn_block,
+    welcome, welcome_group,
 };
 #[allow(unused_imports)]
 pub use progress::{make_aggregate_bar, make_spinner};

--- a/crates/uvr/src/ui/print.rs
+++ b/crates/uvr/src/ui/print.rs
@@ -56,6 +56,17 @@ pub fn info(text: impl std::fmt::Display) {
     println!("{} {text}", palette::info(glyph::info()));
 }
 
+/// `› <text>` on **stderr** — informational headline that belongs with the
+/// diagnostics rather than with the command's data output.
+///
+/// Use this when the line has to stay glued to a `warn`/`hint`/prompt
+/// sequence: those all go to stderr, so an [`info`] line printed to stdout
+/// disappears from the user's terminal the moment they redirect stdout to a
+/// log file, leaving a prompt whose context is missing.
+pub fn info_err(text: impl std::fmt::Display) {
+    eprintln!("{} {text}", palette::info(glyph::info()));
+}
+
 /// Dedicated hint line — use after an error or warning to tell the user
 /// what to do next. Renders as:
 ///
@@ -77,6 +88,12 @@ pub fn hint(text: impl std::fmt::Display) {
 /// Indented bullet: `  · <text>`.
 pub fn bullet(text: impl std::fmt::Display) {
     println!("  {} {text}", palette::dim(glyph::bullet()));
+}
+
+/// Indented bullet `  · <text>` on **stderr** — the [`info_err`] counterpart,
+/// for listing items under a stderr headline.
+pub fn bullet_err(text: impl std::fmt::Display) {
+    eprintln!("  {} {text}", palette::dim(glyph::bullet()));
 }
 
 /// Indented bullet with explicit dim body — for metadata under a header.

--- a/crates/uvr/src/ui/print.rs
+++ b/crates/uvr/src/ui/print.rs
@@ -101,6 +101,22 @@ pub fn bullet_dim(text: impl std::fmt::Display) {
     println!("  {} {}", palette::dim(glyph::bullet()), palette::dim(text));
 }
 
+/// Dim continuation line under a [`bullet_err`], indented one level further:
+/// `      <text>`. For annotating a listed item without competing with it —
+/// the sysreqs consent block uses it to tag each command's provenance and
+/// what it does.
+pub fn sub_err(text: impl std::fmt::Display) {
+    eprintln!("      {}", palette::dim(text));
+}
+
+/// Dim line at [`bullet_err`] indentation but with no bullet glyph:
+/// `  <text>`. For a remark about a stderr list as a whole — at bullet
+/// depth it cannot be misread as an annotation of the last item the way a
+/// [`sub_err`] would be.
+pub fn note_err(text: impl std::fmt::Display) {
+    eprintln!("  {}", palette::dim(text));
+}
+
 /// `<glyph> <pkg-name> <version>` — a single row in a change list.
 pub fn row(glyph_str: console::StyledObject<&str>, name: &str, version: &str) {
     println!(


### PR DESCRIPTION
Stacked on #220 — review that first; this branch contains its commits.

## The gap

The sysreqs rules carry setup commands — 63 of the 131 vendored rule files have `pre_install`, 2 have `post_install` — and uvr dropped all of them. The build script never emitted them into the generated table, and `PpmRequirementDetail` deserialized only `packages`, discarding `install_scripts`/`pre_install`/`post_install` from the API response.

So `--install-system-deps` on Rocky 9 would try to install `gdal3.4-devel` from repos that were never enabled, and `rJava` never got `R CMD javareconf`.

Both paths had to change. Fixing only the local resolver would look right and do nothing where it matters: on RHEL and its rebuilds — exactly the distros carrying the interesting commands — the API answers, so `check_pkg_local` is never reached.

## The change

`DependencyStatic` and `resolve_local` carry the commands; `PpmRequirementDetail` deserializes them; `SysReqsCheck` collects them, deduplicated in stable order across matched rules. `run_rule_commands` runs `pre_install` before the batched package install and `post_install` after.

Collection is gated on something actually being missing, so a fully-provisioned machine never re-enables EPEL on every sync.

## Security posture — the part worth your attention

This extends uvr's executed surface from package-manager invocations it builds itself to **shell strings from a data file, run as root**. That includes `add-apt-repository -y ppa:ubuntugis/ppa` and `rpm -q epel-release || yum install -y https://…`. `pak` and `rig` already execute the same rule data, which is the precedent this follows.

Deliberate choices:

- **`sh -c`, not a direct spawn** — several commands rely on `||`.
- **Nothing runs without opt-in.** The only call sites sit in the `(true, Some(..))` arm behind `--install-system-deps` / `UVR_INSTALL_SYSREQS`, inside `!missing.is_empty()`.
- **The invoking user's `$PATH` never reaches a root shell.** `pre_install` passes no `PATH` override at all, so sudo's `secure_path` applies unchanged. Only `post_install` needs R, and it prepends the R bin directory to a fixed `ROOT_SAFE_PATH` mirroring the stock `secure_path`. Handing `$PATH` through would let root resolve `rpm` or `curl` from a user's conda or `~/.local/bin` — and `rust.json` pipes a remote script through `curl`.
- **Consent covers what actually runs.** The full command list prints before the confirmation, on stderr alongside the prompt, and unconditionally so non-interactive runs log it too.
- **Asymmetric failure handling.** `pre_install` bails — a repo that could not be enabled makes the following install fail anyway. `post_install` warns and continues, naming the command to re-run: the packages are already installed by then, and a failing `javareconf` should not turn a successful install into a failed sync.

## Verification, on stock `rockylinux:9` with EPEL confirmed absent

```
Running: dnf install -y epel-release
Running: dnf install -y dnf-plugins-core
Running: dnf config-manager --set-enabled crb
Running: dnf install -y … gdal3.4-devel geos-devel proj-devel …
```

gdal/geos/proj then resolve *from* `epel`/`crb` in the transaction. `rJava` gets `R CMD javareconf`. With the full transitive set pre-installed, zero setup commands run.

## Known limitation

Deduplication keeps the first occurrence, which assumes rule commands are order-independent across rules. On EOL Ubuntu 16.04 a `sf` + `gert` sync can land a PPA after the last `apt-get update`. Documented in the code; 18.04+ `add-apt-repository` self-updates.

Tests: 504 → 511.
