### PR TITLE
fix: diagnose a CRAN binary failing to load under a non-CRAN R

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ release page on GitHub. Issue numbers reference https://github.com/nbafrank/uvr/
 
 Pure tracking section — fixes and small features land here between tags.
 
+- **A CRAN mac binary failing to load under a non-CRAN R is now diagnosed
+  as what it is** (#238). When a package's compiled code cannot load because
+  it expects CRAN's R at `/Library/Frameworks/R.framework` (dlopen's
+  "Library not loaded"), the hint now explains the CRAN-binary/Homebrew-R
+  mismatch and both ways out — use CRAN R, or make the Fortran runtime
+  findable to the loader. Previously this failure either got no hint at
+  all or the "missing Fortran toolchain" one, which told users who already
+  had a working gfortran to go install one.
+
 ## v0.4.5 (2026-08-03)
 
 The community release. Four contributors filed thirteen pull requests in

--- a/crates/uvr/src/main.rs
+++ b/crates/uvr/src/main.rs
@@ -290,11 +290,13 @@ fn hint_for(msg: &str) -> Option<&'static str> {
         Some(
             "A package installed as a CRAN binary expects CRAN's R at \
              /Library/Frameworks/R.framework, and this R (Homebrew?) is not it, so the \
-             binary's compiled code cannot load. Either use CRAN R from \
-             https://cran.r-project.org/bin/macosx/, or keep this R and make the runtime \
-             findable: `brew install gcc`, then symlink the libraries named in the error \
-             (e.g. libgfortran.5.dylib) from `$(brew --prefix gcc)/lib/gcc/current/` into \
-             `$(R RHOME)/lib/` — the loader's fallback path shown in the error.",
+             binary's compiled code cannot load. Fixes, best first: switch the project to \
+             a uvr-managed R (`uvr r install <ver> && uvr r pin <ver>`) — its lib/ \
+             bundles the Fortran runtime on the loader's fallback path, so CRAN binaries \
+             load; or use CRAN R from https://cran.r-project.org/bin/macosx/; or keep \
+             this R and symlink the libraries named in the error (e.g. \
+             libgfortran.5.dylib) from `$(brew --prefix gcc)/lib/gcc/current/` into \
+             `$(R RHOME)/lib/`.",
         )
     } else if m.contains("emutls_w") || m.contains("/opt/gfortran") {
         Some(
@@ -355,6 +357,11 @@ mod tests {
                    ERROR: lazy loading failed for package 'fields'";
         let hint = hint_for(msg).expect("framework-path load failure should carry a hint");
         assert!(hint.contains("CRAN binary"), "{hint}");
+        // The uvr-native fix leads: the managed portable R bundles
+        // lib/libgfortran.5.dylib (verified against the R-4.6.1 macos-arm64
+        // tarball), which sits exactly on the dlopen fallback path the
+        // error itself prints.
+        assert!(hint.contains("uvr r install"), "{hint}");
         assert!(hint.contains("$(R RHOME)/lib"), "{hint}");
         assert!(
             !hint.contains("mac.r-project.org"),

--- a/crates/uvr/src/main.rs
+++ b/crates/uvr/src/main.rs
@@ -283,6 +283,19 @@ fn hint_for(msg: &str) -> Option<&'static str> {
         Some("Run `uvr r install <version>` or ensure R is on PATH.")
     } else if m.contains("base r package") {
         Some("Remove this package from your manifest — base packages ship with R.")
+    } else if m.contains("library not loaded") && m.contains("/library/frameworks/r.framework") {
+        // Checked before the missing-toolchain case: this failure names a
+        // library CRAN's R would provide, so "install gfortran" sends a user
+        // who already has it (Homebrew's, say) chasing the wrong fix (#238).
+        Some(
+            "A package installed as a CRAN binary expects CRAN's R at \
+             /Library/Frameworks/R.framework, and this R (Homebrew?) is not it, so the \
+             binary's compiled code cannot load. Either use CRAN R from \
+             https://cran.r-project.org/bin/macosx/, or keep this R and make the runtime \
+             findable: `brew install gcc`, then symlink the libraries named in the error \
+             (e.g. libgfortran.5.dylib) from `$(brew --prefix gcc)/lib/gcc/current/` into \
+             `$(R RHOME)/lib/` — the loader's fallback path shown in the error.",
+        )
     } else if m.contains("emutls_w") || m.contains("/opt/gfortran") {
         Some(
             "Missing Fortran toolchain on macOS. Install the CRAN gfortran build from \
@@ -325,5 +338,38 @@ mod tests {
         let msg = "Network error: error sending request for url (https://example.org): \
                    connection refused";
         assert!(hint_for(msg).is_none_or(|h| !h.contains("trust store")));
+    }
+
+    #[test]
+    fn cran_binary_on_a_non_cran_r_gets_the_framework_hint_not_the_toolchain_one() {
+        // #238: a CRAN mac binary (dotCall64) hard-links CRAN's
+        // R.framework path for libgfortran; under Homebrew R that path
+        // doesn't exist and the load fails. The reporter *had* a working
+        // Homebrew gfortran — it compiled the very package being
+        // installed — so "install a Fortran toolchain" is the wrong door.
+        let msg = "Failed to install fields\n\
+                   R CMD INSTALL failed for 'fields' (exit 1):\n\
+                   dlopen(/Users/x/proj/.uvr/library/dotCall64/libs/dotCall64.so, 0x0006): \
+                   Library not loaded: /Library/Frameworks/R.framework/Versions/4.6/\
+                   Resources/lib/libgfortran.5.dylib\n\
+                   ERROR: lazy loading failed for package 'fields'";
+        let hint = hint_for(msg).expect("framework-path load failure should carry a hint");
+        assert!(hint.contains("CRAN binary"), "{hint}");
+        assert!(hint.contains("$(R RHOME)/lib"), "{hint}");
+        assert!(
+            !hint.contains("mac.r-project.org"),
+            "misrouted to the missing-toolchain hint: {hint}"
+        );
+    }
+
+    #[test]
+    fn a_genuinely_missing_fortran_toolchain_still_gets_the_toolchain_hint() {
+        // The pre-#238 case must keep its hint: no dlopen, no framework
+        // path — the compiler itself is absent at CRAN's install location.
+        let msg = "Failed to install edgeR\n\
+                   R CMD INSTALL failed for 'edgeR' (exit 1):\n\
+                   make: /opt/gfortran/bin/gfortran: No such file or directory";
+        let hint = hint_for(msg).expect("missing toolchain should carry a hint");
+        assert!(hint.contains("mac.r-project.org"), "{hint}");
     }
 }


### PR DESCRIPTION
Refs #238.

## What actually failed there

Reading the full log in #238, `gfortran` is present and working — it compiled `fields`' own Fortran a few lines above the failure. What died is the **lazy-load of `dotCall64`**, a dependency that was installed as a **CRAN mac binary**:

```
dlopen(.../.uvr/library/dotCall64/libs/dotCall64.so, 0x0006): Library not loaded:
/Library/Frameworks/R.framework/Versions/4.6/Resources/lib/libgfortran.5.dylib
```

CRAN binaries hard-link CRAN's R.framework path for the Fortran runtime. The reporter runs **Homebrew R** (`/opt/homebrew/Cellar/r/4.6.1`), so that path doesn't exist. dlopen's "tried" list shows the loader's fallback — the running R's own `lib/` dir — which is why only Fortran-linking binaries break under Homebrew R while pure C/C++ binaries load fine.

The released binary routed this to the "missing Fortran toolchain / install CRAN gfortran" hint (wrong door: they have gfortran); current main's tightened matcher (`emutls_w` / `/opt/gfortran`) gives it **no hint at all**.

## Fix

A more specific `hint_for` branch, checked before the toolchain patterns: `Library not loaded` + `/Library/Frameworks/R.framework` → explain the CRAN-binary/non-CRAN-R mismatch, with three ways out, best first:

1. **Switch the project to a uvr-managed R** — `uvr r install <ver> && uvr r pin <ver>`. Verified against the real `R-4.6.1-macos-arm64.tar.gz` portable archive: it ships `lib/libgfortran.5.dylib` and `lib/libquadmath.0.dylib`, and R puts `$R_HOME/lib` on `DYLD_FALLBACK_LIBRARY_PATH` — the exact fallback path the reporter's error prints. CRAN binaries load under it, and it's the one remedy that is uvr's own mechanism.
2. Use CRAN R from cran.r-project.org/bin/macosx/.
3. Keep Homebrew R and `brew install gcc`, then symlink the libraries named in the error from `$(brew --prefix gcc)/lib/gcc/current/` into `$(R RHOME)/lib/`.

Two tests: the #238 message routes to the new hint (asserting the managed-R option leads, and not the toolchain hint), and a genuine missing-toolchain failure (`/opt/gfortran/...: No such file or directory`) keeps its existing hint.

## Not attempted here

The *mechanism* fix — e.g. having `uvr run`/install put Homebrew gcc's lib dir on `DYLD_FALLBACK_LIBRARY_PATH`, the mac analog of the `LD_LIBRARY_PATH` handling REnv already does on Linux — would make these binaries just work under Homebrew R too, but it changes loader behavior for every mac user and needs verification on actual macOS, which I can't do from this machine. Happy to file it as a follow-up if you think it's the right direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XpSACGGRFa97rcv5sYPML8