### PR TITLE
fix: honor UVR_LIBRARY everywhere the library is read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ release page on GitHub. Issue numbers reference https://github.com/nbafrank/uvr/
 
 Pure tracking section — fixes and small features land here between tags.
 
+- **`UVR_LIBRARY` now applies to the whole project, not just `uvr sync`**
+  (#97). Previously only sync honoured it as an install target, so setting
+  it sent packages to a directory that `uvr run`, `uvr activate`, doctor
+  and IDE sessions never looked at. All of them — including the `.Rprofile`
+  snippet, which refreshes on the next sync — now resolve the library
+  through the same rule: `UVR_LIBRARY` when set, else `.uvr/library/`.
+  This is the machine-local escape hatch for projects living on slow
+  network storage (Azure ML mapped drives and similar), matching
+  `UV_PROJECT_ENVIRONMENT` / `RENV_PATHS_LIBRARY` / `RV_LIBRARY_DIR`.
+  Pruning still never runs against an override target.
+
 ## v0.4.5 (2026-08-03)
 
 The community release. Four contributors filed thirteen pull requests in

--- a/crates/uvr-core/src/env_vars.rs
+++ b/crates/uvr-core/src/env_vars.rs
@@ -84,6 +84,8 @@ pub fn install_timeout() -> Option<String> {
 /// snippet), via `Project::library_path` (#97).
 /// Expects a valid absolute or relative directory path.
 /// Note: The CLI `--library` argument takes precedence over this variable.
+/// Defaults to the project-local `.uvr/library/` directory when unset or
+/// empty.
 pub fn library() -> Option<PathBuf> {
     read_env_var("UVR_LIBRARY").map(PathBuf::from)
 }

--- a/crates/uvr-core/src/env_vars.rs
+++ b/crates/uvr-core/src/env_vars.rs
@@ -78,10 +78,12 @@ pub fn install_timeout() -> Option<String> {
 
 /// UVR_LIBRARY
 ///
-/// Defines a custom target directory for R package installations.
+/// Defines a custom library directory in place of the project-local
+/// `.uvr/library/` — both as the install target and for everything that
+/// reads the library (`uvr run`, `activate`, doctor, the `.Rprofile`
+/// snippet), via `Project::library_path` (#97).
 /// Expects a valid absolute or relative directory path.
 /// Note: The CLI `--library` argument takes precedence over this variable.
-/// Defaults to the project-local `.uvr/library/` directory if neither are provided.
 pub fn library() -> Option<PathBuf> {
     read_env_var("UVR_LIBRARY").map(PathBuf::from)
 }
@@ -278,6 +280,14 @@ mod tests {
 
         env::set_var("UVR_LIBRARY", "/custom/library");
         assert_eq!(library(), Some(PathBuf::from("/custom/library")));
+        // #97: the project's library path follows the override, so the
+        // commands that *read* the library look where sync installed.
+        let project = crate::project::Project {
+            root: PathBuf::from("/proj"),
+            manifest: crate::manifest::Manifest::new("t", None),
+            manifest_source: crate::project::ManifestSource::Toml,
+        };
+        assert_eq!(project.library_path(), PathBuf::from("/custom/library"));
 
         env::set_var("UVR_PACKAGES_DIR", "/custom/packages");
         assert_eq!(packages_dir(), Some(PathBuf::from("/custom/packages")));
@@ -303,6 +313,8 @@ mod tests {
         assert_eq!(library(), None);
         assert_eq!(packages_dir(), None);
         assert_eq!(progress(), None);
+        // …and the project's library path falls back to project-local.
+        assert!(project.library_path().ends_with(".uvr/library"));
 
         let empty_r_install = r_install_dir();
         assert!(empty_r_install.is_some());

--- a/crates/uvr-core/src/project.rs
+++ b/crates/uvr-core/src/project.rs
@@ -76,7 +76,18 @@ impl Project {
         self.root.join(DOT_UVR_DIR)
     }
 
+    /// The library R uses for this project: `UVR_LIBRARY` when set — a
+    /// machine-local override for hosts where the project tree sits on slow
+    /// network storage (#97) — else the project's own `.uvr/library/`.
+    ///
+    /// `uvr sync` has installed into the variable since it grew `--library`;
+    /// routing every *reader* through the same rule is what makes those
+    /// packages reachable from `uvr run`, `activate`, and doctor instead of
+    /// landing in a directory nothing else looks at.
     pub fn library_path(&self) -> PathBuf {
+        if let Some(lib) = crate::env_vars::library() {
+            return lib;
+        }
         self.dot_uvr_dir().join(LIBRARY_DIR)
     }
 

--- a/crates/uvr/src/commands/init.rs
+++ b/crates/uvr/src/commands/init.rs
@@ -129,7 +129,8 @@ const RPROFILE_END: &str = "# <<< uvr <<<";
 // file's git history, not in the user-facing snippet.
 const RPROFILE_SNIPPET: &str = r#"# >>> uvr >>>
 local({
-  lib <- file.path(getwd(), ".uvr", "library")
+  lib <- Sys.getenv("UVR_LIBRARY")
+  if (!nzchar(lib)) lib <- file.path(getwd(), ".uvr", "library")
   lock <- file.path(getwd(), "uvr.lock")
   rver_file <- file.path(getwd(), ".r-version")
   count_locked <- function(path) {
@@ -525,6 +526,16 @@ mod rprofile_tests {
         let existing = RPROFILE_SNIPPET.to_string();
         let new = refresh_uvr_block(&existing, RPROFILE_SNIPPET).unwrap();
         assert_eq!(new, existing);
+    }
+
+    #[test]
+    fn rprofile_snippet_honours_the_library_override() {
+        // #97: an IDE session sources .Rprofile, not uvr — the snippet must
+        // apply the same UVR_LIBRARY-else-project-local rule as
+        // Project::library_path, or `uvr sync` under the override installs
+        // packages RStudio/Positron sessions never see.
+        assert!(RPROFILE_SNIPPET.contains(r#"Sys.getenv("UVR_LIBRARY")"#));
+        assert!(RPROFILE_SNIPPET.contains(r#"file.path(getwd(), ".uvr", "library")"#));
     }
 
     #[test]

--- a/crates/uvr/src/commands/init.rs
+++ b/crates/uvr/src/commands/init.rs
@@ -131,6 +131,7 @@ const RPROFILE_SNIPPET: &str = r#"# >>> uvr >>>
 local({
   lib <- Sys.getenv("UVR_LIBRARY")
   if (!nzchar(lib)) lib <- file.path(getwd(), ".uvr", "library")
+  lib <- normalizePath(lib, mustWork = FALSE)
   lock <- file.path(getwd(), "uvr.lock")
   rver_file <- file.path(getwd(), ".r-version")
   count_locked <- function(path) {


### PR DESCRIPTION
Closes #97.

## The gap

`UVR_LIBRARY` already exists — but only `uvr sync` honors it, and only as an **install target**. `uvr run`, `uvr activate`, doctor, and the `.Rprofile` snippet all hard-resolve `.uvr/library/`. So the exact workflow #97 describes (Azure ML mapped-SMB project dir, library redirected to compute-local disk) installs packages into a directory that no R session ever has on its search path.

## The fix — one rule, one seam each side

- **Rust side**: `Project::library_path()` resolves `UVR_LIBRARY` when set, else `.uvr/library/`. Every reader (`run`, `activate`, doctor, `ensure_library_dir`) already routes through it.
- **R side**: the `.Rprofile` snippet applies the same rule (`Sys.getenv("UVR_LIBRARY")`, else project-local), so RStudio/Positron sessions agree with the CLI. Existing projects pick this up automatically via the managed-block refresh on their next sync.

This matches the env-var precedent the issue cites (`UV_PROJECT_ENVIRONMENT`, `RENV_PATHS_LIBRARY`, `RV_LIBRARY_DIR`) and deliberately stays machine-local — no manifest/lockfile surface, per the reporter's own preference ("the env var is the preferable option; it is machine specific, not fixed at project level").

## What deliberately does not change

- `sync`'s precedence stays `--library` > `UVR_LIBRARY` > project-local.
- **Pruning never touches an override target** (they may be shared): `do_prune` keys off the override's *presence*, which the env var already sets — unchanged and still covered by its doc comment.
- `uvr run` outside a project keeps its existing fallback; the override is a project-scoped concept.

Tests: the consolidated env-var test asserts `library_path()` follows the override and falls back when unset/empty; a template test pins the `.Rprofile` contract so the two sides can't silently diverge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XpSACGGRFa97rcv5sYPML8