### PR TITLE
feat: show the per-package install plan under -v

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ release page on GitHub. Issue numbers reference https://github.com/nbafrank/uvr/
 
 Pure tracking section — fixes and small features land here between tags.
 
+- **`uvr sync -v` shows the per-package install plan** (#205). Before
+  anything compiles, `-v` expands the aggregate "Installing 83: 80 binary ·
+  3 from source" into one row per package — name, version, cached/binary/
+  pure-R/source, and the URL it resolved to — and names each binary-capable
+  custom source behind the "Using N custom source(s)" line. An unexpected
+  source build now explains itself up front instead of being
+  reverse-engineered from `uvr.lock` afterwards. Default output is
+  unchanged.
+
 ## v0.4.5 (2026-08-03)
 
 The community release. Four contributors filed thirteen pull requests in

--- a/crates/uvr-core/src/registry/cran.rs
+++ b/crates/uvr-core/src/registry/cran.rs
@@ -317,6 +317,18 @@ impl CranRegistry {
     /// Returns true iff at least one entry in this registry has a `Built:`
     /// line matching the host. Used at sync time to decide whether this
     /// custom source contributes binaries.
+    /// Display identity: the source's name and its tarball base URL, for
+    /// telling the user *which* source served their packages (#205).
+    pub fn name_and_base(&self) -> (&str, &str) {
+        let name = match &self.source {
+            PackageSource::Custom { name } => name.as_str(),
+            PackageSource::Cran => "CRAN",
+            PackageSource::Bioconductor => "Bioconductor",
+            _ => "source",
+        };
+        (name, &self.src_base)
+    }
+
     pub fn is_binary_capable(
         &self,
         host: &crate::r_version::downloader::HostTriple,

--- a/crates/uvr/src/commands/sync.rs
+++ b/crates/uvr/src/commands/sync.rs
@@ -914,15 +914,24 @@ async fn install_from_lockfile_with_r(
         // is the post-download sniff above, so the rows show what will
         // actually happen, not the lock-time estimate.
         if tracing::event_enabled!(tracing::Level::DEBUG) {
-            for (plan, kind) in plans.iter().zip(&detected_per_plan) {
+            for ((plan, kind), result) in plans.iter().zip(&detected_per_plan).zip(&results) {
                 let kind_label = match kind {
                     InstallKind::Binary => "binary",
                     InstallKind::PureR => "pure R",
                     InstallKind::Source => "source",
                 };
+                // The URL that actually served the bytes: when a binary
+                // plan's download fell back to source, showing the binary
+                // URL next to a "source" row would mislead in exactly the
+                // debug case these rows exist for.
+                let url = if plan.is_binary && !result.used_binary {
+                    plan.fallback_url.as_deref().unwrap_or(&plan.url)
+                } else {
+                    &plan.url
+                };
                 ui::bullet_dim(format!(
-                    "{} {} — {kind_label} — {}",
-                    plan.pkg.name, plan.pkg.version, plan.url
+                    "{} {} — {kind_label} — {url}",
+                    plan.pkg.name, plan.pkg.version
                 ));
             }
         }

--- a/crates/uvr/src/commands/sync.rs
+++ b/crates/uvr/src/commands/sync.rs
@@ -605,7 +605,8 @@ async fn install_from_lockfile_with_r(
     // lookup; the cache is still written to on successful install so
     // future syncs benefit again.
     let mut cache_misses: Vec<&LockedPackage> = Vec::new();
-    let mut cache_hit_count = 0usize;
+    // The packages themselves, not just a count: `-v` prints them (#205).
+    let mut cache_hits: Vec<&LockedPackage> = Vec::new();
     let ignore_cache = cache_lookup_disabled();
     // Whether a cached *binary* entry is usable here at all — see
     // `package_cache::lookup_any`.
@@ -642,7 +643,7 @@ async fn install_from_lockfile_with_r(
         ) {
             match package_cache::clone_to_library(&cached_dir, &library, &pkg.name) {
                 Ok(()) => {
-                    cache_hit_count += 1;
+                    cache_hits.push(pkg);
                     tracing::debug!("Cache hit: {} {}", pkg.name, pkg.version);
                 }
                 Err(e) => {
@@ -655,6 +656,15 @@ async fn install_from_lockfile_with_r(
             }
         } else {
             cache_misses.push(pkg);
+        }
+    }
+
+    // #205: under `-v`, name each package served straight from the package
+    // cache. Printed here rather than with the download rows below because
+    // an all-cached sync never enters that block at all.
+    if tracing::event_enabled!(tracing::Level::DEBUG) {
+        for pkg in &cache_hits {
+            ui::bullet_dim(format!("{} {} — cached", pkg.name, pkg.version));
         }
     }
 
@@ -736,6 +746,14 @@ async fn install_from_lockfile_with_r(
                 "Using {} binary-capable custom source(s); P3M suppressed.",
                 custom_binary.len()
             );
+            // #205: `-v` names them — "1 custom source(s)" is not enough to
+            // debug why a package resolved (or didn't) to a binary.
+            if tracing::event_enabled!(tracing::Level::DEBUG) {
+                for reg in &custom_binary {
+                    let (name, base) = reg.name_and_base();
+                    ui::bullet_dim(format!("{name} ({base})"));
+                }
+            }
             None
         };
 
@@ -863,6 +881,7 @@ async fn install_from_lockfile_with_r(
             .count();
 
         // Compact plan line: "3 cached · 4 binary · 1 from source"
+        let cache_hit_count = cache_hits.len();
         if cache_hit_count > 0 || runtime_binary > 0 || runtime_source > 0 {
             let mut parts = Vec::new();
             if cache_hit_count > 0 {
@@ -885,6 +904,27 @@ async fn install_from_lockfile_with_r(
             // ASCII mode where `bullet()` renders as `.` and the line ends up looking
             // like "Installing 116 package(s) . 111 binary . 5 from source".
             ui::info(format!("{}: {}", action, palette::dim(parts.join(&sep))));
+        }
+
+        // #205: `-v` expands the aggregate into per-package rows — how each
+        // package installs and the URL it resolved to — so an unexpected
+        // source build is explained *before* compilation starts instead of
+        // being reverse-engineered from uvr.lock afterwards. Gated on the
+        // debug filter, which is exactly what `-v` enables; classification
+        // is the post-download sniff above, so the rows show what will
+        // actually happen, not the lock-time estimate.
+        if tracing::event_enabled!(tracing::Level::DEBUG) {
+            for (plan, kind) in plans.iter().zip(&detected_per_plan) {
+                let kind_label = match kind {
+                    InstallKind::Binary => "binary",
+                    InstallKind::PureR => "pure R",
+                    InstallKind::Source => "source",
+                };
+                ui::bullet_dim(format!(
+                    "{} {} — {kind_label} — {}",
+                    plan.pkg.name, plan.pkg.version, plan.url
+                ));
+            }
         }
 
         // "No binary repo" hint — only fires when no packages were binary and at
@@ -1210,7 +1250,7 @@ async fn install_from_lockfile_with_r(
     };
     let mut sub_parts: Vec<String> = Vec::new();
     if total_count > 0 {
-        let hit_pct = (cache_hit_count as f64 / total_count as f64 * 100.0).round() as u64;
+        let hit_pct = (cache_hits.len() as f64 / total_count as f64 * 100.0).round() as u64;
         sub_parts.push(format!("{hit_pct}% cache hit"));
     }
     if runtime_binary > 0 {


### PR DESCRIPTION
Refs #205 — the verbose-gated slice of pat-s's ask, deliberately without new flags.

## What `-v` now shows

At the point the aggregate line prints (post-download tarball sniff, before anything compiles):

```
› Installing 83 package(s): 80 binary · 3 from source
  · openssl 2.4.2 — binary — https://cran.rpkgs.com/amd64/alpine323/latest/src/contrib/openssl_2.4.2.tgz
  · RSQLite 2.3.9 — source — https://api.github.com/repos/r-dbi/RSQLite/tarball/...
  ...
```

plus one row per cache-served package (`jsonlite 1.8.9 — cached`), and under `INFO Using 1 binary-capable custom source(s)` each source's name and base URL. Rows use the runtime classification (the same post-download sniff the aggregate line uses since the rpkgs.com work), so they say what will actually happen — an unexpected source build explains itself before the compiler starts, instead of being reverse-engineered from `uvr.lock`.

## Scope choices

- **Gate is the debug filter** — exactly what `-v` enables; default and `-q` output are byte-identical to before (asserted by the untouched existing output tests).
- **No `--dry-run` flag here**: pat-s's issue offers `-v` as an acceptable form, and a plan-without-installing mode is a bigger design call (it would need the download phase to run for honest classification). Left for the maintainer to decide separately.
- `cache_hit_count` became the `cache_hits` list it was counting — same value everywhere it was used (including the final "N% cache hit" line), plus the names `-v` needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XpSACGGRFa97rcv5sYPML8