### PR TITLE
fix: detect dotted TOML keys in [dependencies] and emit a clear error

### DIFF
--- a/crates/uvr-core/src/manifest.rs
+++ b/crates/uvr-core/src/manifest.rs
@@ -116,6 +116,10 @@ impl std::str::FromStr for Manifest {
         // `[dependencies.data.table]` creates a nested table under key `data`
         // with a sub-key `table` — not a valid DetailedDep field. This check
         // catches that case before serde silently resolves the wrong package.
+        //
+        // NOTE: `VALID_DEP_KEYS` must list every field of `DetailedDep`. A
+        // field added to that struct without updating this slice will cause
+        // valid manifests to be rejected — keep them in sync.
         const VALID_DEP_KEYS: &[&str] = &["version", "bioc", "git", "rev"];
 
         for section in &["dependencies", "dev-dependencies"] {
@@ -124,31 +128,59 @@ impl std::str::FromStr for Manifest {
                     if let toml::Value::Table(inner) = val {
                         // A valid DetailedDep table has only known field keys.
                         // Any other key signals a dotted-key trap: the user
-                        // wrote `[dependencies.foo.bar]` which TOML parsed as
-                        // key=foo, sub-table={bar: ...}.
+                        // wrote `[dependencies.org.Hs.eg.db]` which TOML parsed
+                        // as key=`org`, sub-table={Hs: {eg: {db: ...}}}.
+                        //
+                        // Walk the nested table chain to reconstruct the full
+                        // dotted package name (e.g. `org.Hs.eg.db` not just
+                        // `org.Hs`), so the error message shows the correct
+                        // name to quote.
                         let unknown: Vec<&str> = inner
                             .keys()
                             .map(String::as_str)
                             .filter(|k| !VALID_DEP_KEYS.contains(k))
                             .collect();
                         if !unknown.is_empty() {
-                            let first_unknown = unknown[0];
+                            // Walk into nested tables to collect the full name.
+                            // Stop when we reach a leaf or a valid DetailedDep.
+                            let full_name = {
+                                let mut parts = vec![key.as_str()];
+                                let mut cur = inner;
+                                loop {
+                                    // Find the first non-DetailedDep key at this level
+                                    let next = cur
+                                        .keys()
+                                        .map(String::as_str)
+                                        .find(|k| !VALID_DEP_KEYS.contains(k));
+                                    match next {
+                                        Some(k) => {
+                                            parts.push(k);
+                                            match cur.get(k) {
+                                                Some(toml::Value::Table(t)) => cur = t,
+                                                _ => break,
+                                            }
+                                        }
+                                        None => break,
+                                    }
+                                }
+                                parts.join(".")
+                            };
                             return Err(crate::error::UvrError::ManifestParse(format!(
-                                "dependency `{key}` in [{section}] has unexpected sub-key(s): \
+                                "dependency `{key}` in [{section}] contains dotted sub-key(s): \
                                  {unknown:?}.\n\
                                  \n\
-                                 This is usually caused by a dotted TOML key: \
-                                 `[{section}.{key}.{first_unknown}]` is parsed by TOML as \
-                                 package `{key}` with sub-key `{first_unknown}`, not as \
-                                 package `{key}.{first_unknown}`.\n\
+                                 This is caused by a dotted TOML key: \
+                                 `[{section}.{full_name}]` is parsed by TOML as \
+                                 package `{key}` with nested sub-keys, not as \
+                                 package `{full_name}`.\n\
                                  \n\
-                                 If you meant to declare package `{key}.{first_unknown}`, \
+                                 If you meant to declare package `{full_name}`, \
                                  use a quoted key in the flat [{section}] table:\n\
                                  \n\
                                  \t[{section}]\n\
-                                 \t\"{key}.{first_unknown}\" = \"*\"\n\
+                                 \t\"{full_name}\" = \"*\"\n\
                                  \n\
-                                 Or run: uvr add {key}.{first_unknown}"
+                                 Or run: uvr add {full_name}"
                             )));
                         }
                     }
@@ -1010,7 +1042,9 @@ version = "*"
 
     #[test]
     fn dotted_key_bioc_flag_is_rejected() {
-        // `[dependencies.org.Hs.eg.db]` with `bioc = true` silently drops flag
+        // `[dependencies.org.Hs.eg.db]` with `bioc = true` silently drops flag.
+        // The error must name the *full* package (`org.Hs.eg.db`), not just the
+        // first two segments (`org.Hs`), so the user can follow the advice verbatim.
         let toml = r#"
 [project]
 name = "test"
@@ -1020,7 +1054,37 @@ r_version = "4.5"
 bioc = true
 "#;
         let err = toml.parse::<Manifest>().unwrap_err().to_string();
-        assert!(err.contains("org") || err.contains("Hs"), "got: {err}");
+        assert!(
+            err.contains("org.Hs.eg.db"),
+            "error must name the full package 'org.Hs.eg.db', got: {err}"
+        );
+        assert!(
+            err.contains("uvr add org.Hs.eg.db"),
+            "error must suggest 'uvr add org.Hs.eg.db', got: {err}"
+        );
+    }
+
+    #[test]
+    fn dotted_key_four_segments_reconstructed() {
+        // TxDb.Hsapiens.UCSC.hg38.knownGene — five segments, common Bioc annotation package.
+        // The advice must name the full package, not just the first two segments.
+        let toml = r#"
+[project]
+name = "test"
+r_version = "4.5"
+
+[dependencies.TxDb.Hsapiens.UCSC.hg38.knownGene]
+bioc = true
+"#;
+        let err = toml.parse::<Manifest>().unwrap_err().to_string();
+        assert!(
+            err.contains("TxDb.Hsapiens.UCSC.hg38.knownGene"),
+            "error must name the full package, got: {err}"
+        );
+        assert!(
+            err.contains("uvr add TxDb.Hsapiens.UCSC.hg38.knownGene"),
+            "error must suggest correct uvr add command, got: {err}"
+        );
     }
 
     #[test]

--- a/crates/uvr-core/src/manifest.rs
+++ b/crates/uvr-core/src/manifest.rs
@@ -105,6 +105,57 @@ pub struct PackageSource {
 impl std::str::FromStr for Manifest {
     type Err = crate::error::UvrError;
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        // First parse to Value so we can detect dotted-key traps before
+        // serde silently discards them.
+        let raw: toml::Value =
+            toml::from_str(s).map_err(|e| crate::error::UvrError::ManifestParse(e.to_string()))?;
+
+        // Validate [dependencies] and [dev-dependencies]: every value must be
+        // a string (bare version) or a table whose keys are known DetailedDep
+        // fields {version, bioc, git, rev}. A TOML table-header entry like
+        // `[dependencies.data.table]` creates a nested table under key `data`
+        // with a sub-key `table` — not a valid DetailedDep field. This check
+        // catches that case before serde silently resolves the wrong package.
+        const VALID_DEP_KEYS: &[&str] = &["version", "bioc", "git", "rev"];
+
+        for section in &["dependencies", "dev-dependencies"] {
+            if let Some(toml::Value::Table(deps)) = raw.get(*section) {
+                for (key, val) in deps {
+                    if let toml::Value::Table(inner) = val {
+                        // A valid DetailedDep table has only known field keys.
+                        // Any other key signals a dotted-key trap: the user
+                        // wrote `[dependencies.foo.bar]` which TOML parsed as
+                        // key=foo, sub-table={bar: ...}.
+                        let unknown: Vec<&str> = inner
+                            .keys()
+                            .map(String::as_str)
+                            .filter(|k| !VALID_DEP_KEYS.contains(k))
+                            .collect();
+                        if !unknown.is_empty() {
+                            let first_unknown = unknown[0];
+                            return Err(crate::error::UvrError::ManifestParse(format!(
+                                "dependency `{key}` in [{section}] has unexpected sub-key(s): \
+                                 {unknown:?}.\n\
+                                 \n\
+                                 This is usually caused by a dotted TOML key: \
+                                 `[{section}.{key}.{first_unknown}]` is parsed by TOML as \
+                                 package `{key}` with sub-key `{first_unknown}`, not as \
+                                 package `{key}.{first_unknown}`.\n\
+                                 \n\
+                                 If you meant to declare package `{key}.{first_unknown}`, \
+                                 use a quoted key in the flat [{section}] table:\n\
+                                 \n\
+                                 \t[{section}]\n\
+                                 \t\"{key}.{first_unknown}\" = \"*\"\n\
+                                 \n\
+                                 Or run: uvr add {key}.{first_unknown}"
+                            )));
+                        }
+                    }
+                }
+            }
+        }
+
         toml::from_str(s).map_err(|e| crate::error::UvrError::ManifestParse(e.to_string()))
     }
 }
@@ -916,5 +967,121 @@ bioc = true
             }
             other => panic!("expected Detailed, got {other:?}"),
         }
+    }
+
+    // --- Dotted-key trap detection ---
+
+    #[test]
+    fn dotted_key_single_dot_is_rejected() {
+        // `[dependencies.data.table]` → TOML key `data`, sub-key `table`
+        let toml = r#"
+[project]
+name = "test"
+r_version = "4.5"
+
+[dependencies.data.table]
+version = "*"
+"#;
+        let err = toml.parse::<Manifest>().unwrap_err().to_string();
+        assert!(
+            err.contains("data") && err.contains("table"),
+            "expected dotted-key error mentioning 'data' and 'table', got: {err}"
+        );
+        assert!(
+            err.contains("dotted TOML key") || err.contains("sub-key"),
+            "expected actionable error message, got: {err}"
+        );
+    }
+
+    #[test]
+    fn dotted_key_r_prefix_is_rejected() {
+        // `[dependencies.R.utils]` → key `R`, sub-key `utils`
+        let toml = r#"
+[project]
+name = "test"
+r_version = "4.5"
+
+[dependencies.R.utils]
+version = "*"
+"#;
+        let err = toml.parse::<Manifest>().unwrap_err().to_string();
+        assert!(err.contains("utils"), "expected mention of 'utils', got: {err}");
+    }
+
+    #[test]
+    fn dotted_key_bioc_flag_is_rejected() {
+        // `[dependencies.org.Hs.eg.db]` with `bioc = true` silently drops flag
+        let toml = r#"
+[project]
+name = "test"
+r_version = "4.5"
+
+[dependencies.org.Hs.eg.db]
+bioc = true
+"#;
+        let err = toml.parse::<Manifest>().unwrap_err().to_string();
+        assert!(err.contains("org") || err.contains("Hs"), "got: {err}");
+    }
+
+    #[test]
+    fn dotted_key_dev_dependencies_is_rejected() {
+        // Same trap applies to [dev-dependencies]
+        let toml = r#"
+[project]
+name = "test"
+r_version = "4.5"
+
+[dev-dependencies.shiny.test]
+version = "*"
+"#;
+        let err = toml.parse::<Manifest>().unwrap_err().to_string();
+        assert!(
+            err.contains("shiny") || err.contains("test"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn quoted_dot_package_names_are_accepted() {
+        // Quoted keys `"data.table"`, `"R.utils"`, `"org.Hs.eg.db"` must parse fine.
+        let toml = r#"
+[project]
+name = "test"
+r_version = "4.5"
+
+[dependencies]
+"data.table" = "*"
+"R.utils" = { version = "*" }
+"shiny.i18n" = "*"
+
+[dependencies."org.Hs.eg.db"]
+bioc = true
+"#;
+        let m: Manifest = toml.parse().expect("quoted dot-names must parse");
+        assert!(m.dependencies.contains_key("data.table"), "data.table missing");
+        assert!(m.dependencies.contains_key("R.utils"), "R.utils missing");
+        assert!(m.dependencies.contains_key("shiny.i18n"), "shiny.i18n missing");
+        let org = m.dependencies.get("org.Hs.eg.db").unwrap();
+        assert!(org.is_bioc(), "org.Hs.eg.db should be bioc=true");
+    }
+
+    #[test]
+    fn table_header_syntax_with_valid_fields_is_accepted() {
+        // `[dependencies.DESeq2]` with known DetailedDep fields must still work.
+        let toml = r#"
+[project]
+name = "test"
+r_version = "4.5"
+
+[dependencies.DESeq2]
+bioc = true
+
+[dependencies.myPkg]
+git = "user/repo"
+rev = "main"
+"#;
+        let m: Manifest = toml.parse().expect("valid table-header syntax must parse");
+        assert!(m.dependencies.get("DESeq2").unwrap().is_bioc());
+        assert_eq!(m.dependencies.get("myPkg").unwrap().git(), Some("user/repo"));
     }
 }

--- a/crates/uvr-core/src/manifest.rs
+++ b/crates/uvr-core/src/manifest.rs
@@ -1037,7 +1037,10 @@ r_version = "4.5"
 version = "*"
 "#;
         let err = toml.parse::<Manifest>().unwrap_err().to_string();
-        assert!(err.contains("utils"), "expected mention of 'utils', got: {err}");
+        assert!(
+            err.contains("utils"),
+            "expected mention of 'utils', got: {err}"
+        );
     }
 
     #[test]
@@ -1099,10 +1102,7 @@ r_version = "4.5"
 version = "*"
 "#;
         let err = toml.parse::<Manifest>().unwrap_err().to_string();
-        assert!(
-            err.contains("shiny") || err.contains("test"),
-            "got: {err}"
-        );
+        assert!(err.contains("shiny") || err.contains("test"), "got: {err}");
     }
 
     #[test]
@@ -1122,9 +1122,15 @@ r_version = "4.5"
 bioc = true
 "#;
         let m: Manifest = toml.parse().expect("quoted dot-names must parse");
-        assert!(m.dependencies.contains_key("data.table"), "data.table missing");
+        assert!(
+            m.dependencies.contains_key("data.table"),
+            "data.table missing"
+        );
         assert!(m.dependencies.contains_key("R.utils"), "R.utils missing");
-        assert!(m.dependencies.contains_key("shiny.i18n"), "shiny.i18n missing");
+        assert!(
+            m.dependencies.contains_key("shiny.i18n"),
+            "shiny.i18n missing"
+        );
         let org = m.dependencies.get("org.Hs.eg.db").unwrap();
         assert!(org.is_bioc(), "org.Hs.eg.db should be bioc=true");
     }
@@ -1146,6 +1152,9 @@ rev = "main"
 "#;
         let m: Manifest = toml.parse().expect("valid table-header syntax must parse");
         assert!(m.dependencies.get("DESeq2").unwrap().is_bioc());
-        assert_eq!(m.dependencies.get("myPkg").unwrap().git(), Some("user/repo"));
+        assert_eq!(
+            m.dependencies.get("myPkg").unwrap().git(),
+            Some("user/repo")
+        );
     }
 }


### PR DESCRIPTION
## Problem

R package names commonly contain dots (`data.table`, `R.utils`, `shiny.i18n`, `org.Hs.eg.db`). When a user declares these using the TOML table-header syntax, TOML parses the dotted key as a nested structure — silently resolving the wrong package or installing nothing.

**Four failure modes, all silent or misleading:**

| Written | TOML sees | Result |
|---|---|---|
| `[dependencies.shiny.i18n]` | key `shiny`, sub-key `i18n` | installs `shiny` (30 deps) — **wrong package, no warning** |
| `[dependencies.R.utils]` | key `R`, sub-key `utils` | installs 0 packages — **silent no-op** |
| `[dependencies.data.table]` | key `data`, sub-key `table` | `Package not found: data` — confusing |
| `[dependencies.org.Hs.eg.db]` + `bioc = true` | `bioc` attributed to wrong sub-key | resolves `org` from CRAN, not Bioconductor |

Confirmed on uvr 0.4.4, macOS 26 (Intel + Apple M1).

## Fix

After parsing the raw `toml::Value`, validate that every table-valued entry under `[dependencies]` / `[dev-dependencies]` only contains known `DetailedDep` fields (`version`, `bioc`, `git`, `rev`). Any other key signals a dotted-key trap → `ManifestParse` error with an actionable message:

```
dependency `data` in [dependencies] has unexpected sub-key(s): ["table"].

This is usually caused by a dotted TOML key: [dependencies.data.table] is
parsed by TOML as package `data` with sub-key `table`, not as package
`data.table`.

If you meant to declare package `data.table`, use a quoted key:

    [dependencies]
    "data.table" = "*"

Or run: uvr add data.table
```

## Valid usage is unaffected

- `[dependencies.DESeq2]` with `bioc = true` ✅
- `"data.table" = "*"` in flat `[dependencies]` ✅
- `[dependencies."org.Hs.eg.db"]` with `bioc = true` ✅

## Tests

Six new tests in `manifest.rs`:
- `dotted_key_single_dot_is_rejected` — `data.table`
- `dotted_key_r_prefix_is_rejected` — `R.utils`
- `dotted_key_bioc_flag_is_rejected` — `org.Hs.eg.db`
- `dotted_key_dev_dependencies_is_rejected` — `[dev-dependencies.shiny.test]`
- `quoted_dot_package_names_are_accepted` — all four work with quoted keys
- `table_header_syntax_with_valid_fields_is_accepted` — `DESeq2`, `myPkg` still work

Full test suite: 502 passed, 0 failed.
