### PR TITLE
feat: run a script standalone from its inline dependency header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,12 @@ Pure tracking section — fixes and small features land here between tags.
   analog of Python's PEP 723, and the first slice of it: plain package names
   only. Version constraints, Bioconductor and git sources (#182), an `r`
   version pin (#183), and `uvr add --script` (#184) follow — a header using
-  any of them is rejected or reported rather than quietly misread.
+  any of them is rejected or reported rather than quietly misread. A file
+  may declare only one header block: a second one is a hard error, as in
+  PEP 723, never a silent no-op. And because a headered script is by design
+  a file you accept from someone else, header text is control-escaped
+  before it appears in uvr's own warnings and errors, so a crafted header
+  cannot smuggle ANSI sequences that repaint or forge diagnostics.
 
   Standalone means standalone: a headered script ignores the surrounding
   project's library, its R constraint, any `.r-version` pin walked up from

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ release page on GitHub. Issue numbers reference https://github.com/nbafrank/uvr/
 
 Pure tracking section — fixes and small features land here between tags.
 
+- **A script can carry its own dependencies and run anywhere** (#181). An
+  `.R` file that opens with a `# /// script` … `# ///` comment block listing
+  package names now runs standalone — `uvr run analysis.R` in any directory,
+  with no project, no `uvr.toml` and no setup. The packages are provisioned
+  into an isolated ephemeral environment, cached and reused across runs of
+  the same header, so sending someone the file is enough. This is the R
+  analog of Python's PEP 723, and the first slice of it: plain package names
+  only. Version constraints, Bioconductor and git sources (#182), an `r`
+  version pin (#183), and `uvr add --script` (#184) follow — a header using
+  any of them is rejected or reported rather than quietly misread.
+
+  Standalone means standalone: a headered script ignores the surrounding
+  project's library, its R constraint, any `.r-version` pin walked up from
+  the working directory, and the startup profile that would otherwise put
+  the project library back on the search path. Without all four the same
+  file would resolve differently depending on which directory it was run
+  from, which is the one thing it exists to avoid. Scripts with no header
+  are untouched.
+
 ## v0.4.5 (2026-08-03)
 
 The community release. Four contributors filed thirteen pull requests in

--- a/crates/uvr-core/src/error.rs
+++ b/crates/uvr-core/src/error.rs
@@ -11,6 +11,13 @@ pub enum UvrError {
     #[error("Lockfile parse error: {0}")]
     LockfileParse(String),
 
+    /// A script's inline dependency header could not be read.
+    ///
+    /// Rendered bare because the caller knows the file and prefixes it —
+    /// "Invalid script header in <file>: <this>".
+    #[error("{0}")]
+    ScriptHeaderParse(String),
+
     #[error("Package not found: {0}. If this package was recently archived from CRAN, try installing from the CRAN GitHub mirror: uvr add cran/{0}@master")]
     PackageNotFound(String),
 

--- a/crates/uvr-core/src/lib.rs
+++ b/crates/uvr-core/src/lib.rs
@@ -11,6 +11,7 @@ pub mod r_env;
 pub mod r_version;
 pub mod registry;
 pub mod resolver;
+pub mod script_header;
 pub mod signal;
 pub mod sysreqs;
 pub mod sysreqs_rules;

--- a/crates/uvr-core/src/r_version/detector.rs
+++ b/crates/uvr-core/src/r_version/detector.rs
@@ -120,6 +120,23 @@ pub fn find_all() -> Vec<RInstallation> {
 /// 2. `version_constraint` from `uvr.toml` (semver requirement)
 /// 3. Any managed installation, then system R
 pub fn find_r_binary(version_constraint: Option<&str>) -> Result<PathBuf> {
+    resolve_r_binary(version_constraint, true)
+}
+
+/// Like [`find_r_binary`], but ignores any `.r-version` pin.
+///
+/// For standalone script runs (#181). A script carrying its own dependency
+/// header has to resolve the same way in every directory — that is the whole
+/// promise of it. The pin is walked up from the working directory, so
+/// honouring it would let whatever project the file happens to be sitting in
+/// choose the interpreter, and with it the ephemeral environment's cache key:
+/// the same script would get a different R, and a different set of installed
+/// packages, purely because of where it was run from.
+pub fn find_r_binary_ignoring_pin(version_constraint: Option<&str>) -> Result<PathBuf> {
+    resolve_r_binary(version_constraint, false)
+}
+
+fn resolve_r_binary(version_constraint: Option<&str>, honor_pin: bool) -> Result<PathBuf> {
     let installations = find_all();
 
     if installations.is_empty() {
@@ -127,8 +144,10 @@ pub fn find_r_binary(version_constraint: Option<&str>) -> Result<PathBuf> {
     }
 
     // 1. Honour .r-version exact pin
-    let cwd = std::env::current_dir().unwrap_or_default();
-    if let Some(pinned) = read_r_version_pin_from(&cwd) {
+    let pin = honor_pin
+        .then(|| read_r_version_pin_from(&std::env::current_dir().unwrap_or_default()))
+        .flatten();
+    if let Some(pinned) = pin {
         let bin = find_exact_version(&installations, &pinned)?;
         // Validate the pinned install — a broken managed R (one whose binary
         // doesn't respond to a version query, e.g. a corrupted or partially

--- a/crates/uvr-core/src/script_header.rs
+++ b/crates/uvr-core/src/script_header.rs
@@ -1,0 +1,330 @@
+//! Inline dependency headers — a script that carries its own environment.
+//!
+//! An `.R` file can declare the packages it needs in a fenced comment block
+//! near the top, so `uvr run script.R` provisions them and runs the file in
+//! **any** directory, with no project and no setup. Send someone the script
+//! and it runs.
+//!
+//! ```r
+//! # /// script
+//! # dependencies = [
+//! #   "ggplot2",
+//! #   "dplyr",
+//! # ]
+//! # ///
+//!
+//! library(ggplot2)
+//! ```
+//!
+//! The shape mirrors Python's PEP 723, which solved the same problem: an
+//! opening `# /// script` line, `#`-prefixed TOML, and a closing `# ///`.
+//! R has no published standard here, so uvr defines the format rather than
+//! inventing a second one later.
+//!
+//! Both fence lines must sit at column 0 with no leading whitespace — the
+//! same rule PEP 723 sets. An indented `# /// script` is *not* a header, so
+//! that a line inside a string or a nested comment cannot open a block.
+//!
+//! This is the first slice (#181): plain package names only. Version
+//! constraints, Bioconductor and git sources arrive with #182, and the `r`
+//! version pin with #183 — both are rejected or warned about here rather
+//! than accepted and quietly misread.
+
+use serde::Deserialize;
+
+use crate::error::{Result, UvrError};
+
+/// Opens the block. Matched exactly, ignoring only trailing whitespace.
+const FENCE_OPEN: &str = "# /// script";
+/// Closes the block.
+const FENCE_CLOSE: &str = "# ///";
+
+/// The declarations parsed out of a script's inline header.
+///
+/// Unknown keys are ignored rather than rejected, so a script written for a
+/// newer uvr still runs on an older one instead of failing on a key it hasn't
+/// learned yet.
+#[derive(Debug, Clone, PartialEq, Default, Deserialize)]
+pub struct ScriptHeader {
+    /// Package names, in the order written.
+    #[serde(default)]
+    pub dependencies: Vec<String>,
+
+    /// R version constraint. Parsed but not yet acted on — see [`parse`].
+    #[serde(default)]
+    pub r: Option<String>,
+}
+
+/// True for a bare R package name — a letter, then letters, digits and dots.
+///
+/// The rule *Writing R Extensions* sets, and the whole grammar this slice
+/// accepts. Anything else (`ggplot2>=3.4`, `DESeq2 (bioc)`, `user/repo@ref`)
+/// is a spec kind #182 introduces; accepting one now would send it to the
+/// resolver as a literal package name and produce a baffling
+/// "Package not found: ggplot2>=3.4" instead of naming the real problem.
+fn is_plain_package_name(spec: &str) -> bool {
+    let mut chars = spec.chars();
+    chars.next().is_some_and(|c| c.is_ascii_alphabetic())
+        && chars.all(|c| c.is_ascii_alphanumeric() || c == '.')
+        && !spec.ends_with('.')
+}
+
+/// Parse a script's inline dependency header.
+///
+/// Returns `Ok(None)` when the file has no header at all — the overwhelming
+/// majority of scripts, which must keep running exactly as they do today.
+/// A header that is present but broken is an error, never a silent `None`:
+/// a typo in the fence would otherwise drop every declared dependency and
+/// fail later as a confusing missing-package error.
+///
+/// `r` is parsed but not applied — R-version pinning lands in #183. Callers
+/// should tell the user it was ignored rather than silently running against
+/// whichever R they happen to have.
+pub fn parse(source: &str) -> Result<Option<ScriptHeader>> {
+    let mut lines = source.lines();
+
+    // Scan for the opening fence. Anything before it is ordinary script
+    // content — a shebang, a licence banner, a roxygen block.
+    if !lines.any(|line| line.trim_end() == FENCE_OPEN) {
+        return Ok(None);
+    }
+
+    let mut body = String::new();
+    for line in lines {
+        // Checked before the comment strip below, which would otherwise
+        // consume the closing fence as a body line reading `//`.
+        if line.trim_end() == FENCE_CLOSE {
+            let header: ScriptHeader =
+                toml::from_str(&body).map_err(|e| UvrError::ScriptHeaderParse(e.to_string()))?;
+
+            if let Some(bad) = header
+                .dependencies
+                .iter()
+                .find(|spec| !is_plain_package_name(spec))
+            {
+                return Err(UvrError::ScriptHeaderParse(format!(
+                    "`{bad}` is not a plain package name. Version constraints, \
+                     Bioconductor and git sources in script headers are not \
+                     supported yet (#182)"
+                )));
+            }
+
+            return Ok(Some(header));
+        }
+
+        let content = if line.trim_end() == "#" {
+            ""
+        } else if let Some(rest) = line.strip_prefix("# ") {
+            rest
+        } else {
+            // Not "unterminated" — the block may well be closed further down.
+            // This line simply cannot be part of it, which is almost always a
+            // missing `# ///` above it.
+            return Err(UvrError::ScriptHeaderParse(format!(
+                "`{}` is not a `#` comment, so it cannot be inside the \
+                 `{FENCE_OPEN}` block — is the closing `{FENCE_CLOSE}` missing?",
+                line.trim()
+            )));
+        };
+
+        body.push_str(content);
+        body.push('\n');
+    }
+
+    Err(UvrError::ScriptHeaderParse(format!(
+        "unterminated `{FENCE_OPEN}` block: no closing `{FENCE_CLOSE}` line"
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn deps(source: &str) -> Vec<String> {
+        parse(source)
+            .expect("should parse")
+            .expect("should have a header")
+            .dependencies
+    }
+
+    #[test]
+    fn a_header_yields_its_dependencies_in_order() {
+        let source = "\
+# /// script
+# dependencies = [
+#   \"ggplot2\",
+#   \"dplyr\",
+# ]
+# ///
+
+library(ggplot2)
+";
+        assert_eq!(deps(source), vec!["ggplot2", "dplyr"]);
+    }
+
+    #[test]
+    fn a_single_line_array_works_too() {
+        let source = "# /// script\n# dependencies = [\"jsonlite\"]\n# ///\n";
+        assert_eq!(deps(source), vec!["jsonlite"]);
+    }
+
+    #[test]
+    fn a_file_with_no_header_has_none() {
+        assert_eq!(parse("library(ggplot2)\nprint(1)\n").unwrap(), None);
+    }
+
+    #[test]
+    fn an_empty_file_has_none() {
+        assert_eq!(parse("").unwrap(), None);
+    }
+
+    #[test]
+    fn a_decorative_comment_divider_does_not_open_a_block() {
+        // `# ///` on its own is a plausible section divider in a real script.
+        // Only the full `# /// script` opens a header, so a divider must not
+        // turn the rest of the file into a parse error.
+        let source = "# ///\n# a divider, not a header\nprint(1)\n";
+        assert_eq!(parse(source).unwrap(), None);
+    }
+
+    #[test]
+    fn the_fence_must_sit_at_column_zero() {
+        // Indented, so not a header — matching PEP 723's rule.
+        let source = "  # /// script\n  # dependencies = [\"x\"]\n  # ///\n";
+        assert_eq!(parse(source).unwrap(), None);
+    }
+
+    #[test]
+    fn trailing_whitespace_on_a_fence_is_tolerated() {
+        let source = "# /// script  \n# dependencies = []\n# ///\t\n";
+        assert_eq!(deps(source), Vec::<String>::new());
+    }
+
+    #[test]
+    fn an_empty_dependency_list_is_a_header_not_an_absence() {
+        // Distinct from `Ok(None)`: this script asked for an isolated
+        // environment with nothing in it, and must get one.
+        let source = "# /// script\n# dependencies = []\n# ///\n";
+        assert_eq!(parse(source).unwrap(), Some(ScriptHeader::default()));
+    }
+
+    #[test]
+    fn a_header_with_no_keys_at_all_is_valid() {
+        let source = "# /// script\n# ///\n";
+        assert_eq!(parse(source).unwrap(), Some(ScriptHeader::default()));
+    }
+
+    #[test]
+    fn a_bare_hash_is_a_blank_body_line() {
+        let source = "# /// script\n#\n# dependencies = [\"withr\"]\n#\n# ///\n";
+        assert_eq!(deps(source), vec!["withr"]);
+    }
+
+    #[test]
+    fn an_unterminated_block_is_an_error() {
+        let source = "# /// script\n# dependencies = [\"ggplot2\"]\n";
+        let err = parse(source).unwrap_err().to_string();
+        assert!(err.contains("unterminated"), "got: {err}");
+        assert!(err.contains("no closing"), "got: {err}");
+    }
+
+    #[test]
+    fn script_code_before_the_closing_fence_is_an_error() {
+        // The likeliest real typo: the author forgot the closing line, so
+        // the first line of actual code lands inside the block. The block
+        // *is* closed further down, so the message must point at the stray
+        // line rather than claim the block was never terminated.
+        let source = "# /// script\n# dependencies = [\"ggplot2\"]\nlibrary(ggplot2)\n# ///\n";
+        let err = parse(source).unwrap_err().to_string();
+        assert!(err.contains("library(ggplot2)"), "got: {err}");
+        assert!(err.contains(FENCE_CLOSE), "got: {err}");
+        assert!(!err.contains("unterminated"), "misleading wording: {err}");
+    }
+
+    #[test]
+    fn malformed_toml_in_the_body_is_an_error() {
+        let source = "# /// script\n# dependencies = [\n# ///\n";
+        assert!(parse(source).is_err());
+    }
+
+    #[test]
+    fn a_wrongly_typed_dependencies_key_is_an_error() {
+        let source = "# /// script\n# dependencies = \"ggplot2\"\n# ///\n";
+        assert!(parse(source).is_err());
+    }
+
+    #[test]
+    fn an_unknown_key_is_ignored_for_forward_compatibility() {
+        // A script written against a newer uvr must still run here rather
+        // than failing on a key this version has never heard of.
+        let source = "# /// script\n# future-knob = 7\n# dependencies = [\"cli\"]\n# ///\n";
+        assert_eq!(deps(source), vec!["cli"]);
+    }
+
+    #[test]
+    fn an_r_pin_is_captured_even_though_it_is_not_applied_yet() {
+        // Captured so the caller can say it was ignored (#183). Dropping it
+        // silently would run the script against the wrong R with no signal.
+        let source = "# /// script\n# r = \">=4.3\"\n# dependencies = [\"cli\"]\n# ///\n";
+        let header = parse(source).unwrap().unwrap();
+        assert_eq!(header.r.as_deref(), Some(">=4.3"));
+        assert_eq!(header.dependencies, vec!["cli"]);
+    }
+
+    #[test]
+    fn dotted_package_names_are_plain_names() {
+        // `data.table`, `org.Hs.eg.db` — dots are legal in R package names,
+        // so the plain-name check must not mistake them for a spec grammar.
+        let source = "# /// script\n# dependencies = [\"data.table\", \"org.Hs.eg.db\"]\n# ///\n";
+        assert_eq!(deps(source), vec!["data.table", "org.Hs.eg.db"]);
+    }
+
+    #[test]
+    fn specs_this_slice_cannot_honour_are_rejected_by_name() {
+        // Passing these through would reach the resolver as literal package
+        // names and fail with "Package not found: ggplot2>=3.4" — a message
+        // that describes neither the cause nor the fix.
+        for spec in [
+            "ggplot2>=3.4",
+            "DESeq2 (bioc)",
+            "tidyverse/ggplot2@main",
+            "forgejo::codeberg.org/o/r",
+            "",
+        ] {
+            let source = format!("# /// script\n# dependencies = [\"{spec}\"]\n# ///\n");
+            let err = match parse(&source) {
+                Err(e) => e.to_string(),
+                Ok(ok) => panic!("`{spec}` should be rejected, got {ok:?}"),
+            };
+            assert!(err.contains("not a plain package name"), "got: {err}");
+        }
+    }
+
+    #[test]
+    fn the_header_may_follow_a_shebang_or_banner() {
+        let source = "\
+#!/usr/bin/env Rscript
+# Copyright someone
+# /// script
+# dependencies = [\"cli\"]
+# ///
+";
+        assert_eq!(deps(source), vec!["cli"]);
+    }
+
+    #[test]
+    fn only_the_first_block_is_read() {
+        // A second fence pair later in the file is ordinary script content;
+        // the first block wins and its close ends the header.
+        let source = "\
+# /// script
+# dependencies = [\"cli\"]
+# ///
+print(1)
+# /// script
+# dependencies = [\"nope\"]
+# ///
+";
+        assert_eq!(deps(source), vec!["cli"]);
+    }
+}

--- a/crates/uvr-core/src/script_header.rs
+++ b/crates/uvr-core/src/script_header.rs
@@ -92,7 +92,9 @@ pub fn parse(source: &str) -> Result<Option<ScriptHeader>> {
     let mut body = String::new();
     for line in lines {
         // Checked before the comment strip below, which would otherwise
-        // consume the closing fence as a body line reading `//`.
+        // consume the closing fence as a body line: `# ///` less its `# `
+        // prefix is `///`, which TOML would then reject as a syntax error
+        // rather than the block ending cleanly.
         if line.trim_end() == FENCE_CLOSE {
             let header: ScriptHeader =
                 toml::from_str(&body).map_err(|e| UvrError::ScriptHeaderParse(e.to_string()))?;

--- a/crates/uvr-core/src/script_header.rs
+++ b/crates/uvr-core/src/script_header.rs
@@ -25,6 +25,11 @@
 //! same rule PEP 723 sets. An indented `# /// script` is *not* a header, so
 //! that a line inside a string or a nested comment cannot open a block.
 //!
+//! A file may declare at most one header: a second `# /// script` block is
+//! a hard error, as in PEP 723's reference implementation. First-wins would
+//! silently discard the later block — a stale header surviving a bad merge
+//! is exactly how that bites.
+//!
 //! This is the first slice (#181): plain package names only. Version
 //! constraints, Bioconductor and git sources arrive with #182, and the `r`
 //! version pin with #183 — both are rejected or warned about here rather
@@ -69,6 +74,36 @@ fn is_plain_package_name(spec: &str) -> bool {
         && !spec.ends_with('.')
 }
 
+/// Escape control characters so header-derived text is safe to print.
+///
+/// A script is exactly the thing this feature invites users to accept from
+/// strangers, and TOML's `\u001b` escape legally decodes to a live ESC —
+/// enough for a header to repaint or overwrite uvr's own diagnostics once
+/// it is interpolated into a warning or error. Control characters render
+/// as their `\u{…}` escape instead. Newlines are kept: TOML's multi-line
+/// parse errors stay readable, and a bare `\n` cannot forge a styled line.
+pub fn sanitize_for_display(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    for c in text.chars() {
+        if c.is_control() && c != '\n' {
+            out.extend(c.escape_debug());
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
+/// Build a parse error, sanitizing the message.
+///
+/// Every error this module produces quotes text from the script — the
+/// offending spec, the stray line, TOML's own snippet of the source — so
+/// the escaping lives here, at the one place errors are built, rather than
+/// at each interpolation site.
+fn parse_err(message: String) -> UvrError {
+    UvrError::ScriptHeaderParse(sanitize_for_display(&message))
+}
+
 /// Parse a script's inline dependency header.
 ///
 /// Returns `Ok(None)` when the file has no header at all — the overwhelming
@@ -80,6 +115,9 @@ fn is_plain_package_name(spec: &str) -> bool {
 /// `r` is parsed but not applied — R-version pinning lands in #183. Callers
 /// should tell the user it was ignored rather than silently running against
 /// whichever R they happen to have.
+///
+/// A file may declare at most one block: a second `# /// script` fence after
+/// the first block closes is an error, never silently discarded.
 pub fn parse(source: &str) -> Result<Option<ScriptHeader>> {
     let mut lines = source.lines();
 
@@ -90,28 +128,15 @@ pub fn parse(source: &str) -> Result<Option<ScriptHeader>> {
     }
 
     let mut body = String::new();
-    for line in lines {
+    let mut header: Option<ScriptHeader> = None;
+    for line in lines.by_ref() {
         // Checked before the comment strip below, which would otherwise
         // consume the closing fence as a body line: `# ///` less its `# `
         // prefix is `///`, which TOML would then reject as a syntax error
         // rather than the block ending cleanly.
         if line.trim_end() == FENCE_CLOSE {
-            let header: ScriptHeader =
-                toml::from_str(&body).map_err(|e| UvrError::ScriptHeaderParse(e.to_string()))?;
-
-            if let Some(bad) = header
-                .dependencies
-                .iter()
-                .find(|spec| !is_plain_package_name(spec))
-            {
-                return Err(UvrError::ScriptHeaderParse(format!(
-                    "`{bad}` is not a plain package name. Version constraints, \
-                     Bioconductor and git sources in script headers are not \
-                     supported yet (#182)"
-                )));
-            }
-
-            return Ok(Some(header));
+            header = Some(toml::from_str(&body).map_err(|e| parse_err(e.to_string()))?);
+            break;
         }
 
         let content = if line.trim_end() == "#" {
@@ -122,7 +147,7 @@ pub fn parse(source: &str) -> Result<Option<ScriptHeader>> {
             // Not "unterminated" — the block may well be closed further down.
             // This line simply cannot be part of it, which is almost always a
             // missing `# ///` above it.
-            return Err(UvrError::ScriptHeaderParse(format!(
+            return Err(parse_err(format!(
                 "`{}` is not a `#` comment, so it cannot be inside the \
                  `{FENCE_OPEN}` block — is the closing `{FENCE_CLOSE}` missing?",
                 line.trim()
@@ -133,9 +158,35 @@ pub fn parse(source: &str) -> Result<Option<ScriptHeader>> {
         body.push('\n');
     }
 
-    Err(UvrError::ScriptHeaderParse(format!(
-        "unterminated `{FENCE_OPEN}` block: no closing `{FENCE_CLOSE}` line"
-    )))
+    let Some(header) = header else {
+        return Err(parse_err(format!(
+            "unterminated `{FENCE_OPEN}` block: no closing `{FENCE_CLOSE}` line"
+        )));
+    };
+
+    if let Some(bad) = header
+        .dependencies
+        .iter()
+        .find(|spec| !is_plain_package_name(spec))
+    {
+        return Err(parse_err(format!(
+            "`{bad}` is not a plain package name. Version constraints, \
+             Bioconductor and git sources in script headers are not \
+             supported yet (#182)"
+        )));
+    }
+
+    // The rest of the file gets the same scan the opening fence did, so a
+    // second block is refused rather than silently ignored — PEP 723's
+    // reference implementation errors here too.
+    if lines.any(|line| line.trim_end() == FENCE_OPEN) {
+        return Err(parse_err(format!(
+            "multiple `{FENCE_OPEN}` blocks — a script may declare only one \
+             header; remove the extra block"
+        )));
+    }
+
+    Ok(Some(header))
 }
 
 #[cfg(test)]
@@ -315,9 +366,11 @@ library(ggplot2)
     }
 
     #[test]
-    fn only_the_first_block_is_read() {
-        // A second fence pair later in the file is ordinary script content;
-        // the first block wins and its close ends the header.
+    fn a_second_block_is_a_hard_error() {
+        // First-wins would silently discard the later block — a stale header
+        // surviving a bad merge is exactly how that bites, and #181 promises
+        // a broken header is "never silently ignored". PEP 723's reference
+        // implementation errors on multiple blocks; so does this one.
         let source = "\
 # /// script
 # dependencies = [\"cli\"]
@@ -327,6 +380,53 @@ print(1)
 # dependencies = [\"nope\"]
 # ///
 ";
+        let err = parse(source).unwrap_err().to_string();
+        assert!(err.contains("only one"), "got: {err}");
+    }
+
+    #[test]
+    fn later_dividers_and_indented_fences_are_not_a_second_block() {
+        // The duplicate scan applies the same rules as the opening scan: a
+        // bare `# ///` divider and an indented `# /// script` never open a
+        // block, so they must not be refused as one either.
+        let source = "\
+# /// script
+# dependencies = [\"cli\"]
+# ///
+# ///
+  # /// script
+print(1)
+";
         assert_eq!(deps(source), vec!["cli"]);
+    }
+
+    #[test]
+    fn header_text_in_errors_cannot_smuggle_control_characters() {
+        // Every parse error quotes text from the script — a file this
+        // feature invites users to accept from strangers. TOML forbids raw
+        // control bytes inside strings, but `\u001b` is a legal escape
+        // that decodes to a live ESC; printed raw, it could repaint or
+        // overwrite uvr's own diagnostics. It must surface as the escaped
+        // rendering `\u{1b}` instead.
+        for source in [
+            // Decoded by TOML, quoted by the rejected-spec message.
+            "# /// script\n# dependencies = [\"pkg\\u001b[31mFAKE\"]\n# ///\n",
+            // Raw ESC on a stray line, quoted by the stray-line message.
+            "# /// script\n\u{1b}[31mFAKE\n# ///\n",
+        ] {
+            let err = parse(source).unwrap_err().to_string();
+            assert!(!err.contains('\u{1b}'), "raw ESC leaked: {err:?}");
+            assert!(err.contains("\\u{1b}"), "escaped form missing: {err:?}");
+        }
+    }
+
+    #[test]
+    fn toml_error_snippets_cannot_smuggle_control_characters_either() {
+        // A raw ESC in the body is refused by TOML itself, whose error
+        // message quotes the offending source line — the same trust
+        // boundary, reached through toml's renderer instead of ours.
+        let source = "# /// script\n# x = \"\u{1b}[31mFAKE\"\n# ///\n";
+        let err = parse(source).unwrap_err().to_string();
+        assert!(!err.contains('\u{1b}'), "raw ESC leaked: {err:?}");
     }
 }

--- a/crates/uvr/src/commands/run.rs
+++ b/crates/uvr/src/commands/run.rs
@@ -28,10 +28,13 @@ pub async fn run(
     if let Some(constraint) = header.as_ref().and_then(|h| h.r.as_deref()) {
         // Parsed, but #183 is what makes it select an R. Saying so beats
         // running against whichever interpreter happens to be around and
-        // letting the script fail somewhere less obvious.
+        // letting the script fail somewhere less obvious. The constraint is
+        // free text from the header — control-escape it, or a crafted `r`
+        // value could smuggle ANSI sequences into uvr's own diagnostics.
         crate::ui::warn(format!(
-            "script header pins R `{constraint}`, which uvr does not honour yet (#183) — \
-             running against the R resolved as usual"
+            "script header pins R `{}`, which uvr does not honour yet (#183) — \
+             running against the R resolved as usual",
+            script_header::sanitize_for_display(constraint)
         ));
     }
 

--- a/crates/uvr/src/commands/run.rs
+++ b/crates/uvr/src/commands/run.rs
@@ -1,30 +1,56 @@
 use std::path::PathBuf;
 use std::process::Command;
 
-use anyhow::{Context, Result};
+use anyhow::{anyhow, Context, Result};
 use sha2::{Digest, Sha256};
 
 use uvr_core::manifest::{DependencySpec, Manifest};
 use uvr_core::project::{ManifestSource, Project};
 use uvr_core::r_env::REnv;
-use uvr_core::r_version::detector::{find_r_binary, query_r_version};
+use uvr_core::r_version::detector::{find_r_binary, find_r_binary_ignoring_pin, query_r_version};
+use uvr_core::script_header::{self, ScriptHeader};
 
 pub async fn run(
     script: Option<String>,
     r_version_override: Option<String>,
-    with_packages: Vec<String>,
+    mut with_packages: Vec<String>,
     args: Vec<String>,
 ) -> Result<()> {
+    // A script carrying an inline dependency header runs *standalone*: the
+    // surrounding project is ignored entirely, which is exactly what lets the
+    // same file reproduce in any directory on anyone's machine (#181).
+    let header = match script.as_deref() {
+        Some(path) => read_header(path)?,
+        None => None,
+    };
+    let script_mode = header.is_some();
+
+    if let Some(constraint) = header.as_ref().and_then(|h| h.r.as_deref()) {
+        // Parsed, but #183 is what makes it select an R. Saying so beats
+        // running against whichever interpreter happens to be around and
+        // letting the script fail somewhere less obvious.
+        crate::ui::warn(format!(
+            "script header pins R `{constraint}`, which uvr does not honour yet (#183) — \
+             running against the R resolved as usual"
+        ));
+    }
+
     // Resolve project (optional — uvr run works outside a project too).
-    let (project_library, project_r_constraint) = match Project::find_cwd() {
-        Ok(p) => {
-            p.ensure_library_dir()
-                .context("Failed to create .uvr/library/")?;
-            let lib = p.library_path();
-            let rv = p.manifest.project.r_version.clone();
-            (Some(lib), rv)
+    // Skipped in script mode, so a headered script neither inherits the
+    // project's R constraint nor creates its `.uvr/library/` as a side effect.
+    let (project_library, project_r_constraint) = if script_mode {
+        (None, None)
+    } else {
+        match Project::find_cwd() {
+            Ok(p) => {
+                p.ensure_library_dir()
+                    .context("Failed to create .uvr/library/")?;
+                let lib = p.library_path();
+                let rv = p.manifest.project.r_version.clone();
+                (Some(lib), rv)
+            }
+            Err(_) => (None, None),
         }
-        Err(_) => (None, None),
     };
 
     // --r-version flag takes priority over the project constraint.
@@ -32,23 +58,30 @@ pub async fn run(
         .as_deref()
         .or(project_r_constraint.as_deref());
 
-    let r_binary = find_r_binary(effective_constraint)
-        .context("R not found. Install R or use `uvr r install <version>`")?;
+    // In script mode a `.r-version` pin is ignored along with the rest of the
+    // project. `find_r_binary` walks up from the working directory to find
+    // one, and the pin outranks every other signal — so honouring it would
+    // let the directory a script happens to sit in choose its interpreter,
+    // and with it the ephemeral environment's cache key.
+    let r_binary = if script_mode {
+        find_r_binary_ignoring_pin(effective_constraint)
+    } else {
+        find_r_binary(effective_constraint)
+    }
+    .context("R not found. Install R or use `uvr r install <version>`")?;
 
-    let library: PathBuf = project_library.unwrap_or_else(|| {
-        dirs::data_local_dir()
-            .unwrap_or_else(|| {
-                // HOME-less environment (sandbox/CI): degrade to the system
-                // temp dir instead of dropping a library tree into the
-                // working directory (#161).
-                std::env::temp_dir()
-            })
-            .join("uvr")
-            .join("library")
-    });
+    // A headered script's dependencies join any `--with` packages in a single
+    // ephemeral environment.
+    if let Some(header) = &header {
+        with_packages.extend(header.dependencies.iter().cloned());
+    }
 
-    // Handle --with packages: resolve + install into a cached env.
-    let with_library = if !with_packages.is_empty() {
+    // Script mode always builds an environment, even when the header declares
+    // no packages: an empty isolated library is still the right answer, and is
+    // not the same thing as falling back to whatever the machine provides.
+    let with_env = if with_packages.is_empty() && !script_mode {
+        None
+    } else {
         // The R version is part of the --with cache key (see ensure_with_env).
         // Falling back to a default here would collapse every R version into
         // one cache entry, silently reusing ABI-incompatible compiled
@@ -61,8 +94,17 @@ pub async fn run(
             )
         })?;
         Some(ensure_with_env(&with_packages, &r_ver).await?)
-    } else {
-        None
+    };
+
+    let (library, with_library) = match with_env {
+        // Script mode: the ephemeral environment replaces the project library
+        // rather than sitting in front of it, so the script cannot quietly
+        // satisfy an undeclared `library()` call from whatever happens to be
+        // installed on this machine and then fail on the next one.
+        // (`UVR_EXTRA_LIBS` is still appended by `REnv` — it is a deliberate
+        // per-machine escape hatch, not ambient project state.)
+        Some(env) if script_mode => (env, None),
+        env => (project_library.unwrap_or_else(fallback_library), env),
     };
 
     // The isolated environment — library search path, shadowed system
@@ -83,6 +125,29 @@ pub async fn run(
     // Belt and braces alongside the blank `R_ENVIRON`: a process flag is
     // available here, but not to a sourced activation script.
     cmd.arg("--no-environ");
+
+    if script_mode {
+        // Set here rather than in `REnv::vars()` for the same reason as
+        // `--no-environ` above: it is a property of *this* invocation, not of
+        // the isolated environment `uvr activate` also exports. Activation
+        // must never disable the user's startup profile.
+        //
+        // It is needed because environment variables alone do not isolate a
+        // headered script. R still sources a startup profile, and uvr's own
+        // project `.Rprofile` runs `.libPaths(unique(c(lib, .libPaths())))`,
+        // which puts the surrounding project's library *ahead* of the
+        // script's environment and quietly undoes the isolation the header
+        // exists to provide; `~/.Rprofile` can do the same for the machine at
+        // large. Pointing `R_PROFILE_USER` at the null device skips both, the
+        // same way the installer does (`installer/r_cmd_install.rs`).
+        //
+        // `R_PROFILE` (the *site* profile) is deliberately left alone — uvr
+        // writes its own OpenMP fix into a managed R's `Rprofile.site`.
+        cmd.env(
+            "R_PROFILE_USER",
+            if cfg!(windows) { "NUL" } else { "/dev/null" },
+        );
+    }
 
     if let Some(script_path) = &script {
         // Script mode — run as quietly as Rscript does. `Rscript foo.R` is
@@ -116,20 +181,58 @@ pub async fn run(
     Ok(())
 }
 
-/// Ensure the `--with` packages are installed in a cached environment.
-/// Returns the path to the cached library directory.
-async fn ensure_with_env(packages: &[String], r_version: &str) -> Result<PathBuf> {
-    // Compute a stable cache key from the sorted package list + R version.
-    let mut sorted = packages.to_vec();
-    sorted.sort();
+/// Read a script's inline dependency header (see [`script_header::parse`]).
+///
+/// An unreadable path yields `None` rather than an error: `uvr run` has always
+/// let R report a missing or unopenable script in its own words, and looking
+/// for a header is no reason to start intercepting that.
+fn read_header(path: &str) -> Result<Option<ScriptHeader>> {
+    let Ok(source) = std::fs::read_to_string(path) else {
+        return Ok(None);
+    };
+    script_header::parse(&source).map_err(|e| anyhow!("Invalid script header in {path}: {e}"))
+}
+
+/// Library used when `uvr run` is invoked outside a project.
+fn fallback_library() -> PathBuf {
+    dirs::data_local_dir()
+        .unwrap_or_else(|| {
+            // HOME-less environment (sandbox/CI): degrade to the system
+            // temp dir instead of dropping a library tree into the
+            // working directory (#161).
+            std::env::temp_dir()
+        })
+        .join("uvr")
+        .join("library")
+}
+
+/// Cache key for an ephemeral environment: the directory name under
+/// `<cache>/with-envs/`.
+///
+/// `packages` must already be sorted, so the same set in any order reuses one
+/// environment. The R version is part of the key because compiled packages are
+/// ABI-bound to an R minor (#160).
+///
+/// **This function's output is a compatibility surface.** Changing it silently
+/// orphans every cached environment on every user's machine, so the tests pin
+/// a golden value — #182 generalises the header grammar and must keep a bare
+/// package name hashing exactly as it does now.
+fn with_env_key(packages: &[String], r_version: &str) -> String {
     let mut hasher = Sha256::new();
     hasher.update(r_version.as_bytes());
-    for pkg in &sorted {
+    for pkg in packages {
         hasher.update(b"\0");
         hasher.update(pkg.as_bytes());
     }
-    let hash = format!("{:x}", hasher.finalize());
-    let short_hash = &hash[..12];
+    format!("{:x}", hasher.finalize())[..12].to_string()
+}
+
+/// Ensure the `--with` packages are installed in a cached environment.
+/// Returns the path to the cached library directory.
+async fn ensure_with_env(packages: &[String], r_version: &str) -> Result<PathBuf> {
+    let mut sorted = packages.to_vec();
+    sorted.sort();
+    let short_hash = with_env_key(&sorted, r_version);
 
     let cache_dir = uvr_core::env_vars::cache_dir()
         .unwrap_or_else(|| {
@@ -146,6 +249,13 @@ async fn ensure_with_env(packages: &[String], r_version: &str) -> Result<PathBuf
         .join(short_hash);
 
     let lib_dir = cache_dir.join(".uvr").join("library");
+
+    // Created up front because both early exits below can skip the install
+    // that would otherwise make it: an already-warm cache, and a script whose
+    // header declares no packages at all. R must be handed a library path
+    // that exists either way.
+    std::fs::create_dir_all(&lib_dir)
+        .with_context(|| format!("Failed to create {}", lib_dir.display()))?;
 
     // Check if all requested packages are already installed.
     let all_installed = sorted
@@ -193,3 +303,45 @@ impl std::fmt::Display for ScriptExitError {
 }
 
 impl std::error::Error for ScriptExitError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn key(pkgs: &[&str], r: &str) -> String {
+        let mut sorted: Vec<String> = pkgs.iter().map(|s| s.to_string()).collect();
+        sorted.sort();
+        with_env_key(&sorted, r)
+    }
+
+    #[test]
+    fn the_same_dependency_set_reuses_one_environment() {
+        // What "the ephemeral environment is cached and reused across runs of
+        // the same header" (#181) actually rests on.
+        assert_eq!(key(&["jsonlite"], "4.4.2"), key(&["jsonlite"], "4.4.2"));
+        // Declaration order must not fork the cache.
+        assert_eq!(key(&["a", "b"], "4.4.2"), key(&["b", "a"], "4.4.2"));
+    }
+
+    #[test]
+    fn different_dependency_sets_get_different_environments() {
+        let base = key(&["jsonlite"], "4.4.2");
+        assert_ne!(base, key(&["cli"], "4.4.2"));
+        assert_ne!(base, key(&["jsonlite", "cli"], "4.4.2"));
+        assert_ne!(base, key(&[], "4.4.2"));
+        // ABI: compiled packages built for one R minor must not be reused
+        // under another (#160).
+        assert_ne!(base, key(&["jsonlite"], "4.5.1"));
+    }
+
+    #[test]
+    fn a_bare_package_name_still_hashes_to_its_established_key() {
+        // Golden value. `--with jsonlite` has resolved to this directory
+        // since the ephemeral-env cache shipped; #181 routes header
+        // dependencies through the same function, and #182 will generalise
+        // the grammar. Any change here orphans every user's cache, so this
+        // test exists to make that a deliberate decision rather than a
+        // side effect.
+        assert_eq!(key(&["jsonlite"], "4.4.2"), "c449740c65a0");
+    }
+}

--- a/crates/uvr/src/commands/run.rs
+++ b/crates/uvr/src/commands/run.rs
@@ -212,9 +212,10 @@ fn fallback_library() -> PathBuf {
 /// Cache key for an ephemeral environment: the directory name under
 /// `<cache>/with-envs/`.
 ///
-/// `packages` must already be sorted, so the same set in any order reuses one
-/// environment. The R version is part of the key because compiled packages are
-/// ABI-bound to an R minor (#160).
+/// `packages` must already be sorted and de-duplicated, so the same set in
+/// any order — including a package named both in a header and via `--with` —
+/// reuses one environment. The R version is part of the key because compiled
+/// packages are ABI-bound to an R minor (#160).
 ///
 /// **This function's output is a compatibility surface.** Changing it silently
 /// orphans every cached environment on every user's machine, so the tests pin
@@ -235,6 +236,10 @@ fn with_env_key(packages: &[String], r_version: &str) -> String {
 async fn ensure_with_env(packages: &[String], r_version: &str) -> Result<PathBuf> {
     let mut sorted = packages.to_vec();
     sorted.sort();
+    // Same package from the header and `--with` (or listed twice) is one
+    // logical set — without this it would mint a second cache dir and
+    // install everything again.
+    sorted.dedup();
     let short_hash = with_env_key(&sorted, r_version);
 
     let cache_dir = uvr_core::env_vars::cache_dir()
@@ -312,8 +317,10 @@ mod tests {
     use super::*;
 
     fn key(pkgs: &[&str], r: &str) -> String {
+        // Mirrors ensure_with_env's canonicalisation.
         let mut sorted: Vec<String> = pkgs.iter().map(|s| s.to_string()).collect();
         sorted.sort();
+        sorted.dedup();
         with_env_key(&sorted, r)
     }
 
@@ -324,6 +331,12 @@ mod tests {
         assert_eq!(key(&["jsonlite"], "4.4.2"), key(&["jsonlite"], "4.4.2"));
         // Declaration order must not fork the cache.
         assert_eq!(key(&["a", "b"], "4.4.2"), key(&["b", "a"], "4.4.2"));
+        // Nor must a duplicate: the same package named in the header and via
+        // `--with` is one logical set, not a second environment.
+        assert_eq!(
+            key(&["jsonlite", "jsonlite"], "4.4.2"),
+            key(&["jsonlite"], "4.4.2")
+        );
     }
 
     #[test]

--- a/crates/uvr/tests/cli_tests.rs
+++ b/crates/uvr/tests/cli_tests.rs
@@ -867,3 +867,290 @@ Write-Output ("AFTER_DEACTIVATE_PRESENT=" + (Test-Path Function:\deactivate))
         "{stdout}"
     );
 }
+
+// ─── inline script headers (#181) ───────────────────────────
+
+/// Write `source` to `script.R` in a fresh directory.
+fn script_dir(source: &str) -> TempDir {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("script.R"), source).unwrap();
+    dir
+}
+
+#[test]
+fn test_unterminated_script_header_is_a_hard_error() {
+    // No closing `# ///` at all: every declared dependency would be silently
+    // dropped and resurface as a missing-package failure somewhere far away.
+    let dir = script_dir("# /// script\n# dependencies = [\"ggplot2\"]\n");
+    uvr_cmd()
+        .args(["run", "script.R"])
+        .current_dir(dir.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "Invalid script header in script.R",
+        ))
+        .stderr(predicate::str::contains("unterminated"));
+}
+
+#[test]
+fn test_stray_code_inside_the_header_names_the_offending_line() {
+    // The block *is* closed further down, so "unterminated" would be the
+    // wrong diagnosis — the message must point at the line that cannot
+    // belong to it.
+    let dir = script_dir(
+        "# /// script\n# dependencies = [\"ggplot2\"]\nlibrary(ggplot2)\n# ///\nprint(1)\n",
+    );
+    uvr_cmd()
+        .args(["run", "script.R"])
+        .current_dir(dir.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "Invalid script header in script.R",
+        ))
+        .stderr(predicate::str::contains("library(ggplot2)"));
+}
+
+#[test]
+fn test_a_spec_grammar_this_slice_cannot_honour_is_rejected() {
+    // Passing `ggplot2>=3.4` through would reach the resolver as a literal
+    // package name and fail with "Package not found: ggplot2>=3.4" plus a
+    // nonsense `uvr add cran/ggplot2>=3.4@master` suggestion — naming
+    // neither the cause nor the fix.
+    let dir = script_dir("# /// script\n# dependencies = [\"ggplot2>=3.4\"]\n# ///\n");
+    uvr_cmd()
+        .args(["run", "script.R"])
+        .current_dir(dir.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "Invalid script header in script.R",
+        ))
+        .stderr(predicate::str::contains("not a plain package name"));
+}
+
+#[test]
+fn test_malformed_toml_in_a_script_header_is_a_hard_error() {
+    let dir = script_dir("# /// script\n# dependencies = [\n# ///\n");
+    uvr_cmd()
+        .args(["run", "script.R"])
+        .current_dir(dir.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "Invalid script header in script.R",
+        ));
+}
+
+#[test]
+fn test_header_errors_come_before_r_is_needed() {
+    // The header is parsed before uvr looks for an interpreter, so the
+    // message a user gets is about their typo — not about R being missing on
+    // a machine where it is irrelevant to the failure.
+    let dir = script_dir("# /// script\n# dependencies = [\"x\"]\n");
+    let output = uvr_cmd()
+        .args(["run", "script.R", "--r-version", "99.9.9"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Invalid script header"),
+        "expected a header error, got: {stderr}"
+    );
+    assert!(!stderr.contains("R not found"), "{stderr}");
+}
+
+#[test]
+fn test_a_comment_divider_is_not_a_script_header() {
+    // `# ///` is a plausible section divider. A script using one must not be
+    // rejected as a broken header — it has no header at all, so this behaves
+    // exactly as it did before inline headers existed (regression).
+    let dir = script_dir("# ///\n# just a divider\nprint(1)\n");
+    let output = uvr_cmd()
+        .args(["run", "script.R"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(!stderr.contains("script header"), "{stderr}");
+}
+
+#[test]
+fn test_headerless_script_does_not_gain_a_header_error() {
+    // Regression: ordinary scripts are untouched by header detection.
+    let dir = script_dir("library(stats)\nprint(1)\n");
+    let output = uvr_cmd()
+        .args(["run", "script.R"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(!stderr.contains("script header"), "{stderr}");
+}
+
+#[test]
+#[ignore = "requires network access to CRAN/P3M and a managed R"]
+fn test_headered_script_runs_standalone_in_an_empty_directory() {
+    // The whole promise of #181: no project, no manifest, no setup — the
+    // file carries its environment. Run with `cargo test -- --ignored`.
+    let dir = script_dir(
+        "# /// script\n\
+         # dependencies = [\"jsonlite\"]\n\
+         # ///\n\
+         cat(jsonlite::toJSON(list(ok = TRUE)))\n",
+    );
+    uvr_cmd()
+        .args(["run", "script.R"])
+        .current_dir(dir.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"ok\""));
+}
+
+#[test]
+#[ignore = "requires network access to CRAN/P3M and a managed R"]
+fn test_headered_script_ignores_the_surrounding_project() {
+    // Run the same script inside a project that declares a *different*
+    // package. If the project library leaked onto the search path, the
+    // undeclared package would resolve and the script would wrongly succeed.
+    let dir = init_project("leaky");
+    fs::write(
+        dir.path().join("script.R"),
+        "# /// script\n\
+         # dependencies = [\"jsonlite\"]\n\
+         # ///\n\
+         cat(if (requireNamespace(\"cli\", quietly = TRUE)) \"LEAKED\" else \"ISOLATED\")\n",
+    )
+    .unwrap();
+    uvr_cmd()
+        .args(["add", "cli"])
+        .current_dir(dir.path())
+        .assert()
+        .success();
+
+    uvr_cmd()
+        .args(["run", "script.R"])
+        .current_dir(dir.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("ISOLATED"));
+}
+
+#[test]
+fn test_headered_script_does_not_inherit_the_project_library() {
+    // The isolation that makes a headered script portable is not delivered
+    // by environment variables alone: uvr's own project `.Rprofile` runs
+    // `.libPaths(unique(c(lib, .libPaths())))` at startup, which would put
+    // the surrounding project's library *ahead* of the script's own
+    // environment. An empty dependency list keeps this offline.
+    if !have_r() {
+        eprintln!("skipping: no R on PATH");
+        return;
+    }
+    let dir = init_project("isolation");
+    fs::write(
+        dir.path().join("script.R"),
+        "# /// script\n# dependencies = []\n# ///\ncat(.libPaths(), sep = \"\\n\")\n",
+    )
+    .unwrap();
+
+    let out = uvr_cmd()
+        .args(["run", "script.R"])
+        .current_dir(dir.path())
+        .assert()
+        .success();
+    let stdout = String::from_utf8(out.get_output().stdout.clone()).unwrap();
+
+    let project_lib = dir.path().join(".uvr").join("library");
+    assert!(
+        !stdout.contains(&*project_lib.to_string_lossy()),
+        "the project library leaked into a headered script's search path:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("with-envs"),
+        "expected the ephemeral environment on the search path:\n{stdout}"
+    );
+}
+
+#[test]
+fn test_headerless_script_still_gets_the_project_library() {
+    // The converse regression: suppressing the startup profile is scoped to
+    // script mode, so an ordinary `uvr run` inside a project still has its
+    // library linked by `.Rprofile` exactly as before.
+    if !have_r() {
+        eprintln!("skipping: no R on PATH");
+        return;
+    }
+    let dir = init_project("linked");
+    fs::write(
+        dir.path().join("script.R"),
+        "cat(.libPaths(), sep = \"\\n\")\n",
+    )
+    .unwrap();
+
+    let out = uvr_cmd()
+        .args(["run", "script.R"])
+        .current_dir(dir.path())
+        .assert()
+        .success();
+    let stdout = String::from_utf8(out.get_output().stdout.clone()).unwrap();
+
+    let project_lib = dir.path().join(".uvr").join("library");
+    assert!(
+        stdout.contains(&*project_lib.to_string_lossy()),
+        "the project library is no longer linked for an ordinary run:\n{stdout}"
+    );
+}
+
+#[test]
+fn test_headered_script_ignores_a_surrounding_r_version_pin() {
+    // `.r-version` is walked up from the working directory and outranks every
+    // other signal, so without this a headered script would let whichever
+    // project it happens to sit in choose its interpreter — and the R version
+    // is part of the ephemeral environment's cache key, so the same file
+    // would get a different set of packages per directory.
+    if !have_r() {
+        eprintln!("skipping: no R on PATH");
+        return;
+    }
+    let dir = script_dir("# /// script\n# dependencies = []\n# ///\ncat(\"RAN\\n\")\n");
+    fs::write(dir.path().join("plain.R"), "cat(\"RAN\\n\")\n").unwrap();
+    // A version nobody has installed, so honouring the pin is unmistakable.
+    fs::write(dir.path().join(".r-version"), "3.0.0\n").unwrap();
+
+    uvr_cmd()
+        .args(["run", "script.R"])
+        .current_dir(dir.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("RAN"));
+
+    // The converse: an ordinary run still honours the pin, so the change is
+    // scoped to script mode.
+    uvr_cmd()
+        .args(["run", "plain.R"])
+        .current_dir(dir.path())
+        .assert()
+        .failure();
+}
+
+#[test]
+fn test_an_unsupported_r_pin_in_a_header_is_reported_not_swallowed() {
+    // `r` is parsed but not honoured until #183. Running against whichever R
+    // happens to be around without saying so is the trap this guards.
+    if !have_r() {
+        eprintln!("skipping: no R on PATH");
+        return;
+    }
+    let dir =
+        script_dir("# /// script\n# r = \">=4.3\"\n# dependencies = []\n# ///\ncat(\"RAN\\n\")\n");
+    uvr_cmd()
+        .args(["run", "script.R"])
+        .current_dir(dir.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("RAN"))
+        .stderr(predicate::str::contains("does not honour yet"));
+}

--- a/crates/uvr/tests/cli_tests.rs
+++ b/crates/uvr/tests/cli_tests.rs
@@ -965,6 +965,56 @@ fn test_malformed_toml_in_a_script_header_is_a_hard_error() {
 }
 
 #[test]
+fn test_a_second_header_block_is_a_hard_error() {
+    // #181: a broken header is "never silently ignored". A stale second
+    // block — the classic leftover of a bad merge — used to be discarded
+    // without a word, its dependencies never provisioned.
+    let dir = script_dir(
+        "# /// script\n# dependencies = []\n# ///\n\
+         print(1)\n\
+         # /// script\n# dependencies = [\"nope\"]\n# ///\n",
+    );
+    uvr_cmd()
+        .args(["run", "script.R"])
+        .current_dir(dir.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "Invalid script header in script.R",
+        ))
+        .stderr(predicate::str::contains("only one"));
+}
+
+#[test]
+fn test_header_text_cannot_smuggle_ansi_into_uvr_output() {
+    // A header is text you accept from a stranger. `\u001b` is legal TOML
+    // that decodes to a live ESC; printed raw it can repaint or overwrite
+    // uvr's own diagnostics. The r-pin warning is the interpolation site a
+    // successfully-parsed header reaches, so it is the one exercised here
+    // against the real binary.
+    let dir = script_dir(
+        "# /// script\n# r = \"\\u001b[31mINJECTED>=4.3\"\n# dependencies = []\n# ///\n",
+    );
+    // The warning fires before an interpreter is resolved, so stderr carries
+    // it whether or not this machine has an R to continue with — the exit
+    // status is deliberately not asserted.
+    let output = uvr_cmd()
+        .args(["run", "script.R"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("\\u{1b}[31mINJECTED"),
+        "escaped rendering missing: {stderr:?}"
+    );
+    assert!(
+        !stderr.contains("\u{1b}[31mINJECTED"),
+        "raw ESC reached the terminal: {stderr:?}"
+    );
+}
+
+#[test]
 fn test_header_errors_come_before_r_is_needed() {
     // The header is parsed before uvr looks for an interpreter, so the
     // message a user gets is about their typo — not about R being missing on

--- a/crates/uvr/tests/cli_tests.rs
+++ b/crates/uvr/tests/cli_tests.rs
@@ -877,16 +877,26 @@ fn script_dir(source: &str) -> TempDir {
     dir
 }
 
-/// A path in the form R prints it.
+/// An R script that reports whether the *project* library is on the search
+/// path, printing `LINKED` or `NOT_LINKED`.
 ///
-/// R reports `.libPaths()` with forward slashes on every platform, including
-/// Windows, where `Path` renders backslashes. Comparing the two directly makes
-/// a `contains` assertion fail on Windows and — far worse — makes a
-/// `!contains` assertion pass there no matter what, so an isolation test would
-/// silently stop testing anything.
-fn as_r_prints_it(path: &std::path::Path) -> String {
-    path.to_string_lossy().replace('\\', "/")
-}
+/// The comparison happens inside R rather than by matching the path in Rust,
+/// because a Rust-side `String::contains` cannot survive Windows: R prints
+/// `.libPaths()` with forward slashes where `Path` renders backslashes, and
+/// GitHub's Windows runners point `TEMP` at the 8.3 short form
+/// (`C:\Users\RUNNER~1\…`) while R resolves and prints the long form
+/// (`C:/Users/runneradmin/…`). Two different spellings of one directory.
+///
+/// Getting this wrong is worse than a red test: a `!contains` assertion that
+/// can never match passes vacuously, so the isolation check would quietly
+/// stop checking anything on the one platform where the profile suppression
+/// is spelled differently.
+const REPORTS_PROJECT_LIB_LINKAGE: &str = r#"
+lib <- normalizePath(file.path(getwd(), ".uvr", "library"), winslash = "/", mustWork = FALSE)
+paths <- normalizePath(.libPaths(), winslash = "/", mustWork = FALSE)
+cat(if (lib %in% paths) "LINKED" else "NOT_LINKED", "\n")
+cat(paths, sep = "\n")
+"#;
 
 #[test]
 fn test_unterminated_script_header_is_a_hard_error() {
@@ -1063,7 +1073,7 @@ fn test_headered_script_does_not_inherit_the_project_library() {
     let dir = init_project("isolation");
     fs::write(
         dir.path().join("script.R"),
-        "# /// script\n# dependencies = []\n# ///\ncat(.libPaths(), sep = \"\\n\")\n",
+        format!("# /// script\n# dependencies = []\n# ///\n{REPORTS_PROJECT_LIB_LINKAGE}"),
     )
     .unwrap();
 
@@ -1074,9 +1084,8 @@ fn test_headered_script_does_not_inherit_the_project_library() {
         .success();
     let stdout = String::from_utf8(out.get_output().stdout.clone()).unwrap();
 
-    let project_lib = as_r_prints_it(&dir.path().join(".uvr").join("library"));
     assert!(
-        !stdout.contains(&project_lib),
+        stdout.contains("NOT_LINKED"),
         "the project library leaked into a headered script's search path:\n{stdout}"
     );
     assert!(
@@ -1097,7 +1106,7 @@ fn test_headerless_script_still_gets_the_project_library() {
     let dir = init_project("linked");
     fs::write(
         dir.path().join("script.R"),
-        "cat(.libPaths(), sep = \"\\n\")\n",
+        REPORTS_PROJECT_LIB_LINKAGE.trim_start(),
     )
     .unwrap();
 
@@ -1108,9 +1117,8 @@ fn test_headerless_script_still_gets_the_project_library() {
         .success();
     let stdout = String::from_utf8(out.get_output().stdout.clone()).unwrap();
 
-    let project_lib = as_r_prints_it(&dir.path().join(".uvr").join("library"));
     assert!(
-        stdout.contains(&project_lib),
+        stdout.contains("LINKED") && !stdout.contains("NOT_LINKED"),
         "the project library is no longer linked for an ordinary run:\n{stdout}"
     );
 }

--- a/crates/uvr/tests/cli_tests.rs
+++ b/crates/uvr/tests/cli_tests.rs
@@ -877,6 +877,17 @@ fn script_dir(source: &str) -> TempDir {
     dir
 }
 
+/// A path in the form R prints it.
+///
+/// R reports `.libPaths()` with forward slashes on every platform, including
+/// Windows, where `Path` renders backslashes. Comparing the two directly makes
+/// a `contains` assertion fail on Windows and — far worse — makes a
+/// `!contains` assertion pass there no matter what, so an isolation test would
+/// silently stop testing anything.
+fn as_r_prints_it(path: &std::path::Path) -> String {
+    path.to_string_lossy().replace('\\', "/")
+}
+
 #[test]
 fn test_unterminated_script_header_is_a_hard_error() {
     // No closing `# ///` at all: every declared dependency would be silently
@@ -1063,9 +1074,9 @@ fn test_headered_script_does_not_inherit_the_project_library() {
         .success();
     let stdout = String::from_utf8(out.get_output().stdout.clone()).unwrap();
 
-    let project_lib = dir.path().join(".uvr").join("library");
+    let project_lib = as_r_prints_it(&dir.path().join(".uvr").join("library"));
     assert!(
-        !stdout.contains(&*project_lib.to_string_lossy()),
+        !stdout.contains(&project_lib),
         "the project library leaked into a headered script's search path:\n{stdout}"
     );
     assert!(
@@ -1097,9 +1108,9 @@ fn test_headerless_script_still_gets_the_project_library() {
         .success();
     let stdout = String::from_utf8(out.get_output().stdout.clone()).unwrap();
 
-    let project_lib = dir.path().join(".uvr").join("library");
+    let project_lib = as_r_prints_it(&dir.path().join(".uvr").join("library"));
     assert!(
-        stdout.contains(&*project_lib.to_string_lossy()),
+        stdout.contains(&project_lib),
         "the project library is no longer linked for an ordinary run:\n{stdout}"
     );
 }


### PR DESCRIPTION
Closes #181. First slice of **F1** from the [uv feature-parity design](https://github.com/nbafrank/uvr/blob/main/docs/design/2026-07-23-uv-feature-parity-design.md) — the headline gap, and the live edge over `rv`.

## What a user gets

```r
# /// script
# dependencies = [
#   "jsonlite",
#   "praise",
# ]
# ///

cat(praise::praise(), "\n")
```

```console
$ cd /tmp/anywhere && uvr run analysis.R
> Installing 2 package(s): 2 binary
v Installed 2 package(s) in 1.75s
You are epic!
```

No project, no `uvr.toml`, no setup. Send someone the file and it runs. The declared packages land in an isolated ephemeral environment, cached and reused — the second run of the same header is 0.74s against 4.5s cold.

This is the R analog of PEP 723, whose structure it deliberately mirrors, since R has no published standard here.

## Standalone has to actually mean standalone

The interesting part of this change is not parsing the header. It is that **four independent mechanisms** would otherwise let the directory a script happens to sit in decide what that script sees — and each one breaks the single property the feature exists to provide.

| Mechanism | What leaks without the fix |
|---|---|
| Project library | `.uvr/library/` sits on the search path, so an undeclared `library()` call resolves here and fails on the next machine |
| `uvr.toml` R constraint | The project picks the interpreter |
| `.r-version` pin | Walked up from cwd, **outranks every other signal** |
| Startup profile | uvr's own `.Rprofile` puts the project library **back**, ahead of the script's |

The last two were not obvious and are worth spelling out.

**`.r-version`.** Skipping the manifest constraint is not enough: `find_r_binary` independently walks up from the working directory looking for a pin, and the pin wins over everything. Because the R version is part of the ephemeral environment's cache key, honouring it means the same file gets a *different set of installed packages* depending on where it was run from. Hence `find_r_binary_ignoring_pin`.

**The startup profile.** Environment variables do not isolate R. uvr's project `.Rprofile` runs:

```r
.libPaths(unique(c(lib, .libPaths())))
```

so the project library is prepended *at R startup*, landing **first** — ahead of the script's own environment. Observed directly:

```console
# before
LIBPATHS:
  /tmp/proj/.uvr/library            <- the project, winning
  ~/.uvr/cache/with-envs/971a65/.uvr/library
  /usr/lib/R/library

# after
LIBPATHS:
  ~/.uvr/cache/with-envs/971a65/.uvr/library
  /usr/lib/R/library
```

`R_PROFILE_USER` is pointed at the null device — the same trick `installer/r_cmd_install.rs` already uses — **in script mode only**, so an ordinary `uvr run` still gets its library linked as before. `R_PROFILE` (the *site* profile) is deliberately left alone, because uvr writes its own OpenMP fix into a managed R's `Rprofile.site`.

Both are covered by tests that were confirmed to fail without their fix.

## Slice boundaries are reported, not swallowed

This slice accepts plain package names. The rest of F1 is #182 (version constraints, Bioconductor, git), #183 (`r` pin), #184 (`uvr add --script`). Rather than let a header uvr cannot yet honour be quietly misread:

```console
$ uvr run spec.R
 x ERROR  Invalid script header in spec.R: `ggplot2>=3.4` is not a plain package
          name. Version constraints, Bioconductor and git sources in script
          headers are not supported yet (#182)
```

Without this, `ggplot2>=3.4` reaches the resolver as a literal package name and dies with `Package not found: ggplot2>=3.4` plus a nonsense `uvr add cran/ggplot2>=3.4@master` suggestion — naming neither the cause nor the fix. An `r` key is parsed and reported as not-yet-honoured for the same reason: silently running against whichever R is lying around is exactly the trap the feature exists to close.

Dotted names (`data.table`, `org.Hs.eg.db`) are plain names, per *Writing R Extensions*, and are accepted.

## Compatibility

- **Headerless scripts are untouched.** A `# ///` used as a decorative section divider is not a header, and is tested as such.
- **`--with` cache keys are unchanged.** `with_env_key` is extracted from `ensure_with_env` and pinned by a golden test (`c449740c65a0` for `jsonlite` on R 4.4.2, verified independently with `sha256sum`). #182 generalises the grammar through this same function; changing the key orphans every cached environment on every user's machine, so the test makes that a decision rather than a side effect.

## Tests

613 pass, `clippy -D warnings` and `fmt` clean. 20 unit tests on the parser, 11 CLI tests, plus two `#[ignore]`d end-to-end tests per the design's offline-CI strategy (`cargo test -- --ignored`).

Verified against real R beyond the suite: a headered script installed and ran `praise` in an empty directory, could not see `jsonlite` from the user's personal `~/R/...` library, and ignored both a project `.r-version` pin and a project library placed in its path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
