### PR TITLE
ci: record Alpine 3.20's inability to compile R packages

### DIFF
--- a/ci/distro-suite.sh
+++ b/ci/distro-suite.sh
@@ -356,7 +356,26 @@ if ! skipped sysreqs; then
     "$UVR" init --here sysreqs-smoke --r-version "$R_LATEST"
     printf 'library(%s); cat("sysreqs-smoke-ok\\n")\n' "$SYSREQS_PKG" > check.R
 
-    if sysreqs_autoinstall_supported; then
+    if expect_fail sysreqs; then
+        # This host has a working toolchain that still cannot build R packages,
+        # because R's own Makeconf asks for a C standard its compiler predates.
+        # Asserting it keeps the limitation visible and checked; the sysreqs
+        # half is still verified by the common check below, which is the point
+        # — uvr resolves and installs the system dependency correctly here, and
+        # only the compile step fails.
+        if UVR_INSTALL_SYSREQS=1 "$UVR" add "$SYSREQS_PKG" --no-binary > add.log 2>&1; then
+            cat add.log
+            fail "the source build succeeded, but the matrix records this distro as
+       unable to compile R packages. If the toolchain moved or R's recorded
+       C standard changed, drop the 'expect' block from this entry."
+        fi
+        cat add.log
+        grep -qF "$EXPECT_FAIL_MESSAGE" add.log || fail \
+            "the source build failed, but not for the documented reason.
+       wanted: $EXPECT_FAIL_MESSAGE
+       Something else is broken here, or the known breakage has changed shape."
+        note "expected failure confirmed: $EXPECT_FAIL_MESSAGE"
+    elif sysreqs_autoinstall_supported; then
         UVR_INSTALL_SYSREQS=1 "$UVR" add "$SYSREQS_PKG" --no-binary 2>&1 | tee add.log
         "$UVR" run check.R
     else

--- a/ci/distro-suite.sh
+++ b/ci/distro-suite.sh
@@ -225,6 +225,38 @@ UVR="$DIST/uvr-$TARGET/uvr"
 note "install.sh would fetch: uvr-$TARGET.tar.gz"
 [ -x "$UVR" ] || fail "no release build for $TARGET under $DIST"
 
+# Whether the portable R builds can run here at all.
+#
+# Posit publishes them as manylinux_2_34, so a glibc host below 2.34 gets no R
+# — `MANYLINUX_GLIBC_MIN` in r_version/downloader.rs, and a different number
+# from both the 2.28 floor the uvr *binary* is built against (#212) and the
+# 2.28 `PPM_MANYLINUX_GLIBC_MIN` that gates binary *packages*. Three floors,
+# three meanings; only this one decides whether `uvr r install` can work.
+#
+# Derived from the host, deliberately. This used to be an `expect` block on
+# each entry, which meant it was only as complete as whoever remembered to add
+# one — and it was not: rocky-8, almalinux-8, oracle-8 and opensuse-155 are all
+# below the floor, none of them carried the block, and all four failed the
+# first nightly after the pr lane went green (#230). The floor is a property of
+# the host, so the host is what gets asked.
+R_GLIBC_FLOOR=2.34
+# Set by below_r_glibc_floor; reported by the stage below.
+hv=""
+
+below_r_glibc_floor() {
+    # musllinux builds carry no glibc floor; Alpine is judged on its own terms.
+    if [ "$libc" = musl ]; then return 1; fi
+    hv="$(ldd --version 2>&1 | grep -oE '[0-9]+\.[0-9]+' | head -1)"
+    # An unreadable ldd must not silently excuse a distro. Expect success and
+    # let the stage fail loudly if that was wrong.
+    if [ -z "$hv" ]; then return 1; fi
+    hmaj="${hv%%.*}"; hmin="${hv#*.}"; hmin="${hmin%%.*}"
+    fmaj="${R_GLIBC_FLOOR%%.*}"; fmin="${R_GLIBC_FLOOR#*.}"
+    if [ "$hmaj" -lt "$fmaj" ]; then return 0; fi
+    if [ "$hmaj" -eq "$fmaj" ] && [ "$hmin" -lt "$fmin" ]; then return 0; fi
+    return 1
+}
+
 # `--version` on a bare image is the whole glibc-floor question in one line: a
 # gnu binary linked against a newer glibc than this distro ships dies right
 # here, which is what a user hits seconds after running install.sh.
@@ -239,28 +271,28 @@ endgroup
 
 # --------------------------------------------------------------- stage: R ---
 
-if ! skipped r && expect_fail r; then
-    # Distros below the portable builds' glibc floor (#212). The matrix used to
-    # record this in prose, which meant every PR touching these paths carried a
-    # permanently red check that meant nothing — and a red check nobody reads is
-    # how a real failure hides. Assert the refusal instead.
-    group "Install R ($R_LATEST) — expected to fail on this distro"
+if ! skipped r && below_r_glibc_floor; then
+    # This host cannot run the portable R builds. Assert the refusal rather than
+    # skipping the stage: skipping hides the limitation, and a permanently red
+    # job nobody reads is how a real failure hides. Asserting keeps it visible
+    # *and* checked, in both directions.
+    group "Install R ($R_LATEST) — glibc $hv is below the $R_GLIBC_FLOOR floor"
     if out="$("$UVR" r install "$R_LATEST" 2>&1)"; then
         printf '%s\n' "$out"
-        fail "uvr installed R here, but the matrix records this distro as unsupported.
-       If the floor moved or portable builds gained coverage, drop the
-       'expect' block from this entry in distro_matrix.json."
+        fail "uvr installed R on glibc $hv, below the $R_GLIBC_FLOOR floor the
+       portable builds need. If Posit started publishing lower, update
+       R_GLIBC_FLOOR here and MANYLINUX_GLIBC_MIN in downloader.rs together."
     fi
     printf '%s\n' "$out"
-    printf '%s\n' "$out" | grep -qF "$EXPECT_FAIL_MESSAGE" || fail \
+    printf '%s\n' "$out" | grep -qF "too old for portable R builds" || fail \
         "uvr refused to install R, but not for the documented reason.
-       wanted: $EXPECT_FAIL_MESSAGE
-       This is the #212 message regressing into something a user cannot act on."
+       On a host below the floor it must say so in terms a user can act on;
+       this is #212's message regressing into a bare linker error."
     endgroup
-    note "expected failure confirmed: $EXPECT_FAIL_MESSAGE"
+    note "expected failure confirmed: glibc $hv < $R_GLIBC_FLOOR"
     # Every stage below needs a working R, so there is nothing further to ask
     # this distro. Stopping here is the answer, not a truncation.
-    note "distro suite complete (no R on this platform, as recorded)"
+    note "distro suite complete (no portable R below glibc $R_GLIBC_FLOOR)"
     exit 0
 elif ! skipped r; then
     group "Install R ($R_VERSIONS)"

--- a/crates/uvr-core/tests/distro_matrix.json
+++ b/crates/uvr-core/tests/distro_matrix.json
@@ -523,7 +523,7 @@
         "api": false,
         "local": true
       },
-      "note": "Alpine 3.20 ships gcc 13.2.1, and R 4.5.1's musllinux_1_2 build records `CC = gcc -std=gnu23` in its Makeconf, which needs gcc >= 14. So R installs and runs, and then every source package fails to compile. 3.21 (gcc 14.2) and 3.22 are unaffected, and the manylinux_2_34 build records a bare `CC = gcc`, so this is musl-only and upstream in rstudio/r-builds — not uvr's code, but uvr's users. Tracked in the issue linked from the `expect` block's PR.",
+      "note": "Alpine 3.20 ships gcc 13.2.1, and R 4.5.1's musllinux_1_2 build records `CC = gcc -std=gnu23` in its Makeconf, which needs gcc >= 14. So R installs and runs, and then every source package fails to compile. 3.21 (gcc 14.2) and 3.22 are unaffected, and the manylinux_2_34 build records a bare `CC = gcc`, so this is musl-only and upstream in rstudio/r-builds — not uvr's code, but uvr's users. Tracked in #231.",
       "expect": {
         "stage": "sysreqs",
         "message": "unrecognized command-line option '-std=gnu23'"

--- a/crates/uvr-core/tests/distro_matrix.json
+++ b/crates/uvr-core/tests/distro_matrix.json
@@ -523,7 +523,11 @@
         "api": false,
         "local": true
       },
-      "note": "musl: no P3M repo exists, so the binary stage is skipped and the sysreqs local-rules path (#30) is the coverage. Passed as of #208 — before it, libxml2-dev was never installed and no warning was printed (#207)."
+      "note": "Alpine 3.20 ships gcc 13.2.1, and R 4.5.1's musllinux_1_2 build records `CC = gcc -std=gnu23` in its Makeconf, which needs gcc >= 14. So R installs and runs, and then every source package fails to compile. 3.21 (gcc 14.2) and 3.22 are unaffected, and the manylinux_2_34 build records a bare `CC = gcc`, so this is musl-only and upstream in rstudio/r-builds — not uvr's code, but uvr's users. Tracked in the issue linked from the `expect` block's PR.",
+      "expect": {
+        "stage": "sysreqs",
+        "message": "unrecognized command-line option '-std=gnu23'"
+      }
     },
     {
       "key": "alpine-321",

--- a/crates/uvr-core/tests/distro_matrix.json
+++ b/crates/uvr-core/tests/distro_matrix.json
@@ -36,11 +36,7 @@
         "api": true,
         "local": true
       },
-      "note": "#212 is what lets the CLI start here at all, so the failure is now a clear message instead of a linker error. The portable R builds need glibc 2.34; this distro is below that floor, so the `expect` block above asserts uvr refuses with the #212 message rather than leaving the job permanently red.",
-      "expect": {
-        "stage": "r",
-        "message": "is too old for portable R builds"
-      }
+      "note": "#212 is what lets the CLI start here at all, so the failure is now a clear message instead of a linker error. Below the portable R builds' glibc 2.34 floor, which ci/distro-suite.sh derives from the host rather than from this entry."
     },
     {
       "key": "ubuntu-2204",
@@ -98,11 +94,7 @@
         "api": true,
         "local": true
       },
-      "note": "#212 is what lets the CLI start here at all, so the failure is now a clear message instead of a linker error. The portable R builds need glibc 2.34; this distro is below that floor, so the `expect` block above asserts uvr refuses with the #212 message rather than leaving the job permanently red.",
-      "expect": {
-        "stage": "r",
-        "message": "is too old for portable R builds"
-      }
+      "note": "#212 is what lets the CLI start here at all, so the failure is now a clear message instead of a linker error. Below the portable R builds' glibc 2.34 floor, which ci/distro-suite.sh derives from the host rather than from this entry."
     },
     {
       "key": "debian-12",
@@ -146,7 +138,7 @@
       "key": "rhel-8",
       "image": "registry.access.redhat.com/ubi8:latest",
       "lane": "pr",
-      "note": "The #209 image. UBI is the only RHEL testable without a subscription; it reports the same ID/VERSION_ID as subscribed RHEL, which is the axis under test. #212 is what lets the CLI start here at all, so the failure is now a clear message instead of a linker error. The portable R builds need glibc 2.34; this distro is below that floor, so the `expect` block above asserts uvr refuses with the #212 message rather than leaving the job permanently red.",
+      "note": "The #209 image. UBI is the only RHEL testable without a subscription; it reports the same ID/VERSION_ID as subscribed RHEL, which is the axis under test. #212 is what lets the CLI start here at all, so the failure is now a clear message instead of a linker error. Below the portable R builds' glibc 2.34 floor, which ci/distro-suite.sh derives from the host rather than from this entry.",
       "os_release": {
         "id": "rhel",
         "version_id": "8.10"
@@ -160,10 +152,6 @@
         "release": "8",
         "api": true,
         "local": true
-      },
-      "expect": {
-        "stage": "r",
-        "message": "is too old for portable R builds"
       }
     },
     {

--- a/docs/design/2026-07-31-distro-conformance-ci-design.md
+++ b/docs/design/2026-07-31-distro-conformance-ci-design.md
@@ -178,21 +178,41 @@ Stages, in order:
 3. **r** — install R and list it. Exercises the portable-build download, extract and
    `R --version` validation on this distro's libc.
 
-   Three entries — `rhel-8`, `ubuntu-2004`, `debian-11` — sit below the portable
-   builds' glibc 2.34 floor and *cannot* pass this stage. They carry an `expect`
-   block naming the stage and the substring uvr must print:
+   Seven entries sit below the portable builds' glibc 2.34 floor and *cannot* pass
+   this stage — `rhel-8`, `rocky-8`, `almalinux-8`, `oracle-8` (all 2.28),
+   `ubuntu-2004`, `debian-11`, `opensuse-155` (all 2.31). The floor lands exactly
+   on the RHEL 8 → 9 line: every `*-9` entry reports precisely 2.34.
 
-   ```json
-   "expect": { "stage": "r", "message": "is too old for portable R builds" }
-   ```
+   The suite **derives** that from the host, comparing `ldd --version` against
+   `R_GLIBC_FLOOR` (which mirrors `MANYLINUX_GLIBC_MIN` in `downloader.rs`), and
+   asserts the refusal instead of dying on it, then stops — nothing downstream can
+   run without R.
 
-   The stage then asserts the refusal instead of dying on it, and stops — nothing
-   downstream can run without R. Asserting rather than skipping is the point: a
-   skipped stage hides the limitation, and a permanently-red job nobody reads is how
-   a real failure hides. This way the lane is green, the limitation stays visible,
-   and it turns red in *both* directions — if uvr stops refusing (the floor moved,
-   update the matrix) or refuses for some other reason (#212's message regressed
-   into something a user can't act on).
+   It is derived rather than recorded per entry because recording it per entry is
+   what broke: the first version carried an `expect` block on each affected entry,
+   converted from a hand-written `note`, and only three entries had ever had the
+   note. The other four went straight through and failed the first nightly after
+   the pr lane went green (#230). A per-entry expectation is only as complete as
+   whoever remembered to write it; the floor is a property of the host, so the host
+   is what gets asked.
+
+   Asserting rather than skipping is the other half: a skipped stage hides the
+   limitation, and a permanently-red job nobody reads is how a real failure hides.
+   This way the lane is green, the limitation stays visible, and it turns red in
+   *both* directions — if uvr installs R below the floor (Posit started publishing
+   lower; update `R_GLIBC_FLOOR` and `MANYLINUX_GLIBC_MIN` together) or refuses for
+   some other reason (#212's message regressed into something a user can't act on).
+
+   Note that this is a **third** glibc number, and the three are independent:
+
+   | number | what it gates | set in |
+   |---|---|---|
+   | 2.34 | can the portable R builds run at all | `MANYLINUX_GLIBC_MIN`, downloader.rs |
+   | 2.28 | can uvr get P3M *binary packages* from the portable repo | `PPM_MANYLINUX_GLIBC_MIN`, downloader.rs |
+   | 2.28 | can the uvr binary itself start | `GLIBC_FLOOR`, ci/build-linux-gnu.sh (#212) |
+
+   #212 is why `uvr --version` and `uvr doctor` run on RHEL 8 at all; it does not
+   and cannot move the first row, which is Posit's build, not uvr's.
 4. **binary** — install and `library()` `BINARY_PKG`. #175: a binary from the
    wrong distro's repo installs happily and only fails at load, so the assertion has
    to load it. With no compiler present, an install that quietly falls back to a

--- a/docs/design/2026-07-31-distro-conformance-ci-design.md
+++ b/docs/design/2026-07-31-distro-conformance-ci-design.md
@@ -333,6 +333,7 @@ Bugs this design surfaced before any of it ran in CI, and where each landed:
 | `curl` is a package *conflict* on RHEL images shipping `curl-minimal` | requested by command, not package |
 | uvr tells a zypper host to run `apt-get install -y libxml2-devel` — the same unconditional final branch as the row above, but reaching the user as an instruction that cannot work; `uvr doctor` hardcodes it too | #226 |
 | `uvr add` **fails outright** when P3M serves source where the index promised a binary: the Linux `PACKAGES` index lists every package regardless of build coverage, so uvr announces "3 binary" and then rejects the download | #225 |
+| Alpine 3.20 installs R and then cannot compile a single package: R 4.5.1's musllinux build records `CC = gcc -std=gnu23`, which needs gcc >= 14, while the manylinux build records a bare `CC = gcc` | #231 |
 
 The first four are why this document's own matrix data had to be rewritten before
 merge: a matrix that describes gaps as open after they are closed is worse than no


### PR DESCRIPTION
**Stack position: merge second, after #232.** Built on that branch — until it lands, GitHub shows its commit in this diff. Closes the remaining failure in #230.

Unlike the other four failures in #230, this one is not CI bookkeeping. It is a real limitation users hit, and uvr currently gives them nothing to go on.

## What a user sees

`uvr r install 4.5.1` succeeds. R runs. Then anything with compiled code fails:

```
x ERROR  Failed to install packages after add
  Failed to install rlang
  R CMD INSTALL failed for 'rlang' (exit 1):
  gcc: error: unrecognized command-line option '-std=gnu23'; did you mean '-std=gnu2x'?
  using C compiler: 'gcc (Alpine 13.2.1_git20240309) 13.2.1 20240309'
```

The step that caused it succeeded several minutes earlier, and nothing in the message names the actual problem.

## Cause

R's `etc/Makeconf` records the compiler invocation its build host used. The two portable builds disagree — read straight off the CDN rather than inferred:

```
musllinux_1_2   CC = gcc -std=gnu23
manylinux_2_34  CC = gcc
```

`-std=gnu23` arrived in gcc 14. So the **musl** build requires gcc >= 14 on the user's machine and the glibc build requires nothing at all. That asymmetry is why only one lane went red:

| image | gcc | source builds |
|---|---|---|
| alpine:3.20 | 13.2.1 | **broken** |
| alpine:3.21 | 14.2.0 | fine |
| alpine:3.22 | 14.x | fine |

Any musl host with gcc < 14 is affected. Root cause is upstream in rstudio/r-builds — a portable build should not pin a C standard newer than its oldest supported target — so this PR records it and **#231** tracks it, including what uvr could do to stop being silent about it (`uvr doctor` can probe the installed R's `Makeconf` flags against the host compiler directly).

## The change

`expect` now understands the `sysreqs` stage as well as `r`, and alpine-320 carries:

```json
"expect": {
  "stage": "sysreqs",
  "message": "unrecognized command-line option '-std=gnu23'"
}
```

**Deliberately per-entry, not derived** — the opposite call from #232, and for a reason. The glibc floor is a host property that should self-maintain silently. This one *should* fail loudly the moment it stops being true, so that upstream fixing the Makeconf tells someone #231 can be closed, instead of the matrix quietly self-correcting and the issue rotting open.

## The coverage is not traded away

This entry exists for #30/#207 — Alpine sysreqs resolution — and that assertion still runs. The stage still reaches the common "did uvr skip the sysreqs check" check, and uvr still does the right thing right up to the compiler:

```
xml2 needs: libxml2-dev
> Running: apk add libxml2-dev
v System dependencies installed.
```

Only the compile step fails. That is the distinction worth keeping visible: uvr's sysreqs half works on Alpine 3.20; the toolchain is what does not.

## Verified

```
alpine-320  exit=0  expected failure confirmed: unrecognized command-line option '-std=gnu23'
alpine-321  exit=0  sysreqs-smoke-ok           <- unaffected, no expect block
ubuntu-2204 exit=0  binary-smoke-ok  sysreqs-smoke-ok
```

shellcheck clean, `sh -n` and `bash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B2dAmERdjdAJr7xotiKQPB