### PR TITLE
fix: stop hashing the binary flavor into source cache keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ release page on GitHub. Issue numbers reference https://github.com/nbafrank/uvr/
 
 Pure tracking section — fixes and small features land here between tags.
 
+- **Source-built packages cached on Linux are now found again by later
+  syncs** (#237). The cache key hashed the binary-repo flavour into every
+  entry it stored, but lookups probe source entries without one — so on
+  any Linux host with a binary repo (a flavour), every package that
+  installed from source landed in the cache under a key no lookup could
+  produce, and was rebuilt from source on every warm sync, forever. The
+  flavour is now part of the key only for binary entries, which is the
+  rule lookups always assumed. Existing mis-keyed source entries were
+  unreachable anyway and are simply superseded.
+
 ## v0.4.5 (2026-08-03)
 
 The community release. Four contributors filed thirteen pull requests in

--- a/crates/uvr-core/src/installer/package_cache.rs
+++ b/crates/uvr-core/src/installer/package_cache.rs
@@ -83,10 +83,16 @@ pub fn cache_key(
     // artifacts linking different libraries, and only one of them loads on a
     // given host (#175) — so they must not share a cache entry.
     //
-    // Only hashed when present, which keeps macOS/Windows and source-built
-    // keys byte-identical to before; only Linux binary entries are
-    // re-keyed, and those are exactly the ones that were ambiguous.
-    if let Some(flavor) = binary_flavor {
+    // Only hashed for *binary* entries: a source build is compiled on this
+    // host and is not repo-specific. Enforced here, not at call sites —
+    // the store path passed the session's flavour unconditionally while
+    // lookup probed source entries without one, so every source-kind entry
+    // on flavoured Linux landed under a key no lookup could produce, and
+    // was rebuilt on every warm sync forever (#237). Keying by
+    // `is_binary && flavor` keeps macOS/Windows and source keys
+    // byte-identical to before; only Linux binary entries carry it, and
+    // those are exactly the ones #175 made ambiguous.
+    if let (true, Some(flavor)) = (is_binary, binary_flavor) {
         hasher.update(b"|");
         hasher.update(flavor.as_bytes());
     }
@@ -572,6 +578,22 @@ mod tests {
         let k1 = cache_key("pkg", "1.0", Some("abc"), "4.4", true, None, None);
         let k2 = cache_key("pkg", "1.0", Some("abc"), "4.4", false, None, None);
         assert_ne!(k1, k2);
+    }
+
+    #[test]
+    fn a_source_entry_ignores_the_binary_flavor() {
+        // The store path passes the session's binary flavour for every
+        // package it caches; lookup probes source entries with no flavour
+        // ("a source build is compiled here and is not repo-specific").
+        // Hashing the flavour into a source key therefore stored every
+        // source-kind entry on flavoured Linux under a key no lookup could
+        // ever produce — an eternal warm-tier miss that re-ran
+        // R CMD INSTALL on every sync (#237). The key must make the two
+        // sides agree by construction.
+        assert_eq!(
+            cache_key("pkg", "1.0", Some("abc"), "4.4", false, None, Some("jammy")),
+            cache_key("pkg", "1.0", Some("abc"), "4.4", false, None, None)
+        );
     }
 
     #[test]


### PR DESCRIPTION
Refs #237 — found while trying to reproduce the warm-tier slowness. Full investigation notes going on the issue; the short version:

## The bug (code-provable, independent of #237's trigger)

- **Store** (`sync.rs`, the post-install cache write) passes the session's `binary_flavor` into `cache_key` for **every** package it caches — including PureR/Source-classified ones.
- **Lookup** (`package_cache::lookup_any`) probes source entries with `flavor = None`, per its own comment: *"a source build is compiled here and is not repo-specific."*

So on any Linux host with a flavour (every P3M-supported distro), a package that installs from source is stored under a key **no lookup can ever produce**. It is rebuilt from source on every warm sync, forever. macOS/Windows are untouched (`binary_repo_flavor()` is `None` there) — which is exactly why the laptop control in #237 showed 100% cache hits while the container didn't have to.

## Why this matters for #237's shape

Local reproduction in the bench image (same Dockerfile, R 4.5.3, run as root like CI) shows the healthy path is fine: ggplot2 warm 2.70s/2.69s, tidyverse warm **2.76s/2.78s at 100% cache hit**, all 100 entries `kind=binary`. So the CI 65s isn't intrinsic — but one window in which P3M serves source tarballs (the serving behavior ce75775 fixed for the comparison tools) during the warm tier's warmup would poison the cache with unreachable source-kind entries, and **every warm run after it re-pays the compiles** while the later cold tier, served binaries in a healthy window, looks fast. That reproduces the 10× warm-over-cold, the superlinearity (larger sets ⊃ more poisoned packages), and the fact it never self-heals. The `bench-cmds.log` from your next instrumented run will confirm or kill this: warm-tier plan lines reading "K from source" with a sub-100% hit rate is this mechanism; "100% cache hit" with a slow wall clock is something environmental instead.

## The fix

The invariant moves into `cache_key` itself: flavour is hashed only when `is_binary` — store and lookup agree by construction, and no call site can reintroduce the split. macOS/Windows and source keys are byte-identical to before; only Linux binary entries carry the flavour, exactly the ones #175 introduced it for. Existing mis-keyed source entries were unreachable anyway and are simply superseded (they'll age out via `uvr cache clean`).

Regression test pins `key(source, Some(flavor)) == key(source, None)` alongside the existing flavour-separation tests for binaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XpSACGGRFa97rcv5sYPML8