### PR TITLE
feat: add --install-dir to uvr r install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ release page on GitHub. Issue numbers reference https://github.com/nbafrank/uvr/
 
 Pure tracking section — fixes and small features land here between tags.
 
+- **`uvr r install --install-dir <DIR>`** (#89) installs R into a chosen
+  r-versions directory for that one invocation, taking precedence over
+  `UVR_R_INSTALL_DIR` the way uv's flags beat their env vars. The env var
+  remains the way to make every command look there.
+
 ## v0.4.5 (2026-08-03)
 
 The community release. Four contributors filed thirteen pull requests in

--- a/crates/uvr-core/src/r_version/downloader.rs
+++ b/crates/uvr-core/src/r_version/downloader.rs
@@ -617,20 +617,28 @@ pub fn user_agent(info: &HostInfo) -> String {
     )
 }
 
-/// Download and extract R to `~/.uvr/r-versions/<version>/`.
+/// Download and extract R to `<r-versions>/<version>/`.
 ///
 /// `version` may be partial (`4.5`): it is resolved to the newest published
 /// matching version before install, so the install directory is always a
 /// full `X.Y.Z` that pin resolution and `r list --all` can match (#170).
+///
+/// The r-versions directory is `install_root` when given (`--install-dir`,
+/// which wins over the env var per uv convention, #89), else
+/// `UVR_R_INSTALL_DIR` / `~/.uvr/r-versions`.
 pub async fn download_and_install_r(
     client: &reqwest::Client,
     version: &str,
     platform: Platform,
+    install_root: Option<&Path>,
 ) -> Result<PathBuf> {
     let version = &resolve_install_version(client, version, platform).await?;
-    let install_dir = crate::env_vars::r_install_dir()
-        .ok_or_else(|| UvrError::Other("Cannot determine r-versions directory".into()))?
-        .join(version);
+    let install_dir = match install_root {
+        Some(root) => root.to_path_buf(),
+        None => crate::env_vars::r_install_dir()
+            .ok_or_else(|| UvrError::Other("Cannot determine r-versions directory".into()))?,
+    }
+    .join(version);
 
     let r_binary_name = if platform.is_windows() { "R.exe" } else { "R" };
     let r_binary = install_dir.join("bin").join(r_binary_name);

--- a/crates/uvr-core/src/r_version/manager.rs
+++ b/crates/uvr-core/src/r_version/manager.rs
@@ -13,9 +13,18 @@ impl RManager {
 
     /// Install a specific R version. `version` may be partial (`4.5`);
     /// returns the full version actually installed (e.g. `4.5.3`).
-    pub async fn install(&self, version: &str) -> Result<String> {
+    ///
+    /// `install_root` overrides the r-versions directory (`--install-dir`,
+    /// #89); `None` keeps the default `UVR_R_INSTALL_DIR` / `~/.uvr/r-versions`
+    /// resolution.
+    pub async fn install(
+        &self,
+        version: &str,
+        install_root: Option<&std::path::Path>,
+    ) -> Result<String> {
         let platform = Platform::detect()?;
-        let install_dir = download_and_install_r(&self.client, version, platform).await?;
+        let install_dir =
+            download_and_install_r(&self.client, version, platform, install_root).await?;
         Ok(install_dir
             .file_name()
             .map(|n| n.to_string_lossy().into_owned())

--- a/crates/uvr/src/cli.rs
+++ b/crates/uvr/src/cli.rs
@@ -437,6 +437,13 @@ pub struct RInstallArgs {
     /// Posit CDN slug no longer applies. Accepted for backward compatibility.
     #[arg(long, value_name = "SLUG", hide = true)]
     pub distribution: Option<String>,
+
+    /// Install into this r-versions directory instead of the default
+    /// (overrides UVR_R_INSTALL_DIR for this invocation). Other commands
+    /// find R there only while UVR_R_INSTALL_DIR points at the same
+    /// directory.
+    #[arg(long, value_name = "DIR")]
+    pub install_dir: Option<std::path::PathBuf>,
 }
 
 #[derive(Debug, Args)]

--- a/crates/uvr/src/commands/r_cmd/install.rs
+++ b/crates/uvr/src/commands/r_cmd/install.rs
@@ -6,7 +6,11 @@ use uvr_core::r_version::manager::RManager;
 use crate::ui;
 use crate::ui::palette;
 
-pub async fn run(version: String, distribution: Option<String>) -> Result<()> {
+pub async fn run(
+    version: String,
+    distribution: Option<String>,
+    install_dir: Option<std::path::PathBuf>,
+) -> Result<()> {
     let platform = Platform::detect().context("Unsupported platform")?;
 
     // `--distribution` is deprecated: portable R builds are selected purely by
@@ -65,7 +69,7 @@ pub async fn run(version: String, distribution: Option<String>) -> Result<()> {
     // May differ from the requested version: a partial `4.5` resolves to the
     // newest published `4.5.x` (#170).
     let resolved = manager
-        .install(&version)
+        .install(&version, install_dir.as_deref())
         .await
         .context("R installation failed")?;
 

--- a/crates/uvr/src/main.rs
+++ b/crates/uvr/src/main.rs
@@ -165,7 +165,8 @@ async fn run() -> Result<()> {
         }
         Commands::R(r_args) => match r_args.command {
             Some(RCommands::Install(args)) => {
-                commands::r_cmd::install::run(args.version, args.distribution).await?;
+                commands::r_cmd::install::run(args.version, args.distribution, args.install_dir)
+                    .await?;
             }
             Some(RCommands::Uninstall(args)) => {
                 commands::r_cmd::uninstall::run(args.version)?;

--- a/crates/uvr/tests/cli_tests.rs
+++ b/crates/uvr/tests/cli_tests.rs
@@ -189,6 +189,18 @@ fn test_r_pin_help_works() {
 }
 
 #[test]
+fn test_r_install_advertises_install_dir() {
+    // #89: `--install-dir` overrides UVR_R_INSTALL_DIR for one invocation.
+    // The help text is the discoverable surface of that agreement.
+    uvr_cmd()
+        .args(["r", "install", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--install-dir"))
+        .stdout(predicate::str::contains("UVR_R_INSTALL_DIR"));
+}
+
+#[test]
 fn test_sync_without_lockfile_fails() {
     let dir = init_project("no-lock-test");
     uvr_cmd()

--- a/crates/uvr/tests/cli_tests.rs
+++ b/crates/uvr/tests/cli_tests.rs
@@ -201,6 +201,20 @@ fn test_r_install_advertises_install_dir() {
 }
 
 #[test]
+fn test_r_install_rejects_an_empty_install_dir() {
+    // An empty path would reach the downloader and die there as "Install
+    // path <version> has no parent directory" — an error that never names
+    // the flag. It cannot: clap's PathBuf parser refuses empty values at
+    // the argument layer. This pins that guarantee so a parser change
+    // cannot quietly reopen the hole.
+    uvr_cmd()
+        .args(["r", "install", "4.5.1", "--install-dir", ""])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("a value is required"));
+}
+
+#[test]
 fn test_sync_without_lockfile_fails() {
     let dir = init_project("no-lock-test");
     uvr_cmd()


### PR DESCRIPTION
Closes #89.

Implements the flag as agreed in the thread: **scope (a)** (bsirak's pick — the flag sets the r-versions directory for this one `uvr r install` invocation) and **CLI wins over `UVR_R_INSTALL_DIR`** (uv convention, everyone agreed).

```sh
uvr r install 4.6.0 --install-dir /opt/shared/r-versions
```

## How

`RInstallArgs` gains `--install-dir <DIR>`; the override threads through `RManager::install` into `download_and_install_r`, which now picks the base as `flag → UVR_R_INSTALL_DIR → ~/.uvr/r-versions`. Everything downstream is untouched and applies to a custom root identically: partial-version resolution (#170), the broken-install detect-and-replace path, atomic staging rename (staging lives next to the target, so no cross-device surprises), and the post-install `R --version` probe. The existing `create_dir_all(staging_root)` already materialises a fresh custom root.

Discovery is deliberately unchanged: `r list` / pins / doctor find installs via `UVR_R_INSTALL_DIR`, and the flag's help text says exactly that, so nobody installs somewhere the rest of the tool isn't looking without being told the second step. (That broader flag/env pattern — `--cache-dir` etc. — stays with bsirak's follow-up RFC per the thread.)

Test: CLI help surface asserts the flag and its env-var relationship are advertised. An end-to-end install test would need a ~200 MB download, so verification of the plumbing rests on the type-checked single seam plus the unchanged downstream path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XpSACGGRFa97rcv5sYPML8