### PR TITLE
Add an installer for Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,6 +344,38 @@ jobs:
       - name: Check every mapped repo still serves
         run: cargo test -p uvr-core --test p3m_repos_live -- --ignored --nocapture
 
+  # install.ps1 has no coverage anywhere above: the windows-x86_64 matrix
+  # entry in `test` builds uvr with cargo directly and never touches the
+  # installer. Run it for real, against the latest published release, the
+  # same way a user invoking `irm ... | iex` would. Catches asset-name
+  # drift, a changed zip layout, and PATH-writing regressions — the three
+  # things gdevenyi flagged as most likely to break silently between
+  # releases (PR #224).
+  test-install-script:
+    name: Test install.ps1 (Windows)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run install.ps1 into a temp dir
+        shell: pwsh
+        run: |
+          $installDir = Join-Path $env:RUNNER_TEMP "uvr-install-smoke"
+          $env:UVR_INSTALL_DIR = $installDir
+          .\install.ps1
+          & (Join-Path $installDir "uvr.exe") --version
+
+      - name: Verify the install dir was added to the user PATH
+        shell: pwsh
+        run: |
+          $installDir = Join-Path $env:RUNNER_TEMP "uvr-install-smoke"
+          $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+          if ($userPath -notlike "*$installDir*") {
+            Write-Error "install.ps1 did not add $installDir to the user PATH"
+            exit 1
+          }
+          Write-Host "OK: $installDir present in user PATH"
+
   audit:
     name: Security audit
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -10,9 +10,21 @@ A fast R package and project manager, written in Rust.
 
 `uvr` brings uv-style project management to R: a `uvr.toml` manifest, a reproducible `uvr.lock` lockfile, and a per-project isolated library. Packages install from pre-built [P3M](https://packagemanager.posit.co/) binaries by default — no compilation, no waiting — with automatic fallback to CRAN source. R versions are managed per-project with no `sudo` required.
 
-```sh
-$ curl -fsSL https://raw.githubusercontent.com/nbafrank/uvr/main/install.sh | sh
+1.  Linux / MacOS
 
+    ``` sh
+    curl -fsSL https://raw.githubusercontent.com/nbafrank/uvr/main/install.sh | sh
+    ```
+
+2.  Windows
+
+    ``` sh
+    powershell -ExecutionPolicy Bypass -c "irm https://raw.githubusercontent.com/nbafrank/uvr/main/install.ps1 | iex"
+    ```
+
+Here's a following demo of `uvr`: 
+
+``` sh
 $ uvr init my-analysis
 $ uvr add ggplot2 dplyr tidymodels
 $ uvr sync          # installs from lockfile, idempotent

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ A fast R package and project manager, written in Rust.
 
 2.  Windows
 
-    ``` sh
-    powershell -ExecutionPolicy Bypass -c "irm https://raw.githubusercontent.com/nbafrank/uvr/main/install.ps1 | iex"
+    ``` powershell
+    irm https://raw.githubusercontent.com/nbafrank/uvr/main/install.ps1 | iex
     ```
 
 Here's a following demo of `uvr`: 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ R has several package management tools — `renv`, `pak`, `rv`, `rig` — each s
 
 Here is how existing tools compare and where the gaps are:
 
-- **renv** — the de-facto standard for reproducibility. It snapshots an existing library into a lockfile, but it does not manage R versions ("renv tracks, but doesn't help with, the version of R used") and relies on `install.packages()` under the hood, which is slow and requires compilation on Linux.
+- **renv** — the de-facto standard for reproducibility. It snapshots an existing library into a lockfile, but it does not pin R versions ("renv tracks, but doesn't help with, the version of R used") and relies on `install.packages()` under the hood, which is slow and requires compilation on Linux.
 - **pak** — fast parallel installs and good system dependency detection, but no lockfile and no R version management. A great complement to renv, not a replacement.
 - **rv** — the closest prior art: Rust-based, declarative, fast. It focuses on package resolution. It does not manage R installations, and `rv run` is not yet available.
 - **rig** — excellent R version manager. No package management or lockfile. Requires admin rights on Windows.
@@ -142,6 +142,12 @@ This auto-detects your platform, downloads the binary, verifies the SHA256 check
 curl -fsSL https://raw.githubusercontent.com/nbafrank/uvr/main/install.sh | UVR_INSTALL_DIR=/usr/local/bin sh
 ```
 
+You can quick install on Windows as well with the following Powershell command:
+
+``` bash
+irm https://raw.githubusercontent.com/nbafrank/uvr/main/install.ps1 | iex
+```
+
 ### Manual download
 
 Download the latest release for your platform from [GitHub Releases](https://github.com/nbafrank/uvr/releases/latest):
@@ -164,7 +170,7 @@ curl -fsSL https://github.com/nbafrank/uvr/releases/latest/download/uvr-aarch64-
 sudo mv uvr /usr/local/bin/
 ```
 
-On Windows, download `uvr-x86_64-pc-windows-msvc.zip` from the releases page and add `uvr.exe` to your PATH.
+On Windows, download `uvr-x86_64-pc-windows-msvc.zip` from the releases page and add `uvr.exe` to your PATH. 
 
 ### From R
 

--- a/install.ps1
+++ b/install.ps1
@@ -59,18 +59,19 @@ function Get-ExpectedHash {
     try {
         Invoke-WebRequest -Uri "$BaseUrl/sha256sums.txt" -OutFile $sumsPath -UseBasicParsing
     } catch {
-        Write-Log "Warning: sha256sums.txt not found, skipping checksum verification"
-        return $null
+        Write-ErrExit "Could not fetch sha256sums.txt: $_"
     }
     $line = Select-String -Path $sumsPath -Pattern ([Regex]::Escape($Asset)) | Select-Object -First 1
     if (-not $line) {
-        Write-Log "Warning: no checksum entry for $Asset, skipping checksum verification"
-        return $null
+        Write-ErrExit "sha256sums.txt does not list $Asset"
     }
     return ($line.Line -split "\s+")[0]
 }
 
 function Add-ToUserPath {
+    # Writes straight to the registry so open programs, including this
+    # shell, won't see the change until they restart -- this does not
+    # broadcast WM_SETTINGCHANGE the way the Settings app does.
     param([string]$Dir)
     $key = "HKCU:\Environment"
     $raw = (Get-Item $key).GetValue("Path", "", "DoNotExpandEnvironmentNames")
@@ -94,7 +95,11 @@ function main {
     $target = Get-Target
     Write-Log "Detected platform: $target"
 
-    $version = if ($env:UVR_VERSION) { $env:UVR_VERSION } else { Get-LatestVersion }
+    $version = if ($env:UVR_VERSION) {
+        if ($env:UVR_VERSION -match '^v') { $env:UVR_VERSION } else { "v$env:UVR_VERSION" }
+    } else {
+        Get-LatestVersion
+    }
     Write-Log "Installing uvr $version"
 
     $asset = "uvr-$target.zip"
@@ -112,14 +117,12 @@ function main {
         }
 
         $expected = Get-ExpectedHash -BaseUrl $baseUrl -Asset $asset -TmpDir $tmpDir
-        if ($expected) {
-            Write-Log "Verifying checksum..."
-            $actual = (Get-FileHash -Path $zipPath -Algorithm SHA256).Hash.ToLower()
-            if ($expected.ToLower() -ne $actual) {
-                Write-ErrExit "Checksum mismatch!`n  Expected: $expected`n  Got: $actual"
-            }
-            Write-Log "Checksum verified"
+        Write-Log "Verifying checksum..."
+        $actual = (Get-FileHash -Path $zipPath -Algorithm SHA256).Hash.ToLower()
+        if ($expected.ToLower() -ne $actual) {
+            Write-ErrExit "Checksum mismatch!`n  Expected: $expected`n  Got: $actual"
         }
+        Write-Log "Checksum verified"
 
         Write-Log "Extracting..."
         Expand-Archive -Path $zipPath -DestinationPath $tmpDir -Force

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,142 @@
+# uvr installer for Windows -- https://github.com/nbafrank/uvr
+#
+# Usage:
+#   irm https://raw.githubusercontent.com/nbafrank/uvr/main/install.ps1 | iex
+#
+# Environment variables:
+#   UVR_INSTALL_DIR -- where to place the binary (default: $env:USERPROFILE\.local\bin)
+#   UVR_VERSION -- specific version to install (default: latest)
+
+$ErrorActionPreference = "Stop"
+[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+
+$Repo = "nbafrank/uvr"
+$InstallDir = if ($env:UVR_INSTALL_DIR) { $env:UVR_INSTALL_DIR } else { Join-Path $env:USERPROFILE ".local\bin" }
+
+function Write-Log {
+    param([string]$Message)
+    Write-Host "uvr-install: $Message"
+}
+
+function Write-ErrExit {
+    param([string]$Message)
+    Write-Host "uvr-install: error: $Message" -ForegroundColor Red
+    exit 1
+}
+
+function Get-Target {
+    $arch = $env:PROCESSOR_ARCHITECTURE
+    if ($env:PROCESSOR_ARCHITEW6432) {
+        $arch = $env:PROCESSOR_ARCHITEW6432
+    }
+    switch ($arch) {
+        "AMD64" { return "x86_64-pc-windows-msvc" }
+        "ARM64" {
+            Write-Log "No native ARM64 build published; using the x64 build under emulation."
+            return "x86_64-pc-windows-msvc"
+        }
+        default { Write-ErrExit "Unsupported architecture: $arch" }
+    }
+}
+
+function Get-LatestVersion {
+    $uri = "https://api.github.com/repos/$Repo/releases/latest"
+    try {
+        $release = Invoke-RestMethod -Uri $uri -Headers @{ "User-Agent" = "uvr-install" }
+    } catch {
+        Write-ErrExit "Failed to determine latest version: $_"
+    }
+    if (-not $release.tag_name) {
+        Write-ErrExit "Failed to determine latest version"
+    }
+    return $release.tag_name
+}
+
+function Get-ExpectedHash {
+    param([string]$BaseUrl, [string]$Asset, [string]$TmpDir)
+    $sumsPath = Join-Path $TmpDir "sha256sums.txt"
+    try {
+        Invoke-WebRequest -Uri "$BaseUrl/sha256sums.txt" -OutFile $sumsPath -UseBasicParsing
+    } catch {
+        Write-Log "Warning: sha256sums.txt not found, skipping checksum verification"
+        return $null
+    }
+    $line = Select-String -Path $sumsPath -Pattern ([Regex]::Escape($Asset)) | Select-Object -First 1
+    if (-not $line) {
+        return $null
+    }
+    return ($line.Line -split "\s+")[0]
+}
+
+function Test-InPath {
+    param([string]$Dir)
+    $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+    $entries = @()
+    if ($userPath) {
+        $entries = $userPath -split ";"
+    }
+    return $entries -contains $Dir
+}
+
+function main {
+    $target = Get-Target
+    Write-Log "Detected platform: $target"
+
+    $version = if ($env:UVR_VERSION) { $env:UVR_VERSION } else { Get-LatestVersion }
+    Write-Log "Installing uvr $version"
+
+    $asset = "uvr-$target.zip"
+    $baseUrl = "https://github.com/$Repo/releases/download/$version"
+    $tmpDir = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
+    New-Item -ItemType Directory -Path $tmpDir | Out-Null
+
+    try {
+        $zipPath = Join-Path $tmpDir $asset
+        Write-Log "Downloading $asset..."
+        try {
+            Invoke-WebRequest -Uri "$baseUrl/$asset" -OutFile $zipPath -UseBasicParsing
+        } catch {
+            Write-ErrExit "Download failed: $_"
+        }
+
+        $expected = Get-ExpectedHash -BaseUrl $baseUrl -Asset $asset -TmpDir $tmpDir
+        if ($expected) {
+            Write-Log "Verifying checksum..."
+            $actual = (Get-FileHash -Path $zipPath -Algorithm SHA256).Hash.ToLower()
+            if ($expected.ToLower() -ne $actual) {
+                Write-ErrExit "Checksum mismatch!`n  Expected: $expected`n  Got: $actual"
+            }
+            Write-Log "Checksum verified"
+        }
+
+        Write-Log "Extracting..."
+        Expand-Archive -Path $zipPath -DestinationPath $tmpDir -Force
+
+        $exePath = Get-ChildItem -Path $tmpDir -Filter "uvr.exe" -Recurse | Select-Object -First 1
+        if (-not $exePath) {
+            Write-ErrExit "uvr.exe not found in downloaded archive"
+        }
+
+        New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
+        Copy-Item -Path $exePath.FullName -Destination (Join-Path $InstallDir "uvr.exe") -Force
+    } finally {
+        Remove-Item -Path $tmpDir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    Write-Log "Installed uvr to $InstallDir\uvr.exe"
+
+    if (-not (Test-InPath $InstallDir)) {
+        $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+        $newPath = if ($userPath) { "$userPath;$InstallDir" } else { $InstallDir }
+        [Environment]::SetEnvironmentVariable("Path", $newPath, "User")
+        $env:Path = "$env:Path;$InstallDir"
+        Write-Log "Added $InstallDir to your user PATH."
+        Write-Log "Open a new terminal for the change to take effect there."
+    } else {
+        $env:Path = "$env:Path;$InstallDir"
+    }
+
+    & (Join-Path $InstallDir "uvr.exe") --version
+}
+
+main

--- a/install.ps1
+++ b/install.ps1
@@ -32,6 +32,7 @@ function Get-Target {
     switch ($arch) {
         "AMD64" { return "x86_64-pc-windows-msvc" }
         "ARM64" {
+            # TODO: switch to a native aarch64-pc-windows-msvc asset once one is published.
             Write-Log "No native ARM64 build published; using the x64 build under emulation."
             return "x86_64-pc-windows-msvc"
         }
@@ -68,14 +69,24 @@ function Get-ExpectedHash {
     return ($line.Line -split "\s+")[0]
 }
 
-function Test-InPath {
+function Add-ToUserPath {
     param([string]$Dir)
-    $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+    $key = "HKCU:\Environment"
+    $raw = (Get-Item $key).GetValue("Path", "", "DoNotExpandEnvironmentNames")
+    $kind = (Get-Item $key).GetValueKind("Path")
     $entries = @()
-    if ($userPath) {
-        $entries = $userPath -split ";"
+    if ($raw) {
+        $entries = $raw -split ";" | Where-Object { $_ }
     }
-    return $entries -contains $Dir
+    $target = $Dir.TrimEnd("\")
+    $alreadyPresent = $entries | Where-Object { $_.TrimEnd("\") -ieq $target }
+    if ($alreadyPresent) {
+        return
+    }
+    $newPath = if ($raw) { "$raw;$Dir" } else { $Dir }
+    Set-ItemProperty -Path $key -Name Path -Value $newPath -Type $kind
+    Write-Log "Added $Dir to your user PATH."
+    Write-Log "Open a new terminal for the change to take effect there."
 }
 
 function main {
@@ -125,16 +136,8 @@ function main {
 
     Write-Log "Installed uvr to $InstallDir\uvr.exe"
 
-    if (-not (Test-InPath $InstallDir)) {
-        $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
-        $newPath = if ($userPath) { "$userPath;$InstallDir" } else { $InstallDir }
-        [Environment]::SetEnvironmentVariable("Path", $newPath, "User")
-        $env:Path = "$env:Path;$InstallDir"
-        Write-Log "Added $InstallDir to your user PATH."
-        Write-Log "Open a new terminal for the change to take effect there."
-    } else {
-        $env:Path = "$env:Path;$InstallDir"
-    }
+    Add-ToUserPath -Dir $InstallDir
+    $env:Path = "$env:Path;$InstallDir"
 
     & (Join-Path $InstallDir "uvr.exe") --version
 }

--- a/install.ps1
+++ b/install.ps1
@@ -64,6 +64,7 @@ function Get-ExpectedHash {
     }
     $line = Select-String -Path $sumsPath -Pattern ([Regex]::Escape($Asset)) | Select-Object -First 1
     if (-not $line) {
+        Write-Log "Warning: no checksum entry for $Asset, skipping checksum verification"
         return $null
     }
     return ($line.Line -split "\s+")[0]


### PR DESCRIPTION
Adding `install.ps1`, containing a script for installing `uvr` for Windows. This mirrors the current `install.sh` on the root `main` tree. 