### PR TITLE
ci: derive the portable-R glibc floor from the host, not from each matrix entry

### DIFF
--- a/ci/distro-suite.sh
+++ b/ci/distro-suite.sh
@@ -225,6 +225,38 @@ UVR="$DIST/uvr-$TARGET/uvr"
 note "install.sh would fetch: uvr-$TARGET.tar.gz"
 [ -x "$UVR" ] || fail "no release build for $TARGET under $DIST"
 
+# Whether the portable R builds can run here at all.
+#
+# Posit publishes them as manylinux_2_34, so a glibc host below 2.34 gets no R
+# — `MANYLINUX_GLIBC_MIN` in r_version/downloader.rs, and a different number
+# from both the 2.28 floor the uvr *binary* is built against (#212) and the
+# 2.28 `PPM_MANYLINUX_GLIBC_MIN` that gates binary *packages*. Three floors,
+# three meanings; only this one decides whether `uvr r install` can work.
+#
+# Derived from the host, deliberately. This used to be an `expect` block on
+# each entry, which meant it was only as complete as whoever remembered to add
+# one — and it was not: rocky-8, almalinux-8, oracle-8 and opensuse-155 are all
+# below the floor, none of them carried the block, and all four failed the
+# first nightly after the pr lane went green (#230). The floor is a property of
+# the host, so the host is what gets asked.
+R_GLIBC_FLOOR=2.34
+# Set by below_r_glibc_floor; reported by the stage below.
+hv=""
+
+below_r_glibc_floor() {
+    # musllinux builds carry no glibc floor; Alpine is judged on its own terms.
+    if [ "$libc" = musl ]; then return 1; fi
+    hv="$(ldd --version 2>&1 | grep -oE '[0-9]+\.[0-9]+' | head -1)"
+    # An unreadable ldd must not silently excuse a distro. Expect success and
+    # let the stage fail loudly if that was wrong.
+    if [ -z "$hv" ]; then return 1; fi
+    hmaj="${hv%%.*}"; hmin="${hv#*.}"; hmin="${hmin%%.*}"
+    fmaj="${R_GLIBC_FLOOR%%.*}"; fmin="${R_GLIBC_FLOOR#*.}"
+    if [ "$hmaj" -lt "$fmaj" ]; then return 0; fi
+    if [ "$hmaj" -eq "$fmaj" ] && [ "$hmin" -lt "$fmin" ]; then return 0; fi
+    return 1
+}
+
 # `--version` on a bare image is the whole glibc-floor question in one line: a
 # gnu binary linked against a newer glibc than this distro ships dies right
 # here, which is what a user hits seconds after running install.sh.
@@ -239,28 +271,28 @@ endgroup
 
 # --------------------------------------------------------------- stage: R ---
 
-if ! skipped r && expect_fail r; then
-    # Distros below the portable builds' glibc floor (#212). The matrix used to
-    # record this in prose, which meant every PR touching these paths carried a
-    # permanently red check that meant nothing — and a red check nobody reads is
-    # how a real failure hides. Assert the refusal instead.
-    group "Install R ($R_LATEST) — expected to fail on this distro"
+if ! skipped r && below_r_glibc_floor; then
+    # This host cannot run the portable R builds. Assert the refusal rather than
+    # skipping the stage: skipping hides the limitation, and a permanently red
+    # job nobody reads is how a real failure hides. Asserting keeps it visible
+    # *and* checked, in both directions.
+    group "Install R ($R_LATEST) — glibc $hv is below the $R_GLIBC_FLOOR floor"
     if out="$("$UVR" r install "$R_LATEST" 2>&1)"; then
         printf '%s\n' "$out"
-        fail "uvr installed R here, but the matrix records this distro as unsupported.
-       If the floor moved or portable builds gained coverage, drop the
-       'expect' block from this entry in distro_matrix.json."
+        fail "uvr installed R on glibc $hv, below the $R_GLIBC_FLOOR floor the
+       portable builds need. If Posit started publishing lower, update
+       R_GLIBC_FLOOR here and MANYLINUX_GLIBC_MIN in downloader.rs together."
     fi
     printf '%s\n' "$out"
-    printf '%s\n' "$out" | grep -qF "$EXPECT_FAIL_MESSAGE" || fail \
+    printf '%s\n' "$out" | grep -qF "too old for portable R builds" || fail \
         "uvr refused to install R, but not for the documented reason.
-       wanted: $EXPECT_FAIL_MESSAGE
-       This is the #212 message regressing into something a user cannot act on."
+       On a host below the floor it must say so in terms a user can act on;
+       this is #212's message regressing into a bare linker error."
     endgroup
-    note "expected failure confirmed: $EXPECT_FAIL_MESSAGE"
+    note "expected failure confirmed: glibc $hv < $R_GLIBC_FLOOR"
     # Every stage below needs a working R, so there is nothing further to ask
     # this distro. Stopping here is the answer, not a truncation.
-    note "distro suite complete (no R on this platform, as recorded)"
+    note "distro suite complete (no portable R below glibc $R_GLIBC_FLOOR)"
     exit 0
 elif ! skipped r; then
     group "Install R ($R_VERSIONS)"

--- a/crates/uvr-core/tests/distro_matrix.json
+++ b/crates/uvr-core/tests/distro_matrix.json
@@ -36,11 +36,7 @@
         "api": true,
         "local": true
       },
-      "note": "#212 is what lets the CLI start here at all, so the failure is now a clear message instead of a linker error. The portable R builds need glibc 2.34; this distro is below that floor, so the `expect` block above asserts uvr refuses with the #212 message rather than leaving the job permanently red.",
-      "expect": {
-        "stage": "r",
-        "message": "is too old for portable R builds"
-      }
+      "note": "#212 is what lets the CLI start here at all, so the failure is now a clear message instead of a linker error. Below the portable R builds' glibc 2.34 floor, which ci/distro-suite.sh derives from the host rather than from this entry."
     },
     {
       "key": "ubuntu-2204",
@@ -98,11 +94,7 @@
         "api": true,
         "local": true
       },
-      "note": "#212 is what lets the CLI start here at all, so the failure is now a clear message instead of a linker error. The portable R builds need glibc 2.34; this distro is below that floor, so the `expect` block above asserts uvr refuses with the #212 message rather than leaving the job permanently red.",
-      "expect": {
-        "stage": "r",
-        "message": "is too old for portable R builds"
-      }
+      "note": "#212 is what lets the CLI start here at all, so the failure is now a clear message instead of a linker error. Below the portable R builds' glibc 2.34 floor, which ci/distro-suite.sh derives from the host rather than from this entry."
     },
     {
       "key": "debian-12",
@@ -146,7 +138,7 @@
       "key": "rhel-8",
       "image": "registry.access.redhat.com/ubi8:latest",
       "lane": "pr",
-      "note": "The #209 image. UBI is the only RHEL testable without a subscription; it reports the same ID/VERSION_ID as subscribed RHEL, which is the axis under test. #212 is what lets the CLI start here at all, so the failure is now a clear message instead of a linker error. The portable R builds need glibc 2.34; this distro is below that floor, so the `expect` block above asserts uvr refuses with the #212 message rather than leaving the job permanently red.",
+      "note": "The #209 image. UBI is the only RHEL testable without a subscription; it reports the same ID/VERSION_ID as subscribed RHEL, which is the axis under test. #212 is what lets the CLI start here at all, so the failure is now a clear message instead of a linker error. Below the portable R builds' glibc 2.34 floor, which ci/distro-suite.sh derives from the host rather than from this entry.",
       "os_release": {
         "id": "rhel",
         "version_id": "8.10"
@@ -160,10 +152,6 @@
         "release": "8",
         "api": true,
         "local": true
-      },
-      "expect": {
-        "stage": "r",
-        "message": "is too old for portable R builds"
       }
     },
     {

--- a/docs/design/2026-07-31-distro-conformance-ci-design.md
+++ b/docs/design/2026-07-31-distro-conformance-ci-design.md
@@ -178,21 +178,41 @@ Stages, in order:
 3. **r** — install R and list it. Exercises the portable-build download, extract and
    `R --version` validation on this distro's libc.
 
-   Three entries — `rhel-8`, `ubuntu-2004`, `debian-11` — sit below the portable
-   builds' glibc 2.34 floor and *cannot* pass this stage. They carry an `expect`
-   block naming the stage and the substring uvr must print:
+   Seven entries sit below the portable builds' glibc 2.34 floor and *cannot* pass
+   this stage — `rhel-8`, `rocky-8`, `almalinux-8`, `oracle-8` (all 2.28),
+   `ubuntu-2004`, `debian-11`, `opensuse-155` (all 2.31). The floor lands exactly
+   on the RHEL 8 → 9 line: every `*-9` entry reports precisely 2.34.
 
-   ```json
-   "expect": { "stage": "r", "message": "is too old for portable R builds" }
-   ```
+   The suite **derives** that from the host, comparing `ldd --version` against
+   `R_GLIBC_FLOOR` (which mirrors `MANYLINUX_GLIBC_MIN` in `downloader.rs`), and
+   asserts the refusal instead of dying on it, then stops — nothing downstream can
+   run without R.
 
-   The stage then asserts the refusal instead of dying on it, and stops — nothing
-   downstream can run without R. Asserting rather than skipping is the point: a
-   skipped stage hides the limitation, and a permanently-red job nobody reads is how
-   a real failure hides. This way the lane is green, the limitation stays visible,
-   and it turns red in *both* directions — if uvr stops refusing (the floor moved,
-   update the matrix) or refuses for some other reason (#212's message regressed
-   into something a user can't act on).
+   It is derived rather than recorded per entry because recording it per entry is
+   what broke: the first version carried an `expect` block on each affected entry,
+   converted from a hand-written `note`, and only three entries had ever had the
+   note. The other four went straight through and failed the first nightly after
+   the pr lane went green (#230). A per-entry expectation is only as complete as
+   whoever remembered to write it; the floor is a property of the host, so the host
+   is what gets asked.
+
+   Asserting rather than skipping is the other half: a skipped stage hides the
+   limitation, and a permanently-red job nobody reads is how a real failure hides.
+   This way the lane is green, the limitation stays visible, and it turns red in
+   *both* directions — if uvr installs R below the floor (Posit started publishing
+   lower; update `R_GLIBC_FLOOR` and `MANYLINUX_GLIBC_MIN` together) or refuses for
+   some other reason (#212's message regressed into something a user can't act on).
+
+   Note that this is a **third** glibc number, and the three are independent:
+
+   | number | what it gates | set in |
+   |---|---|---|
+   | 2.34 | can the portable R builds run at all | `MANYLINUX_GLIBC_MIN`, downloader.rs |
+   | 2.28 | can uvr get P3M *binary packages* from the portable repo | `PPM_MANYLINUX_GLIBC_MIN`, downloader.rs |
+   | 2.28 | can the uvr binary itself start | `GLIBC_FLOOR`, ci/build-linux-gnu.sh (#212) |
+
+   #212 is why `uvr --version` and `uvr doctor` run on RHEL 8 at all; it does not
+   and cannot move the first row, which is Posit's build, not uvr's.
 4. **binary** — install and `library()` `BINARY_PKG`. #175: a binary from the
    wrong distro's repo installs happily and only fails at load, so the assertion has
    to load it. With no compiler present, an install that quietly falls back to a


### PR DESCRIPTION
**Stack position: merge first.** Fixes 4 of the 5 failures in #230; the alpine-320 half is a separate PR that builds on this one.

Closes 4/5 of #230.

## What broke

The first nightly after #211's pr lane went green failed on `rocky-8`, `almalinux-8`, `oracle-8` and `opensuse-155` — all at `uvr r install`, all with the same message:

```
x ERROR  R installation failed
  Unsupported platform: glibc 2.28 is too old for portable R builds (need >= 2.34).
```

That is uvr behaving correctly. The suite was wrong.

## Why

#211 turned "expected to fail at `uvr r install`" from prose in each entry's `note` into an asserted `expect` block. It did that by **matching the prose** — and the prose had only ever been written for three entries. Every sub-floor distro whose note nobody had gotten around to writing sailed through unchanged.

I captured `ldd --version` from all 29 images rather than reasoning about it. Seven entries are below the floor; three had the block:

| entry | glibc | had `expect` |
|---|---|---|
| rhel-8 | 2.28 | yes |
| ubuntu-2004 | 2.31 | yes |
| debian-11 | 2.31 | yes |
| **rocky-8** | 2.28 | **no** |
| **almalinux-8** | 2.28 | **no** |
| **oracle-8** | 2.28 | **no** |
| **opensuse-155** | 2.31 | **no** |

`rhel-8` was the *only* sub-floor entry in the `pr` lane, which is exactly why the pr lane looked complete and the nightly did not.

## The fix

Stop recording it per entry. The floor is a property of the host, so ask the host — compare `ldd --version` against `R_GLIBC_FLOOR`, which mirrors `MANYLINUX_GLIBC_MIN` in `downloader.rs`. The three hand-written `expect` blocks are removed.

A per-entry expectation is only ever as complete as whoever remembered to write it. Deriving it means a distro added later is covered without anyone realising they had to do anything — and it gains an assertion the per-entry version could not express: uvr installing R **below** the floor now fails too.

The floor lands exactly on the RHEL 8 → 9 line. Every `*-9` entry reports precisely `2.34`, so `>= floor` is load-bearing rather than decorative, and the comparison is unit-tested across `2.28 … 3.0` including that boundary.

## Verified

Every reachable sub-floor image, plus the boundary, with a binary built by `ci/build-linux-gnu.sh`:

```
rocky-8       exit=0  expected failure confirmed: glibc 2.28 < 2.34
almalinux-8   exit=0  expected failure confirmed: glibc 2.28 < 2.34
oracle-8      exit=0  expected failure confirmed: glibc 2.28 < 2.34
opensuse-155  exit=0  expected failure confirmed: glibc 2.31 < 2.34
ubuntu-2004   exit=0  expected failure confirmed: glibc 2.31 < 2.34
debian-11     exit=0  expected failure confirmed: glibc 2.31 < 2.34
rocky-9       exit=0  binary-smoke-ok  sysreqs-smoke-ok   <- exactly 2.34, normal path
ubuntu-2204   exit=0  binary-smoke-ok  sysreqs-smoke-ok
```

## One thing worth naming

This is the **third** glibc number in the tree, and they are independent — it has now confused more than one reader:

| number | gates | set in |
|---|---|---|
| 2.34 | whether the portable R builds run at all | `MANYLINUX_GLIBC_MIN`, downloader.rs |
| 2.28 | whether P3M binary *packages* come from the portable repo | `PPM_MANYLINUX_GLIBC_MIN`, downloader.rs |
| 2.28 | whether the uvr binary itself starts | `GLIBC_FLOOR`, ci/build-linux-gnu.sh (#212) |

#212 is why `uvr --version` and `uvr doctor` run on RHEL 8 at all — visible in the failing logs, where the binary starts fine and only `r install` refuses. It cannot move the first row: that is Posit's build, not uvr's.

## Note on `expect`

The mechanism is left in place but has no user after this change. Its next one is the alpine-320 PR, where the condition is genuinely per-entry rather than a host property. If that PR is rejected, `expect` should be deleted rather than kept on spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B2dAmERdjdAJr7xotiKQPB