### PR TITLE
fix(sync): pin plain git packages to their commit, not just their version

### DIFF
--- a/crates/uvr-core/src/installer/nested_source.rs
+++ b/crates/uvr-core/src/installer/nested_source.rs
@@ -15,13 +15,33 @@ pub struct NestedProvenance {
 impl NestedProvenance {
     pub fn from_locked(p: &LockedPackage) -> Result<Option<Self>> {
         crate::registry::github::validate_nested_lock_entry(p)?;
-        let Some(subdirectory) = p.subdirectory.as_deref() else {
-            return Ok(None);
+        let subdirectory = match p.subdirectory.as_deref() {
+            Some(subdirectory) => subdirectory.to_string(),
+            // A plain (non-nested) GitHub package still needs its commit
+            // pinned. Without a marker the only thing left to compare is the
+            // DESCRIPTION version, and a package that carries the same
+            // development version across commits - `1.0.3.9001` for every
+            // commit of a fork, say - then looks up to date forever, no matter
+            // which commit the lockfile names.
+            None => {
+                if p.source != crate::lockfile::PackageSource::GitHub {
+                    return Ok(None);
+                }
+                let has_commit = p
+                    .checksum
+                    .as_deref()
+                    .and_then(|c| c.strip_prefix("git:"))
+                    .is_some_and(crate::registry::github::is_full_commit_sha);
+                if !has_commit || p.url.as_deref().unwrap_or_default().is_empty() {
+                    return Ok(None);
+                }
+                String::new()
+            }
         };
         Ok(Some(NestedProvenance {
             url: p.url.clone().unwrap_or_default(),
             checksum: p.checksum.clone().unwrap_or_default(),
-            subdirectory: subdirectory.to_string(),
+            subdirectory,
         }))
     }
 
@@ -60,7 +80,12 @@ impl NestedProvenance {
             *slot = Some(value.to_string());
         }
         let (source, url, checksum, subdirectory) = (source?, url?, checksum?, subdirectory?);
-        if source != "github" || url.is_empty() || !crate::subdirectory::is_valid(&subdirectory) {
+        // An empty subdirectory is the repository root: a plain GitHub package
+        // rather than one nested in a monorepo.
+        if source != "github"
+            || url.is_empty()
+            || (!subdirectory.is_empty() && !crate::subdirectory::is_valid(&subdirectory))
+        {
             return None;
         }
         if !checksum
@@ -285,6 +310,41 @@ mod tests {
             checksum: format!("git:{sha}"),
             subdirectory: subdirectory.to_string(),
         }
+    }
+
+    #[test]
+    fn from_locked_pins_a_plain_github_package() {
+        // Regression: a package with no subdirectory got no marker, so
+        // `is_installed` fell back to the DESCRIPTION version. A fork that
+        // carries the same development version across commits then looks up to
+        // date forever and a stale build is never replaced.
+        let p = NestedProvenance::from_locked(&locked(SHA, None))
+            .unwrap()
+            .expect("a plain GitHub package should still pin its commit");
+        assert_eq!(p.checksum, format!("git:{SHA}"));
+        assert_eq!(p.subdirectory, "");
+    }
+
+    #[test]
+    fn from_locked_ignores_a_non_github_source() {
+        let mut pkg = locked(SHA, None);
+        pkg.source = PackageSource::Cran;
+        assert!(NestedProvenance::from_locked(&pkg).unwrap().is_none());
+    }
+
+    #[test]
+    fn from_locked_ignores_a_package_without_a_commit() {
+        let mut pkg = locked(SHA, None);
+        pkg.checksum = Some("sha256:abc".to_string());
+        assert!(NestedProvenance::from_locked(&pkg).unwrap().is_none());
+    }
+
+    #[test]
+    fn marker_round_trips_an_empty_subdirectory() {
+        let want = provenance(SHA, "");
+        let parsed = NestedProvenance::parse(&want.to_file_contents())
+            .expect("an empty subdirectory is the repository root, not invalid");
+        assert_eq!(parsed, want);
     }
 
     fn locked(sha: &str, subdirectory: Option<&str>) -> LockedPackage {

--- a/crates/uvr/src/commands/sync.rs
+++ b/crates/uvr/src/commands/sync.rs
@@ -2935,8 +2935,23 @@ Built: R 4.5.0; x86_64-pc-linux-musl; 2025-01-15; unix
         let root = nested_locked("rlang", NESTED_SHA, None);
         let pkg_dir = library.path().join("rlang");
 
+        // Neither is installed while the package carries no marker: a root
+        // GitHub entry is pinned to its commit too, so an install of unknown
+        // provenance no longer counts as up to date.
         assert!(!is_installed(&nested, library.path()));
+        assert!(!is_installed(&root, library.path()));
+
+        let root_provenance = NestedProvenance::from_locked(&root).unwrap().unwrap();
+        nested_source::write_marker(&pkg_dir, &root_provenance).unwrap();
         assert!(is_installed(&root, library.path()));
+        assert!(!is_installed(&nested, library.path()));
+        // A root entry at a different commit is not satisfied by this install,
+        // which is the whole point: the version alone cannot tell them apart.
+        assert!(!is_installed(
+            &nested_locked("rlang", NESTED_OTHER_SHA, None),
+            library.path()
+        ));
+        nested_source::clear_marker(&pkg_dir).unwrap();
 
         let provenance = NestedProvenance::from_locked(&nested).unwrap().unwrap();
         nested_source::write_marker(&pkg_dir, &provenance).unwrap();
@@ -2953,7 +2968,7 @@ Built: R 4.5.0; x86_64-pc-linux-musl; 2025-01-15; unix
         ));
 
         nested_source::clear_marker(&pkg_dir).unwrap();
-        assert!(is_installed(&root, library.path()));
+        assert!(!is_installed(&root, library.path()));
 
         let mut version_mismatch = nested;
         version_mismatch.version = "1.1.7".into();


### PR DESCRIPTION
## The bug

`uvr sync` treats a git-sourced package as up to date when the installed **version string** matches the lockfile, without checking that the installed copy came from the **commit** the lockfile names.

For a package whose development version does not change between commits, that means it is never updated. `pat-s/cranlike` carries `Version: 1.0.3.9001` at every commit on its `s3` branch. A library holding a June build kept it through every later sync, even with the lockfile pinned to a commit two months newer.

The consequence in our CI: `bincraft` calls `cranlike::update_PACKAGES(..., built = built)`, an argument added on 2026-07-29. The stale June build has no such argument, so the R side failed with

```
Error: Failed to update PACKAGES after 3 attempts. Last error: unused argument (built = built)
```

on a runner with a persistent package cache, while a fresh runner worked. Nothing about the lockfile or the sync output suggested the installed package was two months behind what was pinned.

## Reproduction

```sh
# a library holding an older commit of the fork
R CMD INSTALL -l /tmp/lib <clone of pat-s/cranlike at a12591f>
# -> Version: 1.0.3.9001, update_PACKAGES has no `built` argument

# a project whose lockfile pins a newer commit of the same package
uvr add --no-install "forgejo::codefloe.com/rpkgs/bincraft@v5.2.1"
grep -A3 'name = "cranlike"' uvr.lock
#   source = "github"
#   url = ".../pat-s/cranlike/tarball/736d753..."
#   checksum = "git:736d753..."

uvr sync --library /tmp/lib
# installs 67 packages, never mentions cranlike
# -> still Version: 1.0.3.9001, still no `built` argument
```

## Cause

`NestedProvenance::from_locked()` returns `None` for any package without a `subdirectory`:

```rust
let Some(subdirectory) = p.subdirectory.as_deref() else {
    return Ok(None);
};
```

So no marker is written for a plain (non-nested) git package, and in `is_installed()` the provenance gate passes trivially:

```rust
(Marker::Absent, None) => true,
```

leaving only the DESCRIPTION version comparison. The lockfile already records the commit — it just is not consulted for these packages.

## Change

A root GitHub entry with a `git:<sha>` checksum now gets a marker too, recorded with an empty `subdirectory`, and `parse()` accepts that as "the repository root" rather than invalid. The existing write and compare paths in `sync.rs` then do the rest unchanged.

Deliberately scoped to GitHub, which is what `NestedProvenance` and its marker format already assume (`source=github`). GitLab and Forgejo git sources have the same gap; covering them needs the marker to carry its source, which felt like a larger change than this fix warrants. Happy to extend it if you would rather do it in one go.

## Behaviour change

Existing installs have no marker, so the first sync after upgrading reinstalls git-sourced packages once. Subsequent syncs are idempotent — verified below.

`is_installed_distinguishes_nested_identity` asserted the old contract (a root entry with no marker counts as installed) and now asserts the new one.

## Verification

With the patched binary, against the same stale library:

```
BEFORE: version 1.0.3.9001 | built arg: FALSE
  ^ cranlike 1.0.3.9001 -> 1.0.3-4.9001
  > Installing 67, upgrading 1: 65 cached - 3 from source
AFTER : version 1.0.3.9001 | built arg: TRUE

marker: source=github url=.../pat-s/cranlike/tarball/736d753... checksum=git:736d753... subdirectory=

second sync: > Installing 1 package(s)   # cranlike untouched
```

- `cargo test -p uvr-core --lib`: 519 passed
- `cargo test -p uvr --bins`: 177 passed
- `cargo fmt --check`, `cargo clippy`: clean
- Four new unit tests: a plain GitHub package is pinned; a non-GitHub source is ignored; an entry without a commit is ignored; a marker round-trips an empty subdirectory.
